### PR TITLE
Calculate class size and field offsets

### DIFF
--- a/functions/assemblyscript/arrays.go
+++ b/functions/assemblyscript/arrays.go
@@ -119,7 +119,8 @@ func writeArray(ctx context.Context, mod wasm.Module, def *metadata.TypeDefiniti
 	}
 
 	// write array object
-	offset, err = allocateWasmMemory(ctx, mod, def.Size, def.Id)
+	const size = 16
+	offset, err = allocateWasmMemory(ctx, mod, size, def.Id)
 	if err != nil {
 		return 0, err
 	}

--- a/functions/assemblyscript/dates.go
+++ b/functions/assemblyscript/dates.go
@@ -32,7 +32,8 @@ func writeDate(ctx context.Context, mod wasm.Module, t time.Time) (offset uint32
 		}
 	}
 
-	offset, err = allocateWasmMemory(ctx, mod, def.Size, def.Id)
+	const size = 24
+	offset, err = allocateWasmMemory(ctx, mod, size, def.Id)
 	if err != nil {
 		return 0, err
 	}

--- a/functions/assemblyscript/maps.go
+++ b/functions/assemblyscript/maps.go
@@ -234,7 +234,8 @@ func writeMap(ctx context.Context, mod wasm.Module, def *metadata.TypeDefinition
 	}
 
 	// write map object
-	offset, err = allocateWasmMemory(ctx, mod, def.Size, def.Id)
+	const size = 24
+	offset, err = allocateWasmMemory(ctx, mod, size, def.Id)
 	if err != nil {
 		return 0, err
 	}

--- a/plugins/metadata/metadata.go
+++ b/plugins/metadata/metadata.go
@@ -64,7 +64,6 @@ func (f *Function) Signature() string {
 
 type TypeDefinition struct {
 	Id     uint32   `json:"id"`
-	Size   uint32   `json:"size"`
 	Path   string   `json:"path"`
 	Name   string   `json:"name"`
 	Fields []*Field `json:"fields"`
@@ -132,9 +131,8 @@ func (p *Parameter) UnmarshalJSON(data []byte) error {
 }
 
 type Field struct {
-	Offset uint32    `json:"offset"`
-	Name   string    `json:"name"`
-	Type   *TypeInfo `json:"type"`
+	Name string    `json:"name"`
+	Type *TypeInfo `json:"type"`
 }
 
 type TypeInfo struct {


### PR DESCRIPTION
We don't need the class size and field offsets in the metadata since we can calculate them directly.