### PR TITLE
More improvements to marshaling classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Sentry is no longer used when `HYPERMODE_DEBUG` is enabled [#187](https://github.com/gohypermode/runtime/pull/187)
 - Only listen on `localhost` when `HYPERMODE_DEBUG` is enabled, to prevent firewall prompt [#188](https://github.com/gohypermode/runtime/pull/188)
-- Improve support for marshaling classes [#189](https://github.com/gohypermode/runtime/pull/189)
+- Improve support for marshaling classes [#189](https://github.com/gohypermode/runtime/pull/189) [#191](https://github.com/gohypermode/runtime/pull/191)
 - Add support for binary data fields [#190](https://github.com/gohypermode/runtime/pull/190)
 
 ## 2024-05-08 - Version 0.6.6


### PR DESCRIPTION
Additional followup from #189.  Fixes marshaling of `[]kvp` to map types, and handles nested `map[string]any` that need to be reinterpreted as structs.

Related to HYP-1126