### PR TITLE
Use explicit option to enable AWS Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ When starting the runtime, you may need to use the following command line argume
 - `--dgraph` - The URL to the Dgraph Alpha endpoint.  Defaults to `http://localhost:8080`.
 - `--noreload` - Disables automatic reloading of plugins.
 - `--s3bucket` - The S3 bucket to use, if using AWS for plugin storage.
+- `--useAwsSecrets` - Directs the Runtime to use AWS Secret Manager for secrets such as model keys.
 - `--refresh` - The refresh interval to check for plugins and schema changes.  Defaults to `5s`.
 - `--jsonlogs` - Switches log output to JSON format.
 

--- a/aws/config.go
+++ b/aws/config.go
@@ -23,10 +23,6 @@ func UseAwsForPluginStorage() bool {
 	return useS3PluginStorage
 }
 
-func Enabled() bool {
-	return awsEnabled
-}
-
 func Initialize(ctx context.Context) error {
 	useS3PluginStorage = hmConfig.S3Bucket != ""
 	defer func() {

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ var DgraphUrl string
 var PluginsPath string
 var NoReload bool
 var S3Bucket string
+var UseAwsSecrets bool
 var RefreshInterval time.Duration
 var UseJsonLogging bool
 
@@ -86,6 +87,7 @@ func ParseCommandLineFlags() {
 	flag.StringVar(&PluginsPath, "plugin", "", "alias for -plugins")
 	flag.BoolVar(&NoReload, "noreload", false, "Disable automatic plugin reloading.")
 	flag.StringVar(&S3Bucket, "s3bucket", "", "The S3 bucket to use, if using AWS for plugin storage.")
+	flag.BoolVar(&UseAwsSecrets, "useAwsSecrets", false, "Use AWS Secrets Manager for API keys and other secrets.")
 	flag.DurationVar(&RefreshInterval, "refresh", time.Second*5, "The refresh interval to check for plugins and schema changes.")
 	flag.BoolVar(&UseJsonLogging, "jsonlogs", false, "Use JSON format for logging.")
 

--- a/main.go
+++ b/main.go
@@ -59,13 +59,11 @@ func main() {
 	}
 	defer host.WasmRuntime.Close(ctx)
 
-	if !aws.Enabled() {
-		// Load environment variables from plugins path
-		// note: .env file is optional, so don't log if it's not found
-		err = godotenv.Load(path.Join(config.PluginsPath, ".env"))
-		if err != nil && !os.IsNotExist(err) {
-			log.Warn().Err(err).Msg("Error reading .env file.  Ignoring.")
-		}
+	// Load environment variables from plugins path
+	// note: .env file is optional, so don't log if it's not found
+	err = godotenv.Load(path.Join(config.PluginsPath, ".env"))
+	if err != nil && !os.IsNotExist(err) {
+		log.Warn().Err(err).Msg("Error reading .env file.  Ignoring.")
 	}
 
 	// Load json


### PR DESCRIPTION
Adding a flag `--useAwsSecrets` to explicitly enable Secrets Manager for model keys.

This requires a corresponding change to the runtime operator, to pass this flag: https://github.com/gohypermode/runtime-operator/pull/12

Completes HYP-765