### PR TITLE
Removing Scheduled run for security Scan

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -8,8 +8,6 @@ on:
       - ready_for_review
     branches:
       - main 
-  schedule:
-    - cron: "0 0 * * *"
 permissions: read-all
 jobs:
   build:


### PR DESCRIPTION
Running CI jobs on PR should be enough