### PR TITLE
Add host function for direct logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Lowercase model name before invoking for hypermode hosted models [#221](https://github.com/gohypermode/runtime/pull/221)
 - Improve HTTP error messages [#222](https://github.com/gohypermode/runtime/pull/222)
+- Add host function for direct logging [#224](https://github.com/gohypermode/runtime/pull/224)
 
 ## 2024-06-03 - Version 0.8.2
 

--- a/hostfunctions/hostfns.go
+++ b/hostfunctions/hostfns.go
@@ -22,6 +22,7 @@ func Instantiate(ctx context.Context, runtime *wazero.Runtime) error {
 	b := (*runtime).NewHostModuleBuilder(hostModuleName)
 
 	// Each host function should get a line here:
+	b.NewFunctionBuilder().WithFunc(hostLog).Export("log")
 	b.NewFunctionBuilder().WithFunc(hostExecuteGQL).Export("executeGQL")
 	b.NewFunctionBuilder().WithFunc(hostInvokeClassifier).Export("invokeClassifier")
 	b.NewFunctionBuilder().WithFunc(hostComputeEmbedding).Export("computeEmbedding")

--- a/hostfunctions/log.go
+++ b/hostfunctions/log.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package hostfunctions
+
+import (
+	"context"
+	"hmruntime/logger"
+	"hmruntime/utils"
+
+	wasm "github.com/tetratelabs/wazero/api"
+)
+
+func hostLog(ctx context.Context, mod wasm.Module, pLevel uint32, pMessage uint32) {
+
+	var level, message string
+	err := readParams2(ctx, mod, pLevel, pMessage, &level, &message)
+	if err != nil {
+		logger.Err(ctx, err).Msg("Error reading input parameters.")
+	}
+
+	// write to the logger
+	logger.Get(ctx).
+		WithLevel(logger.ParseLevel(level)).
+		Str("text", message).
+		Bool("user_visible", true).
+		Msg("Message logged from function.")
+
+	// also store messages in the context, so we can return them to the caller
+	messages := ctx.Value(utils.FunctionMessagesContextKey).(*[]utils.LogMessage)
+	*messages = append(*messages, utils.LogMessage{
+		Level:   level,
+		Message: message,
+	})
+}

--- a/logger/logwriter.go
+++ b/logger/logwriter.go
@@ -41,7 +41,7 @@ func (w logWriter) Write(p []byte) (n int, err error) {
 
 func (w logWriter) logMessage(line string) {
 	l, message := utils.SplitConsoleOutputLine(line)
-	level := parseLevel(l)
+	level := ParseLevel(l)
 	if level == zerolog.NoLevel {
 		level = w.level
 	}
@@ -52,7 +52,7 @@ func (w logWriter) logMessage(line string) {
 		Msg("Message logged from function.")
 }
 
-func parseLevel(level string) zerolog.Level {
+func ParseLevel(level string) zerolog.Level {
 	switch level {
 	case "debug":
 		return zerolog.DebugLevel

--- a/utils/context.go
+++ b/utils/context.go
@@ -9,3 +9,4 @@ type contextKey string
 const ExecutionIdContextKey contextKey = "execution_id"
 const PluginContextKey contextKey = "plugin"
 const FunctionOutputContextKey contextKey = "function_output"
+const FunctionMessagesContextKey contextKey = "function_messages"


### PR DESCRIPTION
Adds a new `log` host function, to be used for direct logging instead of parsing stderr/stdout.  However, it leaves the old approach intact, to remain compatible until all projects are updated.  We can remove the old approach later, or just leave it for WASI compliance. 

Completes HYP-1384

Corresponding Functions PR: https://github.com/hypermodeAI/functions-as/pull/102
