### PR TITLE
Fix memory corruption issue with multiple input parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Add HNSW indexing for collection [#285](https://github.com/hypermodeAI/runtime/pull/285)
+- Fix memory corruption issue with multiple input parameters [#288](https://github.com/hypermodeAI/runtime/pull/288)
 
 ## 2024-07-15 - Version 0.10.0
 

--- a/wasmhost/fncall.go
+++ b/wasmhost/fncall.go
@@ -127,7 +127,7 @@ func getParameters(ctx context.Context, mod wasm.Module, paramInfo []plugins.Par
 
 		mask |= 1 << i
 
-		param, err := assemblyscript.EncodeValue(ctx, mod, arg.Type, val)
+		param, err := assemblyscript.EncodeValueForParameter(ctx, mod, arg.Type, val)
 		if err != nil {
 			return nil, fmt.Errorf("function parameter '%s' is invalid: %w", arg.Name, err)
 		}


### PR DESCRIPTION
When there are multiple input parameters that require memory allocation, it's important that we pin the allocated memory for each parameter, so that allocating another parameter doesn't free the first one.

This doesn't happen automatically, because we haven't yet made the function call - so from the AssemblyScript garbage collector's perspective, they are unused unless they have been pinned.

Fixes HYP-1757