### PR TITLE
Fix schema generation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Improve encoding and decoding of arrays and maps [#308](https://github.com/hypermodeAI/runtime/pull/308)
 - Listen on both IPv4 and IPv6 for localhost [#309](https://github.com/hypermodeAI/runtime/pull/309)
 - Warn instead of error on some db connection failures [#310](https://github.com/hypermodeAI/runtime/pull/310)
-- Modularize language-specific features [#314](https://github.com/hypermodeAI/runtime/pull/314)
+- Modularize language-specific features [#314](https://github.com/hypermodeAI/runtime/pull/314) [#325](https://github.com/hypermodeAI/runtime/pull/325)
 - Fix error reporting with host functions [#318](https://github.com/hypermodeAI/runtime/pull/318)
 - Log cancellations and host function activity [#320](https://github.com/hypermodeAI/runtime/pull/320)
 - Add namespaces to collections to isolate storage [#321](https://github.com/hypermodeAI/runtime/pull/321)

--- a/graphql/schemagen/schemagen.go
+++ b/graphql/schemagen/schemagen.go
@@ -27,8 +27,7 @@ func GetGraphQLSchema(ctx context.Context, md *metadata.Metadata) (*GraphQLSchem
 	defer span.Finish()
 
 	lti := languages.GetLanguageForSDK(md.SDK).TypeInfo()
-	typeDefs := make(map[string]*TypeDefinition, len(md.Types))
-	errors := transformTypes(md.Types, typeDefs, lti)
+	typeDefs, errors := transformTypes(md.Types, lti)
 	functions, errs := transformFunctions(md.FnExports, typeDefs, lti)
 	types := utils.MapValues(typeDefs)
 	errors = append(errors, errs...)
@@ -61,7 +60,8 @@ type TransformError struct {
 	Error  error
 }
 
-func transformTypes(types metadata.TypeMap, typeDefs map[string]*TypeDefinition, lti languages.TypeInfo) []*TransformError {
+func transformTypes(types metadata.TypeMap, lti languages.TypeInfo) (map[string]*TypeDefinition, []*TransformError) {
+	typeDefs := make(map[string]*TypeDefinition, len(types))
 	errors := make([]*TransformError, 0)
 	for _, t := range types {
 		name := lti.GetNameForType(t.Name)
@@ -82,7 +82,7 @@ func transformTypes(types metadata.TypeMap, typeDefs map[string]*TypeDefinition,
 			Fields: fields,
 		}
 	}
-	return errors
+	return typeDefs, errors
 }
 
 type FunctionSignature struct {

--- a/graphql/schemagen/schemagen_test.go
+++ b/graphql/schemagen/schemagen_test.go
@@ -304,8 +304,7 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 				inputTypes[td.Name] = td
 			}
 
-			typeDefs := make(map[string]*TypeDefinition, len(tc.inputTypeDefs))
-			errors := transformTypes(inputTypes, typeDefs, lti)
+			typeDefs, errors := transformTypes(inputTypes, lti)
 			require.Empty(t, errors)
 
 			result, err := convertType(tc.inputType, lti, typeDefs, false)

--- a/languages/assemblyscript/typeinfo.go
+++ b/languages/assemblyscript/typeinfo.go
@@ -58,6 +58,16 @@ func (ti *typeInfoProvider) GetMapSubtypes(t string) (string, string) {
 
 func (ti *typeInfoProvider) GetNameForType(t string) string {
 	s := ti.GetUnderlyingType(t)
+
+	if ti.IsArrayType(s) {
+		return ti.GetNameForType(ti.GetArraySubtype(s)) + "[]"
+	}
+
+	if ti.IsMapType(s) {
+		kt, vt := ti.GetMapSubtypes(s)
+		return "Map<" + ti.GetNameForType(kt) + "," + ti.GetNameForType(vt) + ">"
+	}
+
 	return s[strings.LastIndex(s, "/")+1:]
 }
 


### PR DESCRIPTION
Arrays and maps aren't being generated correctly in the GraphQL schema.  Bug was introduced with #314, which has not yet been released, so this should fix it before there is any impact.