### PR TITLE
Route non-error message to extensions.logs

### DIFF
--- a/graphql/datasource/source.go
+++ b/graphql/datasource/source.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 
 	"hmruntime/functions"
 	"hmruntime/logger"
@@ -60,16 +59,15 @@ func (s Source) callFunction(ctx context.Context, callInfo callInfo) (any, []res
 	// Prepare the context that will be used throughout the function execution
 	ctx = prepareContext(ctx, info)
 
-	// Create output buffers for the function to write to
-	bStdOut := &bytes.Buffer{}
-	bStdErr := &bytes.Buffer{}
+	// Create output buffers for the function to write logs to
+	buffers := utils.OutputBuffers{}
 
 	// Get a module instance for this request.
 	// Each request will get its own instance of the plugin module, so that we can run
 	// multiple requests in parallel without risk of corrupting the module's memory.
 	// This also protects against security risk, as each request will have its own
 	// isolated memory space.  (One request cannot access another request's memory.)
-	mod, err := wasmhost.GetModuleInstance(ctx, info.Plugin, bStdOut, bStdErr)
+	mod, err := wasmhost.GetModuleInstance(ctx, info.Plugin, &buffers)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -78,11 +76,12 @@ func (s Source) callFunction(ctx context.Context, callInfo callInfo) (any, []res
 	// Call the function
 	result, err := functions.CallFunction(ctx, mod, info, callInfo.Parameters)
 
-	// Transform lines in the output buffers to GraphQL gqlErrors
-	gqlErrors := append(
-		transformErrors(bStdOut, callInfo),
-		transformErrors(bStdErr, callInfo)...,
-	)
+	// Store the output buffers in the context
+	allBuffers := ctx.Value(utils.FunctionOutputBuffersContextKey).(map[string]utils.OutputBuffers)
+	allBuffers[callInfo.Function.AliasOrName()] = buffers
+
+	// Transform error lines in the output buffers to GraphQL errors
+	gqlErrors := transformErrors(buffers, callInfo)
 
 	return result, gqlErrors, err
 }
@@ -226,49 +225,21 @@ func transformValue(data []byte, tf templateField) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func transformErrors(buf *bytes.Buffer, ci callInfo) []resolve.GraphQLError {
-	errors := make([]resolve.GraphQLError, 0)
-	for _, s := range strings.Split(buf.String(), "\n") {
-		if s != "" {
-			errors = append(errors, transformError(s, ci))
+func transformErrors(buffers utils.OutputBuffers, ci callInfo) []resolve.GraphQLError {
+	messages := utils.TransformConsoleOutput(buffers)
+	errors := make([]resolve.GraphQLError, 0, len(messages))
+	for _, msg := range messages {
+		// Only include errors.  Other messages will be captured later and
+		// passed back as logs in the extensions section of the response.
+		if msg.IsError() {
+			errors = append(errors, resolve.GraphQLError{
+				Message: msg.Message,
+				Path:    []string{ci.Function.AliasOrName()},
+				Extensions: map[string]interface{}{
+					"level": msg.Level,
+				},
+			})
 		}
 	}
 	return errors
-}
-
-func transformError(msg string, ci callInfo) resolve.GraphQLError {
-	level := ""
-	a := strings.SplitAfterN(msg, ": ", 2)
-	if len(a) == 2 {
-		switch a[0] {
-		case "Debug: ":
-			level = "debug"
-			msg = a[1]
-		case "Info: ":
-			level = "info"
-			msg = a[1]
-		case "Warning: ":
-			level = "warning"
-			msg = a[1]
-		case "Error: ":
-			level = "error"
-			msg = a[1]
-		case "abort: ":
-			level = "fatal"
-			msg = a[1]
-		}
-	}
-
-	e := resolve.GraphQLError{
-		Message: msg,
-		Path:    []string{ci.Function.AliasOrName()},
-	}
-
-	if level != "" {
-		e.Extensions = map[string]interface{}{
-			"level": level,
-		}
-	}
-
-	return e
 }

--- a/utils/buffers.go
+++ b/utils/buffers.go
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package utils
+
+import "bytes"
+
+type OutputBuffers struct {
+	StdOut bytes.Buffer
+	StdErr bytes.Buffer
+}

--- a/utils/console.go
+++ b/utils/console.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package utils
+
+import (
+	"bytes"
+	"strings"
+)
+
+type LogMessage struct {
+	Level   string `json:"level,omitempty"`
+	Message string `json:"message"`
+}
+
+func (l LogMessage) IsError() bool {
+	return l.Level == "error" || l.Level == "fatal"
+}
+
+func TransformConsoleOutput(buffers OutputBuffers) []LogMessage {
+	return append(transformConsoleOutputLines(&buffers.StdOut), transformConsoleOutputLines(&buffers.StdErr)...)
+}
+
+func transformConsoleOutputLines(buf *bytes.Buffer) []LogMessage {
+	lines := strings.Split(buf.String(), "\n")
+	messages := make([]LogMessage, 0, len(lines))
+	for _, line := range lines {
+		if line != "" {
+			level, message := SplitConsoleOutputLine(line)
+			messages = append(messages, LogMessage{level, message})
+		}
+	}
+	return messages
+}
+
+func SplitConsoleOutputLine(line string) (level string, message string) {
+	a := strings.SplitAfterN(line, ": ", 2)
+	if len(a) == 2 {
+		switch a[0] {
+		case "Debug: ":
+			return "debug", a[1]
+		case "Info: ":
+			return "info", a[1]
+		case "Warning: ":
+			return "warning", a[1]
+		case "Error: ":
+			return "error", a[1]
+		case "abort: ":
+			return "fatal", a[1]
+		}
+	}
+	return "", line
+}

--- a/utils/context.go
+++ b/utils/context.go
@@ -8,3 +8,4 @@ type contextKey string
 
 const ExecutionIdContextKey contextKey = "execution_id"
 const PluginContextKey contextKey = "plugin"
+const FunctionOutputBuffersContextKey contextKey = "function_output_buffers"

--- a/wasmhost/wasmhost.go
+++ b/wasmhost/wasmhost.go
@@ -12,6 +12,7 @@ import (
 
 	"hmruntime/logger"
 	"hmruntime/plugins"
+	"hmruntime/utils"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -29,7 +30,7 @@ var RegistrationRequest chan bool = make(chan bool)
 var Plugins = plugins.NewPluginRegistry()
 
 // Gets a module instance for the given plugin, used for a single invocation.
-func GetModuleInstance(ctx context.Context, plugin *plugins.Plugin, wStdOut io.Writer, wStdErr io.Writer) (api.Module, error) {
+func GetModuleInstance(ctx context.Context, plugin *plugins.Plugin, buffers *utils.OutputBuffers) (api.Module, error) {
 
 	// Get the logger and writers for the plugin's stdout and stderr.
 	log := logger.Get(ctx).With().Bool("user_visible", true).Logger()
@@ -37,8 +38,8 @@ func GetModuleInstance(ctx context.Context, plugin *plugins.Plugin, wStdOut io.W
 	wErrorLog := logger.NewLogWriter(&log, zerolog.ErrorLevel)
 
 	// Capture stdout/stderr both to logs, and to provided writers.
-	wOut := io.MultiWriter(wStdOut, wInfoLog)
-	wErr := io.MultiWriter(wStdErr, wErrorLog)
+	wOut := io.MultiWriter(&buffers.StdOut, wInfoLog)
+	wErr := io.MultiWriter(&buffers.StdErr, wErrorLog)
 
 	// Configure the module instance.
 	cfg := wazero.NewModuleConfig().


### PR DESCRIPTION
Output from `console.log`, `console.debug`, `console.info` and `console.warn` should not be considered GraphQL errors.  Instead, they'll be written to a `logs` section in the GraphQL `extensions`.  `console.error` and `throw` will still be considered GraphQL errors.

Completes HYP-1019

Example:
```ts
export function testError(): void {
  console.log("this is a logged message");
  console.debug("this is a debug message");
  console.info("this is an info message");
  console.warn("this is a warning message");
  console.error("this is an error message");
  throw new Error("this is a thrown error message");
}
```

The output is now:
```json
{
    "errors": [
        {
            "message": "this is an error message",
            "path": [
                "testError"
            ],
            "extensions": {
                "level": "error"
            }
        },
        {
            "message": "this is a thrown error message in assembly/index.ts(284:3)",
            "path": [
                "testError"
            ],
            "extensions": {
                "level": "fatal"
            }
        }
    ],
    "data": null,
    "extensions": {
        "logs": {
            "testError": [
                {
                    "message": "this is a logged message"
                },
                {
                    "level": "debug",
                    "message": "this is a debug message"
                },
                {
                    "level": "info",
                    "message": "this is an info message"
                },
                {
                    "level": "warning",
                    "message": "this is a warning message"
                }
            ]
        }
    }
}
```