### PR TITLE
Improve HTTP error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Lowercase model name before invoking for hypermode hosted models [#221](https://github.com/gohypermode/runtime/pull/221)
+- Improve HTTP error messages [#222](https://github.com/gohypermode/runtime/pull/222)
 
 ## 2024-06-03 - Version 0.8.2
 

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -41,8 +41,7 @@ func Test_SendHttp(t *testing.T) {
 
 func Test_SendHttp_ErrorResponse(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, "Internal Server Error")
+		http.Error(w, "Something went wrong!", http.StatusInternalServerError)
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -57,7 +56,7 @@ func Test_SendHttp_ErrorResponse(t *testing.T) {
 		t.Error("Expected an error, but got nil")
 	}
 
-	expected := "bad status: 500 Internal Server Error"
+	expected := "HTTP error: 500 Internal Server Error\nSomething went wrong!\n"
 	if err.Error() != expected {
 		t.Errorf("Unexpected error message. Got: %s, want: %s", err.Error(), expected)
 	}


### PR DESCRIPTION
If an HTTP request gets a non-successful HTTP status code, it may also include a response body with further information about the error.  We should include that in the error response.