### PR TITLE
Reuse AWS service clients

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	hmConfig "hmruntime/config"
 	"hmruntime/logger"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -34,6 +35,10 @@ func Initialize(ctx context.Context) error {
 	}
 
 	awsConfig = cfg
+
+	if hmConfig.UseAwsSecrets {
+		initSecretsManager()
+	}
 
 	logger.Info(ctx).
 		Str("region", awsConfig.Region).

--- a/aws/secrets.go
+++ b/aws/secrets.go
@@ -11,9 +11,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
 
+var smClient *secretsmanager.Client
+
 // TODO: Prefetch secrets on startup and refresh them periodically
 
 var secretsCache = make(map[string]string)
+
+func initSecretsManager() {
+	// Initialize the Secrets Manager service client.
+	// This is safe to hold onto for the lifetime of the application.
+	// See https://github.com/aws/aws-sdk-go-v2/discussions/2566
+	smClient = secretsmanager.NewFromConfig(awsConfig)
+}
 
 func GetSecretString(ctx context.Context, secretId string) (string, error) {
 
@@ -22,8 +31,7 @@ func GetSecretString(ctx context.Context, secretId string) (string, error) {
 		return secret, nil
 	}
 
-	svc := secretsmanager.NewFromConfig(awsConfig)
-	secretValue, err := svc.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+	secretValue, err := smClient.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
 		SecretId: &secretId,
 	})
 

--- a/storage/awsstorage.go
+++ b/storage/awsstorage.go
@@ -7,11 +7,12 @@ package storage
 import (
 	"context"
 	"fmt"
-	"hmruntime/aws"
-	"hmruntime/config"
 	"io"
 	"path"
 	"strings"
+
+	"hmruntime/aws"
+	"hmruntime/config"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/rs/zerolog/log"

--- a/storage/localstorage.go
+++ b/storage/localstorage.go
@@ -18,7 +18,7 @@ import (
 type localStorage struct {
 }
 
-func (s *localStorage) initialize() {
+func (stg *localStorage) initialize() {
 	if config.StoragePath == "" {
 		log.Fatal().Msg("A storage path is required when using local storage.  Exiting.")
 	}
@@ -39,7 +39,7 @@ func (s *localStorage) initialize() {
 	}
 }
 
-func (s *localStorage) listFiles(ctx context.Context, extension string) ([]FileInfo, error) {
+func (stg *localStorage) listFiles(ctx context.Context, extension string) ([]FileInfo, error) {
 	entries, err := os.ReadDir(config.StoragePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list files in storage directory: %w", err)
@@ -64,7 +64,7 @@ func (s *localStorage) listFiles(ctx context.Context, extension string) ([]FileI
 	return files, nil
 }
 
-func (s *localStorage) getFileContents(ctx context.Context, name string) ([]byte, error) {
+func (stg *localStorage) getFileContents(ctx context.Context, name string) ([]byte, error) {
 	path := filepath.Join(config.StoragePath, name)
 	content, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
Per response from AWS team at https://github.com/aws/aws-sdk-go-v2/discussions/2566, we can re-use AWS service clients.
