### PR TITLE
Disable Sentry when debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Sentry is no longer used when `HYPERMODE_DEBUG` is enabled [#187](https://github.com/gohypermode/runtime/pull/187)
+
 ## 2024-05-08 - Version 0.6.6
 
 - Remove `Access-Control-Allow-Credentials`. Add `Access-Control-Request-Headers` [#180](https://github.com/gohypermode/runtime/pull/180)

--- a/utils/sentry.go
+++ b/utils/sentry.go
@@ -20,8 +20,15 @@ import (
 const sentryDsn = "https://d0de28f77651b88c22af84598882d60a@o4507057700470784.ingest.us.sentry.io/4507153498636288"
 
 var rootSourcePath string
+var sentryInitialized bool
 
 func InitSentry(rootPath string) {
+
+	// Don't initialize Sentry when running in debug mode.
+	if HypermodeDebugEnabled() {
+		return
+	}
+
 	rootSourcePath = rootPath
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:         sentryDsn,
@@ -44,10 +51,14 @@ func InitSentry(rootPath string) {
 		// We don't have our logger yet, so just log to stderr.
 		log.Fatalf("sentry.Init: %s", err)
 	}
+
+	sentryInitialized = true
 }
 
 func FlushSentryEvents() {
-	sentry.Flush(5 * time.Second)
+	if sentryInitialized {
+		sentry.Flush(5 * time.Second)
+	}
 }
 
 func NewSentryTransactionForCurrentFunc(ctx context.Context) (*sentry.Span, context.Context) {


### PR DESCRIPTION
If `HYPERMODE_DEBUG` is true, then we are developing locally and we may be creating errors just in the normal course of development.  These shouldn't be sent to Sentry.

Recall, `"HYPERMODE_DEBUG": "true"` is set in the VS Code `launch.json` already.