### PR TITLE
Support pointers when marshalling objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Update manifest library and usage [#275](https://github.com/hypermodeAI/runtime/pull/275)
+- Support pointers when marshalling objects [#277](https://github.com/hypermodeAI/runtime/pull/277)
 
 ## 2024-07-09 - Version 0.9.5
 

--- a/functions/assemblyscript/values.go
+++ b/functions/assemblyscript/values.go
@@ -20,7 +20,7 @@ func EncodeValue(ctx context.Context, mod wasm.Module, typ plugins.TypeInfo, dat
 
 	// Handle null values if the type is nullable
 	if isNullable(typ.Path) {
-		if data == nil {
+		if data == nil || reflect.ValueOf(data).IsNil() {
 			return 0, nil
 		}
 		typ = removeNull(typ)

--- a/hostfunctions/helpers.go
+++ b/hostfunctions/helpers.go
@@ -14,10 +14,17 @@ import (
 )
 
 func writeResult[T any](ctx context.Context, mod wasm.Module, val T) (uint32, error) {
-	switch any(val).(type) {
+	switch t := any(val).(type) {
 	case string:
 		// fast path for strings
-		return assemblyscript.WriteString(ctx, mod, any(val).(string))
+		return assemblyscript.WriteString(ctx, mod, t)
+	case *string:
+		// fast path for nullable strings
+		if any(val) == nil {
+			return 0, nil
+		} else {
+			return assemblyscript.WriteString(ctx, mod, *t)
+		}
 	default:
 		typ, err := assemblyscript.GetTypeInfo[T]()
 		if err != nil {

--- a/hostfunctions/helpers.go
+++ b/hostfunctions/helpers.go
@@ -49,7 +49,19 @@ func readParam[T any](ctx context.Context, mod wasm.Module, p uint32, v *T) erro
 			return err
 		}
 		*v = any(s).(T)
-
+	case *string:
+		// fast path for nullable strings
+		if p == 0 {
+			var s *string
+			*v = any(s).(T)
+		} else {
+			mem := mod.Memory()
+			s, err := assemblyscript.ReadString(mem, p)
+			if err != nil {
+				return err
+			}
+			*v = any(&s).(T)
+		}
 	default:
 		typ, err := assemblyscript.GetTypeInfo[T]()
 		if err != nil {


### PR DESCRIPTION
Allows (for example) returning an object that has a nullable string in AssemblyScript, represented by a `*string` in Go.