### PR TITLE
Add support for binary data fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Sentry is no longer used when `HYPERMODE_DEBUG` is enabled [#187](https://github.com/gohypermode/runtime/pull/187)
 - Only listen on `localhost` when `HYPERMODE_DEBUG` is enabled, to prevent firewall prompt [#188](https://github.com/gohypermode/runtime/pull/188)
 - Improve support for marshaling classes [#189](https://github.com/gohypermode/runtime/pull/189)
+- Add support for binary data fields [#190](https://github.com/gohypermode/runtime/pull/190)
 
 ## 2024-05-08 - Version 0.6.6
 

--- a/functions/assemblyscript/helpers.go
+++ b/functions/assemblyscript/helpers.go
@@ -18,11 +18,12 @@ import (
 
 // These are the managed types that we handle directly.
 var typeMap = map[string]string{
-	"~lib/string/String":       "string",
-	"~lib/array/Array":         "Array",
-	"~lib/map/Map":             "Map",
-	"~lib/date/Date":           "Date",
-	"~lib/wasi_date/wasi_Date": "Date",
+	"~lib/arraybuffer/ArrayBuffer": "ArrayBuffer",
+	"~lib/string/String":           "string",
+	"~lib/array/Array":             "Array",
+	"~lib/map/Map":                 "Map",
+	"~lib/date/Date":               "Date",
+	"~lib/wasi_date/wasi_Date":     "Date",
 }
 
 // Allocate memory within the AssemblyScript module.

--- a/functions/assemblyscript/objects.go
+++ b/functions/assemblyscript/objects.go
@@ -18,9 +18,10 @@ import (
 
 func readObject(ctx context.Context, mem wasm.Memory, typ plugins.TypeInfo, offset uint32) (data any, err error) {
 	switch typ.Name {
+	case "ArrayBuffer":
+		return readBytes(mem, offset)
 	case "string":
 		return ReadString(mem, offset)
-
 	case "Date":
 		return readDate(mem, offset)
 	}
@@ -45,8 +46,14 @@ func readObject(ctx context.Context, mem wasm.Memory, typ plugins.TypeInfo, offs
 }
 
 func writeObject(ctx context.Context, mod wasm.Module, typ plugins.TypeInfo, val any) (offset uint32, err error) {
-
 	switch typ.Name {
+	case "ArrayBuffer":
+		bytes, ok := val.([]byte)
+		if !ok {
+			return 0, fmt.Errorf("input value is not a byte array")
+		}
+		return writeBytes(ctx, mod, bytes)
+
 	case "string":
 		s, ok := val.(string)
 		if !ok {

--- a/graphql/schemagen/schemagen.go
+++ b/graphql/schemagen/schemagen.go
@@ -309,7 +309,9 @@ func convertType(asType string, typeDefs *map[string]TypeDefinition, firstPass b
 	// convert scalar types
 	// TODO: How do we want to provide GraphQL ID scalar types? Maybe they're annotated? or maybe by naming convention?
 	switch asType {
-	case "string":
+	case "string", "ArrayBuffer":
+		// NOTE: ArrayBuffers are converted to []byte.  If the bytes represent valid UTF-8 strings,
+		// Go will serialize them as actual strings.  Otherwise, the data will be base64 encoded.
 		return "String" + n, nil
 	case "bool":
 		return "Boolean" + n, nil


### PR DESCRIPTION
This correctly projects fields defined as `ArrayBuffer` in AssemblyScript to be interpreted as `[]byte` in the Runtime, and then projected as base64-encoded `String` fields in GraphQL.

This is primarily to support binary content in HTTP responses, such as images or audio.

Part of HYP-1192