### PR TITLE
Fix GraphQL errors with __typename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 
 - Fix GraphQL error when resulting data contains a nested null field [#150](https://github.com/gohypermode/runtime/issues/150)
+- Fix GraphQL error when resolving `__typename` fields; also add `HYPERMODE_TRACE` debugging flag [#151](https://github.com/gohypermode/runtime/issues/151)
 
 # 2024-04-25 - Version 0.6.0
 

--- a/graphql/datasource/source.go
+++ b/graphql/datasource/source.go
@@ -60,7 +60,7 @@ func (s Source) callFunction(ctx context.Context, callInfo callInfo) (any, []res
 	// Get the function info
 	info, ok := functions.Functions[callInfo.Function.Name]
 	if !ok {
-		return nil, nil, fmt.Errorf("no function registered named %s", callInfo.Function)
+		return nil, nil, fmt.Errorf("no function registered named %s", callInfo.Function.Name)
 	}
 
 	// Prepare the context that will be used throughout the function execution

--- a/graphql/engine/engine.go
+++ b/graphql/engine/engine.go
@@ -6,8 +6,6 @@ package engine
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"sync"
 
 	"context"
@@ -18,6 +16,7 @@ import (
 	"hmruntime/graphql/schemagen"
 	"hmruntime/logger"
 	"hmruntime/plugins"
+	"hmruntime/utils"
 
 	"github.com/wundergraph/graphql-go-tools/execution/engine"
 	gql "github.com/wundergraph/graphql-go-tools/execution/graphql"
@@ -48,7 +47,7 @@ func Activate(ctx context.Context, metadata plugins.PluginMetadata) error {
 		return err
 	}
 
-	if b, err := strconv.ParseBool(os.Getenv("HYPERMODE_DEBUG")); err == nil && b {
+	if utils.HypermodeDebugEnabled() {
 		if config.UseJsonLogging {
 			logger.Debug(ctx).Str("schema", schemaContent).Msg("Generated schema")
 		} else {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,8 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -65,4 +67,14 @@ func ConvertToStruct[T any](data map[string]any) (T, error) {
 	}
 
 	return result, nil
+}
+
+func EnvVarFlagEnabled(envVarName string) bool {
+	v := os.Getenv(envVarName)
+	b, err := strconv.ParseBool(v)
+	return err == nil && b
+}
+
+func HypermodeDebugEnabled() bool {
+	return EnvVarFlagEnabled("HYPERMODE_DEBUG")
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -78,3 +78,7 @@ func EnvVarFlagEnabled(envVarName string) bool {
 func HypermodeDebugEnabled() bool {
 	return EnvVarFlagEnabled("HYPERMODE_DEBUG")
 }
+
+func HypermodeTraceEnabled() bool {
+	return EnvVarFlagEnabled("HYPERMODE_TRACE")
+}


### PR DESCRIPTION
Fixes HYP-1066

Also further improved error handling, and added support for a `HYPERMODE_TRACE` environment variable to emit super detailed trace info to the GraphQL response.  (That will be only used for detailed debugging purposes.)