### PR TITLE
Fix error when using a map as an input parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Fix panic from Go maps with primitive types [#370](https://github.com/hypermodeAI/runtime/pull/370)
+- Fix error when using a map as an input parameter [#373](https://github.com/hypermodeAI/runtime/pull/373)
 
 ## 2024-09-16 - Version 0.12.0
 

--- a/languages/assemblyscript/handler_objects.go
+++ b/languages/assemblyscript/handler_objects.go
@@ -174,6 +174,10 @@ func (h *managedObjectHandler) doWrite(ctx context.Context, wa langsupport.WasmA
 		}
 	}
 
+	if h.nullable {
+		obj = utils.DereferencePointer(obj)
+	}
+
 	id := h.typeDef.Id
 	size := h.innerHandler.Info().TypeSize()
 

--- a/utils/pointers.go
+++ b/utils/pointers.go
@@ -46,11 +46,20 @@ func DereferencePointer(obj any) any {
 		return *t
 	case *time.Duration:
 		return *t
+	case *map[string]string:
+		return *t
+	case *map[string]any:
+		return *t
+	case *map[string]map[string]any:
+		return *t
+	case *map[string]*map[string]any:
+		return *t
 	case string, bool,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64, uintptr,
 		float32, float64,
-		time.Time, time.Duration:
+		time.Time, time.Duration,
+		map[string]string, map[string]any, map[string]map[string]any, map[string]*map[string]any:
 		return t // already dereferenced
 	}
 


### PR DESCRIPTION
Fixes `"input is not a map"` or `"unsupported map type []interface {}"` errors when using a map as an input parameter to a function.

Also improves the map handler, and nullable managed object handling for AssemblyScript.