### PR TITLE
Warn instead of error on some db connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix certain errors reporting incorrectly [#307](https://github.com/hypermodeAI/runtime/pull/307)
 - Improve encoding and decoding of arrays and maps [#308](https://github.com/hypermodeAI/runtime/pull/308)
 - Listen on both IPv4 and IPv6 for localhost [#309](https://github.com/hypermodeAI/runtime/pull/309)
+- Warn instead of error on some db connection failures [#310](https://github.com/hypermodeAI/runtime/pull/310)
 
 ## 2024-07-23 - Version 0.10.1
 


### PR DESCRIPTION
Since writing plugin info and inference history to the db is optional, then when the db is not configured, or when it can't be connected to, we should warn instead of error.