### PR TITLE
Support objects as parameters to functions via GraphQL input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Major refactoring to support multiple guest languages [#347](https://github.com/hypermodeAI/runtime/pull/347)
 - Rename `hmruntime` to `hypruntime` [#348](https://github.com/hypermodeAI/runtime/pull/348)
 - Make empty dgraph responses nil [#355](https://github.com/hypermodeAI/runtime/pull/355)
+- Support objects as parameters to functions via GraphQL input types [#359](https://github.com/hypermodeAI/runtime/pull/359)
 
 ## 2024-08-27 - Version 0.11.2
 

--- a/graphql/schemagen/schemagen_test.go
+++ b/graphql/schemagen/schemagen_test.go
@@ -6,6 +6,8 @@ package schemagen
 
 import (
 	"context"
+	"regexp"
+	"strings"
 	"testing"
 
 	"hypruntime/languages"
@@ -82,6 +84,9 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 	md.FnExports.AddFunction("getPeople").
 		WithResult("~lib/array/Array<assembly/test/Person>")
 
+	md.FnExports.AddFunction("addPerson").
+		WithParameter("person", "assembly/test/Person")
+
 	md.FnExports.AddFunction("getProductMap").
 		WithResult("~lib/map/Map<~lib/string/String,assembly/test/Product>")
 
@@ -91,6 +96,42 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 	md.FnExports.AddFunction("myEmbedder").
 		WithParameter("text", "~lib/string/String").
 		WithResult("~lib/array/Array<f64>")
+
+	// Generated input object from the output object
+	md.FnExports.AddFunction("testObj1").
+		WithParameter("obj", "assembly/test/Obj1").
+		WithResult("assembly/test/Obj1")
+	md.Types.AddType("assembly/test/Obj1").
+		WithField("id", "i32").
+		WithField("name", "~lib/string/String")
+
+	// Separate input and output objects defined
+	md.FnExports.AddFunction("testObj2").
+		WithParameter("obj", "assembly/test/Obj2Input").
+		WithResult("assembly/test/Obj2")
+	md.Types.AddType("assembly/test/Obj2").
+		WithField("id", "i32").
+		WithField("name", "~lib/string/String")
+	md.Types.AddType("assembly/test/Obj2Input").
+		WithField("name", "~lib/string/String")
+
+	// Generated input object without output object
+	md.FnExports.AddFunction("testObj3").
+		WithParameter("obj", "assembly/test/Obj3")
+	md.Types.AddType("assembly/test/Obj3").
+		WithField("name", "~lib/string/String")
+
+	// Single input object defined without output object
+	md.FnExports.AddFunction("testObj4").
+		WithParameter("obj", "assembly/test/Obj4Input")
+	md.Types.AddType("assembly/test/Obj4Input").
+		WithField("name", "~lib/string/String")
+
+	md.Types.AddType("~lib/array/Array<i32>")
+	md.Types.AddType("~lib/array/Array<f64>")
+	md.Types.AddType("~lib/array/Array<assembly/test/Person>")
+	md.Types.AddType("~lib/map/Map<~lib/string/String,~lib/string/String>")
+	md.Types.AddType("~lib/map/Map<~lib/string/String,assembly/test/Product>")
 
 	md.Types.AddType("assembly/test/Company").
 		WithField("name", "~lib/string/String")
@@ -105,8 +146,6 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 		WithField("name", "~lib/string/String").
 		WithField("age", "i32").
 		WithField("addresses", "~lib/array/Array<assembly/test/Address>")
-
-	md.Types.AddType("~lib/array/Array<assembly/test/Person>")
 
 	md.Types.AddType("assembly/test/Address").
 		WithField("street", "~lib/string/String").
@@ -127,11 +166,14 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 
 	result, err := GetGraphQLSchema(context.Background(), md)
 
+	t.Log(result.Schema)
+
 	expectedSchema := `
 # Hypermode GraphQL Schema (auto-generated)
 
 type Query {
   add(a: Int!, b: Int!): Int!
+  addPerson(person: PersonInput!): Void
   currentTime: Timestamp!
   doNothing: Void
   getPeople: [Person!]!
@@ -141,11 +183,57 @@ type Query {
   testDefaultArrayParams(a: [Int!]!, b: [Int!]! = [], c: [Int!]! = [1,2,3], d: [Int!], e: [Int!] = null, f: [Int!] = [], g: [Int!] = [1,2,3]): Void
   testDefaultIntParams(a: Int!, b: Int! = 0, c: Int! = 1): Void
   testDefaultStringParams(a: String!, b: String! = "", c: String! = "a\"b", d: String, e: String = null, f: String = "", g: String = "test"): Void
-  transform(items: [StringStringPair!]!): [StringStringPair!]!
+  testObj1(obj: Obj1Input!): Obj1!
+  testObj2(obj: Obj2Input!): Obj2!
+  testObj3(obj: Obj3Input!): Void
+  testObj4(obj: Obj4Input!): Void
+  transform(items: [StringStringPairInput!]!): [StringStringPair!]!
 }
 
 scalar Timestamp
 scalar Void
+
+input AddressInput {
+  street: String!
+  city: String!
+  state: String!
+  country: String!
+  postalCode: String!
+  location: CoordinatesInput!
+}
+
+input CoordinatesInput {
+  lat: Float!
+  lon: Float!
+}
+
+input Obj1Input {
+  id: Int!
+  name: String!
+}
+
+input Obj2Input {
+  name: String!
+}
+
+input Obj3Input {
+  name: String!
+}
+
+input Obj4Input {
+  name: String!
+}
+
+input PersonInput {
+  name: String!
+  age: Int!
+  addresses: [AddressInput!]!
+}
+
+input StringStringPairInput {
+  key: String!
+  value: String!
+}
 
 type Address {
   street: String!
@@ -163,6 +251,16 @@ type Company {
 type Coordinates {
   lat: Float!
   lon: Float!
+}
+
+type Obj1 {
+  id: Int!
+  name: String!
+}
+
+type Obj2 {
+  id: Int!
+  name: String!
 }
 
 type Person {
@@ -198,35 +296,52 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 	lti := languages.AssemblyScript().TypeInfo()
 
 	testCases := []struct {
-		inputType          string
-		expectedOutputType string
-		inputTypeDefs      []*metadata.TypeDefinition
-		expectedTypeDefs   []*TypeDefinition
+		sourceType          string
+		forInput            bool
+		expectedGraphQLType string
+		sourceTypeDefs      []*metadata.TypeDefinition
+		expectedTypeDefs    []*TypeDefinition
 	}{
 		// Plain non-nullable types
-		{"~lib/string/String", "String!", nil, nil},
-		{"bool", "Boolean!", nil, nil},
-		{"i32", "Int!", nil, nil},
-		{"i16", "Int!", nil, nil},
-		{"i8", "Int!", nil, nil},
-		{"u16", "Int!", nil, nil},
-		{"u8", "Int!", nil, nil},
-		{"f64", "Float!", nil, nil},
-		{"f32", "Float!", nil, nil},
+		{"~lib/string/String", false, "String!", nil, nil},
+		{"~lib/string/String", true, "String!", nil, nil},
+		{"bool", false, "Boolean!", nil, nil},
+		{"bool", true, "Boolean!", nil, nil},
+		{"i8", false, "Int!", nil, nil},
+		{"i8", true, "Int!", nil, nil},
+		{"i16", false, "Int!", nil, nil},
+		{"i16", true, "Int!", nil, nil},
+		{"i32", false, "Int!", nil, nil},
+		{"i32", true, "Int!", nil, nil},
+		{"u8", false, "Int!", nil, nil},
+		{"u8", true, "Int!", nil, nil},
+		{"u16", false, "Int!", nil, nil},
+		{"u16", true, "Int!", nil, nil},
+		{"f32", false, "Float!", nil, nil},
+		{"f32", true, "Float!", nil, nil},
+		{"f64", false, "Float!", nil, nil},
+		{"f64", true, "Float!", nil, nil},
 
 		// Array types
-		{"~lib/array/Array<~lib/string/String>", "[String!]!", nil, nil},
-		{"~lib/array/Array<~lib/array/Array<~lib/string/String>>", "[[String!]!]!", nil, nil},
-		{"~lib/array/Array<~lib/string/String|null>", "[String]!", nil, nil},
+		{"~lib/array/Array<~lib/string/String>", false, "[String!]!", nil, nil},
+		{"~lib/array/Array<~lib/string/String>", true, "[String!]!", nil, nil},
+		{"~lib/array/Array<~lib/array/Array<~lib/string/String>>", false, "[[String!]!]!", nil, nil},
+		{"~lib/array/Array<~lib/array/Array<~lib/string/String>>", true, "[[String!]!]!", nil, nil},
+		{"~lib/array/Array<~lib/string/String|null>", false, "[String]!", nil, nil},
+		{"~lib/array/Array<~lib/string/String|null>", true, "[String]!", nil, nil},
 
 		// Custom scalar types
-		{"~lib/date/Date", "Timestamp!", nil, []*TypeDefinition{{Name: "Timestamp"}}},
-		{"i64", "Int64!", nil, []*TypeDefinition{{Name: "Int64"}}},
-		{"u32", "UInt!", nil, []*TypeDefinition{{Name: "UInt"}}},
-		{"u64", "UInt64!", nil, []*TypeDefinition{{Name: "UInt64"}}},
+		{"~lib/date/Date", false, "Timestamp!", nil, []*TypeDefinition{{Name: "Timestamp"}}},
+		{"~lib/date/Date", true, "Timestamp!", nil, []*TypeDefinition{{Name: "Timestamp"}}},
+		{"i64", false, "Int64!", nil, []*TypeDefinition{{Name: "Int64"}}},
+		{"i64", true, "Int64!", nil, []*TypeDefinition{{Name: "Int64"}}},
+		{"u32", false, "UInt!", nil, []*TypeDefinition{{Name: "UInt"}}},
+		{"u32", true, "UInt!", nil, []*TypeDefinition{{Name: "UInt"}}},
+		{"u64", false, "UInt64!", nil, []*TypeDefinition{{Name: "UInt64"}}},
+		{"u64", true, "UInt64!", nil, []*TypeDefinition{{Name: "UInt64"}}},
 
 		// Custom types
-		{"assembly/test/User", "User!",
+		{"assembly/test/User", false, "User!",
 			[]*metadata.TypeDefinition{{
 				Name: "User",
 				Fields: []*metadata.Field{
@@ -243,16 +358,37 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 					{"age", "Int!"},
 				},
 			}}},
+		{"assembly/test/User", true, "UserInput!",
+			[]*metadata.TypeDefinition{{
+				Name: "User",
+				Fields: []*metadata.Field{
+					{Name: "firstName", Type: "~lib/string/String"},
+					{Name: "lastName", Type: "~lib/string/String"},
+					{Name: "age", Type: "u8"},
+				},
+			}},
+			[]*TypeDefinition{{
+				Name: "UserInput",
+				Fields: []*NameTypePair{
+					{"firstName", "String!"},
+					{"lastName", "String!"},
+					{"age", "Int!"},
+				},
+			}}},
 
 		// bool and numeric types can't be nullable in AssemblyScript
 		// but string and custom types can
-		{"~lib/string/String | null", "String", nil, nil},
-		{"assembly/test/Foo | null", "Foo",
+		{"~lib/string/String | null", false, "String", nil, nil},
+		{"~lib/string/String | null", true, "String", nil, nil},
+		{"assembly/test/Foo | null", false, "Foo", // scalar
+			[]*metadata.TypeDefinition{{Name: "assembly/test/Foo"}},
+			[]*TypeDefinition{{Name: "Foo"}}},
+		{"assembly/test/Foo | null", true, "Foo", // scalar
 			[]*metadata.TypeDefinition{{Name: "assembly/test/Foo"}},
 			[]*TypeDefinition{{Name: "Foo"}}},
 
 		// Map types
-		{"~lib/map/Map<~lib/string/String,~lib/string/String>", "[StringStringPair!]!", nil, []*TypeDefinition{{
+		{"~lib/map/Map<~lib/string/String,~lib/string/String>", false, "[StringStringPair!]!", nil, []*TypeDefinition{{
 			Name: "StringStringPair",
 			Fields: []*NameTypePair{
 				{"key", "String!"},
@@ -260,7 +396,15 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 			},
 			IsMapType: true,
 		}}},
-		{"~lib/map/Map<~lib/string/String,~lib/string/String|null>", "[StringNullableStringPair!]!", nil, []*TypeDefinition{{
+		{"~lib/map/Map<~lib/string/String,~lib/string/String>", true, "[StringStringPairInput!]!", nil, []*TypeDefinition{{
+			Name: "StringStringPairInput",
+			Fields: []*NameTypePair{
+				{"key", "String!"},
+				{"value", "String!"},
+			},
+			IsMapType: true,
+		}}},
+		{"~lib/map/Map<~lib/string/String,~lib/string/String|null>", false, "[StringNullableStringPair!]!", nil, []*TypeDefinition{{
 			Name: "StringNullableStringPair",
 			Fields: []*NameTypePair{
 				{"key", "String!"},
@@ -268,7 +412,15 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 			},
 			IsMapType: true,
 		}}},
-		{"~lib/map/Map<i32,~lib/string/String>", "[IntStringPair!]!", nil, []*TypeDefinition{{
+		{"~lib/map/Map<~lib/string/String,~lib/string/String|null>", true, "[StringNullableStringPairInput!]!", nil, []*TypeDefinition{{
+			Name: "StringNullableStringPairInput",
+			Fields: []*NameTypePair{
+				{"key", "String!"},
+				{"value", "String"},
+			},
+			IsMapType: true,
+		}}},
+		{"~lib/map/Map<i32,~lib/string/String>", false, "[IntStringPair!]!", nil, []*TypeDefinition{{
 			Name: "IntStringPair",
 			Fields: []*NameTypePair{
 				{"key", "Int!"},
@@ -276,7 +428,15 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 			},
 			IsMapType: true,
 		}}},
-		{"~lib/map/Map<~lib/string/String,~lib/map/Map<~lib/string/String,f32>>", "[StringStringFloatPairListPair!]!", nil, []*TypeDefinition{
+		{"~lib/map/Map<i32,~lib/string/String>", true, "[IntStringPairInput!]!", nil, []*TypeDefinition{{
+			Name: "IntStringPairInput",
+			Fields: []*NameTypePair{
+				{"key", "Int!"},
+				{"value", "String!"},
+			},
+			IsMapType: true,
+		}}},
+		{"~lib/map/Map<~lib/string/String,~lib/map/Map<~lib/string/String,f32>>", false, "[StringStringFloatPairListPair!]!", nil, []*TypeDefinition{
 			{
 				Name: "StringStringFloatPairListPair",
 				Fields: []*NameTypePair{
@@ -294,23 +454,47 @@ func Test_ConvertType_AssemblyScript(t *testing.T) {
 				IsMapType: true,
 			},
 		}},
+		{"~lib/map/Map<~lib/string/String,~lib/map/Map<~lib/string/String,f32>>", true, "[StringStringFloatPairListPairInput!]!", nil, []*TypeDefinition{
+			{
+				Name: "StringStringFloatPairListPairInput",
+				Fields: []*NameTypePair{
+					{"key", "String!"},
+					{"value", "[StringFloatPairInput!]!"},
+				},
+				IsMapType: true,
+			},
+			{
+				Name: "StringFloatPairInput",
+				Fields: []*NameTypePair{
+					{"key", "String!"},
+					{"value", "Float!"},
+				},
+				IsMapType: true,
+			},
+		}},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.inputType, func(t *testing.T) {
+	nameRegex := regexp.MustCompile(`(?:[~\w]+/)+?`)
 
-			inputTypes := make(metadata.TypeMap, len(tc.inputTypeDefs))
-			for _, td := range tc.inputTypeDefs {
-				inputTypes[td.Name] = td
+	for _, tc := range testCases {
+		testName := strings.ReplaceAll(nameRegex.ReplaceAllString(tc.sourceType, ""), " ", "")
+		if tc.forInput {
+			testName += "_input"
+		}
+		t.Run(testName, func(t *testing.T) {
+
+			types := make(metadata.TypeMap, len(tc.sourceTypeDefs))
+			for _, td := range tc.sourceTypeDefs {
+				types[td.Name] = td
 			}
 
-			typeDefs, errors := transformTypes(inputTypes, lti)
+			typeDefs, errors := transformTypes(types, lti, tc.forInput)
 			require.Empty(t, errors)
 
-			result, err := convertType(tc.inputType, lti, typeDefs, false)
+			result, err := convertType(tc.sourceType, lti, typeDefs, false, tc.forInput)
 
 			require.Nil(t, err)
-			require.Equal(t, tc.expectedOutputType, result)
+			require.Equal(t, tc.expectedGraphQLType, result)
 
 			if tc.expectedTypeDefs == nil {
 				require.Empty(t, typeDefs)


### PR DESCRIPTION
Adds ability to pass objects in function parameters.

There are two supported patterns.

- Single object type

```ts
class Foo {
  // ...
}

export function doSomething(x: Foo): Foo {
  // ...
}
```

- Split object types

```ts
class Foo {
  // ...
}

class FooInput {
  // ...
}

export function doSomething(x: FooInput): Foo {
  // ...
}
```

In both cases, the generated schema will be as follows:

```graphql
type Query {
  doSomething(x: FooInput!): Foo!
}

input FooInput {
   ...
}

type Foo {
  ...
}
```

The difference between the two patterns is that one allows the user to use the same type for input and output, and the other allows the user to create input/output types that differ.  (For example, an input type might omit an ID field.)

## IMPORTANT

The suffix `"Input"` is now a naming convention that all types must adhere to.  In other words, we don't support naming _output_ types with a suffix of `"Input"`. 

## CAVEAT

I uncovered a bug in the GraphQL Go Tools library while working on this.  When querying, if you don't supply a required field on an input object, it _should_ give a validation error, but instead the request goes through and can either pass or fail depending on the type of parameters.

Reported upstream to https://github.com/wundergraph/graphql-go-tools/issues/885.  We'll take that fix via an update when it's ready.