### PR TITLE
Don't watch recursively if symlinks aren't supported

### DIFF
--- a/pluginLoader.go
+++ b/pluginLoader.go
@@ -104,7 +104,16 @@ func watchPluginDirectory(ctx context.Context) error {
 		}
 	}()
 
-	err := w.AddRecursive(*pluginsPath)
+	// Test if symlinks are supported
+	_, err := os.Lstat(*pluginsPath)
+	if err == nil {
+		// They are, so we can watch recursively (local dev workflow).
+		err = w.AddRecursive(*pluginsPath)
+	} else {
+		// They are not.  Just watch the single directory (production workflow).
+		err = w.Add(*pluginsPath)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to watch plugins directory: %w", err)
 	}


### PR DESCRIPTION
In k8s, we use the s3 mountpoint driver, which doesn't support links.  Watching the plugin folder recursively ultimately invokes `os.Lstat`, which fails when symlinks aren't supported by the filesystem.  Since we don't need to watch recursively in k8s, we can bypass that and just watch the single folder contents.