### PR TITLE
Update cd-runtime.yml to drop the check for "runtime-" in tag name

### DIFF
--- a/.github/workflows/cd-runtime.yml
+++ b/.github/workflows/cd-runtime.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           #!/bin/bash
           GIT_TAG_NAME='${{ github.event.inputs.releasetag }}'
-          if [[ "$GIT_TAG_NAME" == "runtime-v"* ]]; 
+          if [[ "$GIT_TAG_NAME" == "v"* ]]; 
           then
             echo "this is a release tag"
           else


### PR DESCRIPTION
CD Pipeline is looking for the tag name to have "runtime-" as the prefix without which the pipeline fails. This check is unnecessary as the build process anyway drops the prefix and builds the final ECR image as vx.x.x-SHA.