### PR TITLE
Improve plugin resolving on module creation

### DIFF
--- a/functions/fncall.go
+++ b/functions/fncall.go
@@ -46,7 +46,7 @@ func CallFunction(ctx context.Context, mod wasm.Module, info schema.FunctionInfo
 
 	// Call the wasm function
 	logger.Info(ctx).
-		Str("plugin", info.PluginName).
+		Str("plugin", info.Plugin.Name()).
 		Str("function", fnName).
 		Str("resolver", schema.Resolver()).
 		Bool("user_visible", true).
@@ -56,7 +56,7 @@ func CallFunction(ctx context.Context, mod wasm.Module, info schema.FunctionInfo
 	duration := time.Since(start)
 	if err != nil {
 		logger.Err(ctx, err).
-			Str("plugin", info.PluginName).
+			Str("plugin", info.Plugin.Name()).
 			Str("function", fnName).
 			Dur("duration_ms", duration).
 			Bool("user_visible", true).
@@ -70,7 +70,7 @@ func CallFunction(ctx context.Context, mod wasm.Module, info schema.FunctionInfo
 	result, err := convertResult(mem, *schema.FieldDef.Type, def.ResultTypes()[0], res[0])
 	if err != nil {
 		logger.Err(ctx, err).
-			Str("plugin", info.PluginName).
+			Str("plugin", info.Plugin.Name()).
 			Str("function", fnName).
 			Dur("duration_ms", duration).
 			Str("schema_type", schema.FieldDef.Type.NamedType).
@@ -81,7 +81,7 @@ func CallFunction(ctx context.Context, mod wasm.Module, info schema.FunctionInfo
 	}
 
 	logger.Info(ctx).
-		Str("plugin", info.PluginName).
+		Str("plugin", info.Plugin.Name()).
 		Str("function", fnName).
 		Dur("duration_ms", duration).
 		Bool("user_visible", true).

--- a/functions/registration.go
+++ b/functions/registration.go
@@ -50,7 +50,7 @@ func registerFunctions(ctx context.Context, gqlSchema string) error {
 			for _, fn := range module.ExportedFunctions() {
 				fnName := fn.ExportNames()[0]
 				if strings.EqualFold(fnName, scma.FunctionName()) {
-					info := schema.FunctionInfo{PluginName: plugin.Name(), Schema: scma}
+					info := schema.FunctionInfo{Plugin: &plugin, Schema: scma}
 					resolver := scma.Resolver()
 					oldInfo, existed := FunctionsMap[resolver]
 					if existed && reflect.DeepEqual(oldInfo, info) {
@@ -77,13 +77,13 @@ func registerFunctions(ctx context.Context, gqlSchema string) error {
 				break
 			}
 		}
-		_, foundPlugin := host.Plugins.GetByName(info.PluginName)
+		_, foundPlugin := host.Plugins.GetByName(info.Plugin.Name())
 		if !foundSchema || !foundPlugin {
 			delete(FunctionsMap, resolver)
 			logger.Info(ctx).
 				Str("resolver", resolver).
 				Str("function", info.FunctionName()).
-				Str("plugin", info.PluginName).
+				Str("plugin", info.Plugin.Name()).
 				Msg("Unregistered function.")
 		}
 	}

--- a/host/management.go
+++ b/host/management.go
@@ -158,7 +158,7 @@ func unloadPlugin(ctx context.Context, plugin Plugin) error {
 	return (*plugin.Module).Close(ctx)
 }
 
-func GetModuleInstance(ctx context.Context, pluginName string) (wasm.Module, buffers, error) {
+func GetModuleInstance(ctx context.Context, plugin *Plugin) (wasm.Module, buffers, error) {
 
 	// Get the logger and writers for the plugin's stdout and stderr.
 	log := logger.Get(ctx).With().Bool("user_visible", true).Logger()
@@ -171,15 +171,9 @@ func GetModuleInstance(ctx context.Context, pluginName string) (wasm.Module, buf
 	wOut := io.MultiWriter(buf.Stdout, wInfoLog)
 	wErr := io.MultiWriter(buf.Stderr, wErrorLog)
 
-	// Get the plugin.
-	plugin, ok := Plugins.GetByName(pluginName)
-	if !ok {
-		return nil, buf, fmt.Errorf("plugin not found with name '%s'", pluginName)
-	}
-
 	// Configure the module instance.
 	cfg := wazero.NewModuleConfig().
-		WithName(pluginName + "_" + uuid.NewString()).
+		WithName(plugin.Name() + "_" + uuid.NewString()).
 		WithSysWalltime().WithSysNanotime().
 		WithStdout(wOut).WithStderr(wErr)
 

--- a/schema/fnschema.go
+++ b/schema/fnschema.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"hmruntime/host"
 	"hmruntime/logger"
 
 	"github.com/dgraph-io/gqlparser/ast"
@@ -16,8 +17,8 @@ import (
 )
 
 type FunctionInfo struct {
-	PluginName string
-	Schema     FunctionSchema
+	Plugin *host.Plugin
+	Schema FunctionSchema
 }
 
 type FunctionSchema struct {

--- a/server.go
+++ b/server.go
@@ -72,10 +72,10 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Each request will get its own instance of the plugin module,
 	// so that we can run multiple requests in parallel without risk
 	// of corrupting the module's memory.
-	mod, buf, err := host.GetModuleInstance(ctx, info.PluginName)
+	mod, buf, err := host.GetModuleInstance(ctx, info.Plugin.Name())
 	if err != nil {
 		logger.Err(ctx, err).
-			Str("plugin", info.PluginName).
+			Str("plugin", info.Plugin.Name()).
 			Msg("Failed to get module instance.")
 		err := writeErrorResponse(w, err)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -72,7 +72,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 	// Each request will get its own instance of the plugin module,
 	// so that we can run multiple requests in parallel without risk
 	// of corrupting the module's memory.
-	mod, buf, err := host.GetModuleInstance(ctx, info.Plugin.Name())
+	mod, buf, err := host.GetModuleInstance(ctx, info.Plugin)
 	if err != nil {
 		logger.Err(ctx, err).
 			Str("plugin", info.Plugin.Name()).


### PR DESCRIPTION
This is a small refactoring with a bit of perf improvement, since we don't need to lookup the plugin by name at execution time.