### PR TITLE
Support manual reloading of plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ FROM ubuntu:20.04
 LABEL maintainer="Hypermode <hello@hypermode.com>"
 COPY --from=builder /src/hmruntime /usr/bin/hmruntime
 
-ENTRYPOINT ["hmruntime"]
+ENTRYPOINT ["hmruntime", "--noreload"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ When starting the runtime, you may sometimes need to use the following command l
 - `--port` - The port that the runtime will listen for HTTP requests on.  Defaults to `8686`.
 - `--dgraph` - The URL to the Dgraph Alpha endpoint.  Defaults to `http://localhost:8080`.
 - `--plugins` (or `--plugin`) - The folder that the runtime will look for plugins in.  Defaults to `./plugins`.
+- `--noreload` - Disables automatic reloading of plugins.
 
 _Note: You can use either `-` or `--` prefixes, and you can add parameters with either a space or `=`._
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 // command line flag variables
 var DgraphUrl *string
 var PluginsPath *string
+var NoReload bool
 
 // map that holds the compiled modules for each plugin
 var CompiledModules = make(map[string]wazero.CompiledModule)

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,8 @@ import (
 )
 
 // command line flag variables
-var DgraphUrl *string
-var PluginsPath *string
+var DgraphUrl string
+var PluginsPath string
 var NoReload bool
 
 // map that holds the compiled modules for each plugin

--- a/main.go
+++ b/main.go
@@ -23,16 +23,16 @@ func main() {
 	var port = flag.Int("port", 8686, "The HTTP port to listen on.")
 	dgraph.DgraphUrl = flag.String("dgraph", "http://localhost:8080", "The Dgraph url to connect to.")
 
-	config.PluginsPath = flag.String("plugins", "./plugins", "The path to the plugins directory.")
-	flag.StringVar(config.PluginsPath, "plugin", "./plugins", "alias for -plugins")
+	config.PluginsPath = *flag.String("plugins", "./plugins", "The path to the plugins directory.")
+	flag.StringVar(&config.PluginsPath, "plugin", "./plugins", "alias for -plugins")
 
 	flag.BoolVar(&config.NoReload, "noreload", false, "Disable automatic plugin reloading.")
 
 	flag.Parse()
 
 	// Ensure the plugins directory exists.
-	if _, err := os.Stat(*config.PluginsPath); os.IsNotExist(err) {
-		err := os.MkdirAll(*config.PluginsPath, 0755)
+	if _, err := os.Stat(config.PluginsPath); os.IsNotExist(err) {
+		err := os.MkdirAll(config.PluginsPath, 0755)
 		if err != nil {
 			log.Fatalln(fmt.Errorf("failed to create plugins directory: %w", err))
 		}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 	config.PluginsPath = flag.String("plugins", "./plugins", "The path to the plugins directory.")
 	flag.StringVar(config.PluginsPath, "plugin", "./plugins", "alias for -plugins")
 
+	flag.BoolVar(&config.NoReload, "noreload", false, "Disable automatic plugin reloading.")
+
 	flag.Parse()
 
 	// Ensure the plugins directory exists.

--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -24,8 +24,8 @@ const pluginRefreshInterval time.Duration = time.Second * 5
 func LoadPlugins(ctx context.Context) error {
 
 	// If the plugins path is a single plugin's base directory, load the single plugin.
-	if _, err := os.Stat(*config.PluginsPath + "/build/debug.wasm"); err == nil {
-		pluginName := path.Base(*config.PluginsPath)
+	if _, err := os.Stat(config.PluginsPath + "/build/debug.wasm"); err == nil {
+		pluginName := path.Base(config.PluginsPath)
 		err := loadPluginModule(ctx, pluginName)
 		if err != nil {
 			log.Printf("Failed to load plugin '%s': %v\n", pluginName, err)
@@ -33,7 +33,7 @@ func LoadPlugins(ctx context.Context) error {
 	}
 
 	// Otherwise, load all plugins in the plugins directory.
-	entries, err := os.ReadDir(*config.PluginsPath)
+	entries, err := os.ReadDir(config.PluginsPath)
 	if err != nil {
 		return fmt.Errorf("failed to read plugins directory: %w", err)
 	}
@@ -45,7 +45,7 @@ func LoadPlugins(ctx context.Context) error {
 		entryName := entry.Name()
 		if entry.IsDir() {
 			pluginName = entryName
-			path := fmt.Sprintf("%s/%s/build/debug.wasm", *config.PluginsPath, pluginName)
+			path := fmt.Sprintf("%s/%s/build/debug.wasm", config.PluginsPath, pluginName)
 			if _, err := os.Stat(path); err != nil {
 				continue
 			}
@@ -116,13 +116,13 @@ func WatchPluginDirectory(ctx context.Context) error {
 	}()
 
 	// Test if symlinks are supported
-	_, err := os.Lstat(*config.PluginsPath)
+	_, err := os.Lstat(config.PluginsPath)
 	if err == nil {
 		// They are, so we can watch recursively (local dev workflow).
-		err = w.AddRecursive(*config.PluginsPath)
+		err = w.AddRecursive(config.PluginsPath)
 	} else {
 		// They are not.  Just watch the single directory (production workflow).
-		err = w.Add(*config.PluginsPath)
+		err = w.Add(config.PluginsPath)
 	}
 
 	if err != nil {
@@ -142,19 +142,19 @@ func WatchPluginDirectory(ctx context.Context) error {
 func getPathForPlugin(name string) (string, error) {
 
 	// Normally the plugin will be directly in the plugins directory, by filename.
-	path := *config.PluginsPath + "/" + name + ".wasm"
+	path := config.PluginsPath + "/" + name + ".wasm"
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}
 
 	// For local development, the plugin will be in a subdirectory and we'll use the debug.wasm file.
-	path = *config.PluginsPath + "/" + name + "/build/debug.wasm"
+	path = config.PluginsPath + "/" + name + "/build/debug.wasm"
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}
 
 	// Or, the plugins path might pointing to a single plugin's base directory.
-	path = *config.PluginsPath + "/build/debug.wasm"
+	path = config.PluginsPath + "/build/debug.wasm"
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
 	}

--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -66,6 +66,12 @@ func LoadPlugins(ctx context.Context) error {
 }
 
 func WatchPluginDirectory(ctx context.Context) error {
+
+	if config.NoReload {
+		fmt.Println("NOTE: Automatic plugin reloading is disabled.  Restart the server to load new or modified plugins.")
+		return nil
+	}
+
 	w := watcher.New()
 	w.AddFilterHook(watcher.RegexFilterHook(regexp.MustCompile(`^.+\.wasm$`), false))
 


### PR DESCRIPTION
- Adds a `--noreload` flag, which will disable automatic polling of the plugins directory
- Adds a `/admin` endpoint, which when posted `{"action":"reload"}` to, will manually reload the plugins


Temporarily, `--noreload` is passed by default in the dockerfile entrypoint so we can bypass the flaky reloading issue.

To reload manually:

```sh
curl 'http://<runtimeurl>:8686/admin' -d '{"action": "reload"}'
```
