### PR TITLE
Only listen on localhost when debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Sentry is no longer used when `HYPERMODE_DEBUG` is enabled [#187](https://github.com/gohypermode/runtime/pull/187)
+- Only listen on `localhost` when `HYPERMODE_DEBUG` is enabled, to prevent firewall prompt [#188](https://github.com/gohypermode/runtime/pull/188)
 
 ## 2024-05-08 - Version 0.6.6
 

--- a/server/server.go
+++ b/server/server.go
@@ -30,9 +30,14 @@ func Start(ctx context.Context) {
 
 	// Create the configuration for the server.
 	mux := GetHandlerMux()
-	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", config.Port),
-		Handler: mux,
+	server := &http.Server{Handler: mux}
+	if utils.HypermodeDebugEnabled() {
+		// If we are in debug mode, only listen on localhost.
+		// This prevents getting nagged for firewall permissions each launch.
+		server.Addr = fmt.Sprintf("localhost:%d", config.Port)
+	} else {
+		// Otherwise, listen on all interfaces.
+		server.Addr = fmt.Sprintf(":%d", config.Port)
 	}
 
 	// Start the server in a goroutine so we can listen for signals to shutdown.


### PR DESCRIPTION
I was tired of getting these constantly:

<img width="263" alt="image" src="https://github.com/gohypermode/runtime/assets/1396388/315d0517-cb76-4d27-ae9d-f407d6deddd2">

Turns out, if you listen on `localhost:8686` instead of just `:8686` (all interfaces), MacOS doesn't nag you with a firewall prompt any more.