### PR TITLE
Fix startup deadlock

### DIFF
--- a/functions/registration.go
+++ b/functions/registration.go
@@ -18,7 +18,7 @@ import (
 var FunctionsMap = make(map[string]schema.FunctionInfo)
 
 // channel used to signal when registration is completed
-var RegistrationCompleted chan bool = make(chan bool)
+var RegistrationCompleted chan bool = make(chan bool, 1)
 
 func MonitorRegistration(ctx context.Context) {
 	go func() {
@@ -90,7 +90,9 @@ func registerFunctions(gqlSchema string) error {
 		}
 	}
 
-	// Signal that registration is complete (non-blocking send to avoid deadlock if no one is waiting)
+	// Signal that registration is complete.  This is a non-blocking send to
+	// avoid a deadlock if no one is waiting, but the channel has a buffer size
+	// of 1, so it will not lose the message if the receiver is slow to start.
 	select {
 	case RegistrationCompleted <- true:
 	default:


### PR DESCRIPTION
If the plugin registers fast enough, it can signal completion before the web server is waiting.  Since it's a non-blocking send, the message is lost.  When the web server finally starts, it blocks and waits forever for registration completion.

This fixes it by setting the channel buffer size to `1` so the message won't get lost.