### PR TITLE
correctly reset the timer when it is not fired for inference history

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -398,6 +398,11 @@ func (w *runtimePostgresWriter) worker(ctx context.Context) {
 			if batchIndex == batchSize {
 				WriteInferenceHistoryToDB(ctx, batch[:batchSize])
 				batchIndex = 0
+
+				// we need to drain the timer channel to prevent the timer from firing
+				if !timer.Stop() {
+					<-timer.C
+				}
 				timer.Reset(inferenceRefresherInterval)
 			}
 		case <-timer.C:


### PR DESCRIPTION
We periodically send inference history data to postgres. The periodicity depends on both time and amount of data. We use a timer to ensure that data is being sent to postgres for the case when not a lot of data is being generated.

But if data is continuously being generated, we were resetting the timer without draining the timer channel. The effect of this would be that timers will get fired later on without waiting the right amount of time.

This commit fixes that. This is being fixed in Go 1.23 and we can simply call timer.Reset() in the begining of the loop irrespective of the state of the timer.

Reference: https://go.dev/wiki/Go123Timer