### PR TITLE
Emit execution ids with logs in results

### DIFF
--- a/utils/context.go
+++ b/utils/context.go
@@ -8,4 +8,4 @@ type contextKey string
 
 const ExecutionIdContextKey contextKey = "execution_id"
 const PluginContextKey contextKey = "plugin"
-const FunctionOutputBuffersContextKey contextKey = "function_output_buffers"
+const FunctionOutputContextKey contextKey = "function_output"


### PR DESCRIPTION
An improvement on #144  - we also now return the Execution ID for each function call.

Example:

```graphql
query SayHello {
    a: sayHello(name: "Alice")
    b: sayHello(name: "Bob")
    c: sayHello(name: "Charlie")
}
```

Result:

```json
{
    "data": {
        "a": "Hello Alice",
        "b": "Hello Bob",
        "c": "Hello Charlie"
    },
    "extensions": {
        "invocations": {
            "a": {
                "executionId": "coja0e24jkdjrijumbvg"
            },
            "b": {
                "executionId": "coja0e24jkdjrijumbv0"
            },
            "c": {
                "executionId": "coja0e24jkdjrijumc00"
            }
        }
    }
}
```

Or with other errors or other log output:

```graphql
query TestError {
    testError
}
```

Result:
```json
{
    "errors": [
        {
            "message": "this is an error message",
            "path": [
                "testError"
            ],
            "extensions": {
                "level": "error"
            }
        },
        {
            "message": "this is a thrown error message in assembly/index.ts(7:3)",
            "path": [
                "testError"
            ],
            "extensions": {
                "level": "fatal"
            }
        }
    ],
    "data": null,
    "extensions": {
        "invocations": {
            "testError": {
                "executionId": "coja0q24jkdjrijumc0g",
                "logs": [
                    {
                        "message": "this is a logged message"
                    },
                    {
                        "level": "debug",
                        "message": "this is a debug message"
                    },
                    {
                        "level": "info",
                        "message": "this is an info message"
                    },
                    {
                        "level": "warning",
                        "message": "this is a warning message"
                    }
                ]
            }
        }
    }
}
```

Completes HYP-1031