### PR TITLE
Don't panic when the metadata DB is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Don't panic when the metadata DB is not configured [#256](https://github.com/hypermodeAI/runtime/pull/256)
+
 ## 2024-06-24 - Version 0.9.2
 
 - Add auto-embedding for collection based on text checkpoint [#250](https://github.com/hypermodeAI/runtime/pull/250)


### PR DESCRIPTION
Starting the Runtime without `HYPERMODE_METADATA_DB` currently panics.  This fixes it, and ensures the warning only appears once.