### PR TITLE
Raphael/readme aws

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,10 @@
             "env": {
                 "ENV": "dev",
                 "AWS_REGION":"us-west-2",
-                "AWS_PROFILE":"hm-cp-staging",
+                "AWS_PROFILE":"hm-rumtime",
                 "AWS_SDK_LOAD_CONFIG": "true"
               },
-              "args": ["--dgraph", "http://localhost:8080", "--plugins", "/Users/jairadhakrishnan/plugins/"]
+              "args": ["--dgraph", "http://localhost:8080", "--plugins", "~/plugins"]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -38,10 +38,35 @@ docker run --name hmruntime -p 8686:8686 -v ./plugins:/plugins hypermode/runtime
 _Note, if you have previously created a container with the same name, then delete it first with `docker rm hmruntime`._
 
 ## AWS Setup
+Runtime may access AWS Secret manager, so we need to use an AWS Profile.
 
-in the `launch.json` you will find the runtime uses the `hm-cp-staging`, which is necessary for secrets management. For local testing, you must save that profile in `~/.aws/config`. Reach out to the runtime team for the credentials.
+```
+export AWS_PROFILE=hm-runtime
+```
+Have the `hm-runtime` profile and sso session configured in `~/.aws/config` file.
 
-Then run `aws sso login --profile hm-cp-staging` to login to the profile.
+To work in Sandbox declare the following profile:
+```
+[profile hm-runtime]
+sso_session = hm-runtime
+sso_account_id = 436061841671
+sso_role_name = Hypermode-EKS-Cluster-Admin
+[sso-session hm-runtime]
+sso_start_url = https://d-92674fec42.awsapps.com/start#
+sso_region = us-west-2
+sso_registration_scopes = sso:account:access
+```
+
+If you are using VSCode launcher, check `launch.json` and verify the profile `hm-runtime`.
+
+Then run `aws sso login --profile hm-runtime` to login to the profile.
+After SSO login you can start the runtime 
+
+```
+export AWS_PROFILE=hm-runtime; ./hmruntime --plugins <your plugin folder>
+
+```
+You can omit the export if the environment variable is already set.
 
 ## Building without Docker
 


### PR DESCRIPTION
Clarify readme to set AWS SSO to run runtime locally and use invokeClassifier function which reads a secret in AWS Secret Manager.
launch.json with path from home.
