### PR TITLE
Improve logger registration code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Improve logger registration code [#335](https://github.com/hypermodeAI/runtime/pull/335)
+
 ## 2024-08-12 - Version 0.11.0
 
 - Perf improvements to internal storage of hnsw data in Collections [#299](https://github.com/hypermodeAI/runtime/pull/299)

--- a/integration_tests/postgresql_integration_test.go
+++ b/integration_tests/postgresql_integration_test.go
@@ -132,11 +132,13 @@ func TestMain(m *testing.M) {
 	}
 
 	// run tests
-	m.Run()
+	exitCode := m.Run()
 
 	// stop the HTTP server
 	stop()
 	<-done
+
+	os.Exit(exitCode)
 }
 
 func TestPostgresqlNoConnection(t *testing.T) {
@@ -260,7 +262,9 @@ func (ps *postgresqlSuite) setupPostgresContainer() error {
 		return fmt.Errorf("error pulling docker image: %w", err)
 	}
 	defer imagePullResp.Close()
-	io.Copy(os.Stdout, imagePullResp)
+	if _, err := io.Copy(os.Stdout, imagePullResp); err != nil {
+		return fmt.Errorf("error copying image pull response: %w", err)
+	}
 
 	ports := nat.PortSet{"5432": {}}
 	pgEnv := []string{"POSTGRES_PASSWORD=password", "POSTGRES_DB=data"}

--- a/models/legacymodels/legacymodels_test.go
+++ b/models/legacymodels/legacymodels_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"hmruntime/manifestdata"
@@ -46,7 +47,7 @@ func TestMain(m *testing.M) {
 		},
 	})
 
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func TestPostExternalModelEndpoint(t *testing.T) {

--- a/models/legacymodels/textgeneration.go
+++ b/models/legacymodels/textgeneration.go
@@ -46,7 +46,7 @@ func InvokeTextGenerator(ctx context.Context, modelName string, format string, i
 	}
 
 	if result.Error.Message != "" {
-		err := fmt.Errorf(result.Error.Message)
+		err := fmt.Errorf("error received: %s", result.Error.Message)
 		return "", err
 	}
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"hmruntime/manifestdata"
@@ -39,7 +40,7 @@ func TestMain(m *testing.M) {
 		},
 	})
 
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func TestGetModels(t *testing.T) {

--- a/pluginmanager/loader.go
+++ b/pluginmanager/loader.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
-func MonitorPlugins(ctx context.Context) {
+func monitorPlugins(ctx context.Context) {
 	loadPluginFile := func(fi storage.FileInfo) error {
 		err := loadPlugin(ctx, fi.Name)
 		if err != nil {

--- a/pluginmanager/pluginmanager.go
+++ b/pluginmanager/pluginmanager.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package pluginmanager
+
+import (
+	"context"
+
+	"hmruntime/logger"
+	"hmruntime/plugins"
+
+	"github.com/rs/zerolog"
+)
+
+func Initialize(ctx context.Context) {
+	configureLogger()
+	monitorPlugins(ctx)
+}
+
+func configureLogger() {
+	logger.AddAdapter(func(ctx context.Context, lc zerolog.Context) zerolog.Context {
+
+		if plugin := plugins.GetPlugin(ctx); plugin != nil {
+			if buildId := plugin.BuildId(); buildId != "" {
+				lc = lc.Str("build_id", buildId)
+			}
+
+			if pluginName := plugin.Name(); pluginName != "" {
+				lc = lc.Str("plugin", pluginName)
+			}
+		}
+
+		return lc
+	})
+}

--- a/services/services.go
+++ b/services/services.go
@@ -41,7 +41,7 @@ func Start(ctx context.Context) {
 	db.Initialize(ctx)
 	collections.InitializeIndexFactory(ctx)
 	manifestdata.MonitorManifestFile(ctx)
-	pluginmanager.MonitorPlugins(ctx)
+	pluginmanager.Initialize(ctx)
 	graphql.Initialize()
 }
 

--- a/wasmhost/initialization.go
+++ b/wasmhost/initialization.go
@@ -7,8 +7,10 @@ package wasmhost
 import (
 	"context"
 
+	"hmruntime/logger"
 	"hmruntime/utils"
 
+	"github.com/rs/zerolog"
 	"github.com/tetratelabs/wazero"
 )
 
@@ -16,7 +18,19 @@ func InitWasmHost(ctx context.Context) {
 	span := utils.NewSentrySpanForCurrentFunc(ctx)
 	defer span.Finish()
 
+	configureLogger()
+
 	cfg := wazero.NewRuntimeConfig()
 	cfg = cfg.WithCloseOnContextDone(true)
 	RuntimeInstance = wazero.NewRuntimeWithConfig(ctx, cfg)
+}
+
+func configureLogger() {
+	logger.AddAdapter(func(ctx context.Context, lc zerolog.Context) zerolog.Context {
+		if executionId, ok := ctx.Value(utils.ExecutionIdContextKey).(string); ok {
+			lc = lc.Str("execution_id", executionId)
+		}
+
+		return lc
+	})
 }


### PR DESCRIPTION
This is a bit of refactoring, using IoC to reduce the dependency graph.  It allows logger to be used from various places where it would currently create an import cycle.

Includes some unrelated linter fixes, due to `golangci-lint` updates.