### PR TITLE
disabling CI jobs on push to main for Runtime repo

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -1,8 +1,5 @@
 name: ci-aqua-security-trivy-tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -1,8 +1,5 @@
 name: ci-golang-lint
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Disabling these two CI jobs on push to main-
-ci-aqua-security-trivy-tests.yml
- ci-golang-lint.yml

"Require branches to be up to date before merging" policy is set on this repo. And these CI jobs are running on PR