### PR TITLE
Improve execution plan creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix missing GraphQL type schema [#376](https://github.com/hypermodeAI/runtime/pull/376)
 - Add FunctionExecutionDurationMillisecondsSummary metric [#377](https://github.com/hypermodeAI/runtime/pull/377)
 - Fix field alignment issue [#378](https://github.com/hypermodeAI/runtime/pull/378)
+- Improve execution plan creation [#379](https://github.com/hypermodeAI/runtime/pull/379)
 
 ## 2024-09-18 - Version 0.12.1
 

--- a/graphql/schemagen/schemagen.go
+++ b/graphql/schemagen/schemagen.go
@@ -69,7 +69,7 @@ func (e *TransformError) String() string {
 	return fmt.Sprintf("source: %+v, error: %v", e.Source, e.Error)
 }
 
-func transformTypes(types metadata.TypeMap, lti langsupport.TypeInfo, forInput bool) (map[string]*TypeDefinition, []*TransformError) {
+func transformTypes(types metadata.TypeMap, lti langsupport.LanguageTypeInfo, forInput bool) (map[string]*TypeDefinition, []*TransformError) {
 	typeDefs := make(map[string]*TypeDefinition, len(types))
 	errors := make([]*TransformError, 0)
 	for _, t := range types {
@@ -132,7 +132,7 @@ type ParameterSignature struct {
 	Default *any
 }
 
-func transformFunctions(functions metadata.FunctionMap, inputTypeDefs, resultTypeDefs map[string]*TypeDefinition, lti langsupport.TypeInfo) ([]*FunctionSignature, []*TransformError) {
+func transformFunctions(functions metadata.FunctionMap, inputTypeDefs, resultTypeDefs map[string]*TypeDefinition, lti langsupport.LanguageTypeInfo) ([]*FunctionSignature, []*TransformError) {
 	output := make([]*FunctionSignature, len(functions))
 	errors := make([]*TransformError, 0)
 
@@ -348,7 +348,7 @@ func writeSchema(buf *bytes.Buffer, functions []*FunctionSignature, scalarTypes 
 	buf.WriteByte('\n')
 }
 
-func convertParameters(parameters []*metadata.Parameter, lti langsupport.TypeInfo, typeDefs map[string]*TypeDefinition) ([]*ParameterSignature, error) {
+func convertParameters(parameters []*metadata.Parameter, lti langsupport.LanguageTypeInfo, typeDefs map[string]*TypeDefinition) ([]*ParameterSignature, error) {
 	if len(parameters) == 0 {
 		return nil, nil
 	}
@@ -379,7 +379,7 @@ func convertParameters(parameters []*metadata.Parameter, lti langsupport.TypeInf
 	return output, nil
 }
 
-func convertResults(results []*metadata.Result, lti langsupport.TypeInfo, typeDefs map[string]*TypeDefinition) (string, error) {
+func convertResults(results []*metadata.Result, lti langsupport.LanguageTypeInfo, typeDefs map[string]*TypeDefinition) (string, error) {
 	switch len(results) {
 	case 0:
 		return newScalar("Void", typeDefs), nil
@@ -442,7 +442,7 @@ func getTypeForFields(fields []*NameTypePair, typeDefs map[string]*TypeDefinitio
 	return newType(name, fields, typeDefs)
 }
 
-func convertFields(fields []*metadata.Field, lti langsupport.TypeInfo, typeDefs map[string]*TypeDefinition, forInput bool) ([]*NameTypePair, error) {
+func convertFields(fields []*metadata.Field, lti langsupport.LanguageTypeInfo, typeDefs map[string]*TypeDefinition, forInput bool) ([]*NameTypePair, error) {
 	if len(fields) == 0 {
 		return nil, nil
 	}
@@ -461,7 +461,7 @@ func convertFields(fields []*metadata.Field, lti langsupport.TypeInfo, typeDefs 
 	return results, nil
 }
 
-func convertType(typ string, lti langsupport.TypeInfo, typeDefs map[string]*TypeDefinition, firstPass, forInput bool) (string, error) {
+func convertType(typ string, lti langsupport.LanguageTypeInfo, typeDefs map[string]*TypeDefinition, firstPass, forInput bool) (string, error) {
 
 	// Unwrap parentheses if present
 	if strings.HasPrefix(typ, "(") && strings.HasSuffix(typ, ")") {
@@ -472,12 +472,12 @@ func convertType(typ string, lti langsupport.TypeInfo, typeDefs map[string]*Type
 	// In GraphQL, types are nullable by default,
 	// and non-nullable types are indicated by a "!" suffix
 	var n string
-	if !lti.IsNullable(typ) {
+	if !lti.IsNullableType(typ) {
 		n = "!"
 	}
 
 	// unwrap nullable types (and dereference pointers)
-	for lti.IsNullable(typ) {
+	for lti.IsNullableType(typ) {
 		t := lti.GetUnderlyingType(typ)
 		if t == typ {
 			break

--- a/langsupport/executionplan.go
+++ b/langsupport/executionplan.go
@@ -190,7 +190,7 @@ func (plan *executionPlan) interpretWasmResults(ctx context.Context, wa WasmAdap
 			return handler.Decode(ctx, wa, vals)
 		} else {
 			// no actual result value, but we need to return a zero value of the expected type
-			return handler.Info().ZeroValue(), nil
+			return handler.TypeInfo().ZeroValue(), nil
 		}
 	}
 
@@ -207,10 +207,10 @@ func (plan *executionPlan) readIndirectResults(ctx context.Context, wa WasmAdapt
 
 	fieldOffset := uint32(0)
 	for i, handler := range handlers {
-		size := handler.Info().TypeSize()
+		size := handler.TypeInfo().Size()
 
-		fieldType := handler.Info().TypeName()
-		alignment, err := wa.TypeInfo().GetAlignOfType(ctx, fieldType)
+		fieldType := handler.TypeInfo().Name()
+		alignment, err := wa.TypeInfo().GetAlignmentOfType(ctx, fieldType)
 		if err != nil {
 			return nil, err
 		}

--- a/langsupport/langtypeinfo.go
+++ b/langsupport/langtypeinfo.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Hypermode, Inc.
+ */
+
+package langsupport
+
+import (
+	"context"
+	"reflect"
+)
+
+type LanguageTypeInfo interface {
+	GetReflectedType(ctx context.Context, typ string) (reflect.Type, error)
+	GetSizeOfType(ctx context.Context, typ string) (uint32, error)
+	GetAlignmentOfType(ctx context.Context, typ string) (uint32, error)
+	GetDataSizeOfType(ctx context.Context, typ string) (uint32, error)
+	GetEncodingLengthOfType(ctx context.Context, typ string) (uint32, error)
+
+	GetListSubtype(typ string) string
+	GetMapSubtypes(typ string) (string, string)
+	GetNameForType(typ string) string
+	GetUnderlyingType(typ string) string
+
+	IsBooleanType(typ string) bool
+	IsByteSequenceType(typ string) bool
+	IsFloatType(typ string) bool
+	IsIntegerType(typ string) bool
+	IsListType(typ string) bool
+	IsMapType(typ string) bool
+	IsObjectType(typ string) bool
+	IsNullableType(typ string) bool
+	IsPointerType(typ string) bool
+	IsPrimitiveType(typ string) bool
+	IsSignedIntegerType(typ string) bool
+	IsStringType(typ string) bool
+	IsTimestampType(typ string) bool
+}

--- a/langsupport/language.go
+++ b/langsupport/language.go
@@ -12,18 +12,18 @@ import (
 
 type Language interface {
 	Name() string
-	TypeInfo() TypeInfo
+	TypeInfo() LanguageTypeInfo
 	NewPlanner(md *metadata.Metadata) Planner
 	NewWasmAdapter(mod wasm.Module) WasmAdapter
 }
 
-func NewLanguage(name string, typeInfo TypeInfo, plannerFactory func(*metadata.Metadata) Planner, waFactory func(wasm.Module) WasmAdapter) Language {
+func NewLanguage(name string, typeInfo LanguageTypeInfo, plannerFactory func(*metadata.Metadata) Planner, waFactory func(wasm.Module) WasmAdapter) Language {
 	return &language{name, typeInfo, plannerFactory, waFactory}
 }
 
 type language struct {
 	name           string
-	typeInfo       TypeInfo
+	typeInfo       LanguageTypeInfo
 	plannerFactory func(*metadata.Metadata) Planner
 	waFactory      func(wasm.Module) WasmAdapter
 }
@@ -32,7 +32,7 @@ func (l *language) Name() string {
 	return l.name
 }
 
-func (l *language) TypeInfo() TypeInfo {
+func (l *language) TypeInfo() LanguageTypeInfo {
 	return l.typeInfo
 }
 

--- a/langsupport/typehandler.go
+++ b/langsupport/typehandler.go
@@ -6,65 +6,14 @@ package langsupport
 
 import (
 	"context"
-	"reflect"
 
 	"hypruntime/utils"
 )
 
 type TypeHandler interface {
-	Info() TypeHandlerInfo
+	TypeInfo() TypeInfo
 	Read(ctx context.Context, wa WasmAdapter, offset uint32) (any, error)
 	Write(ctx context.Context, wa WasmAdapter, offset uint32, obj any) (utils.Cleaner, error)
 	Decode(ctx context.Context, wa WasmAdapter, vals []uint64) (any, error)
 	Encode(ctx context.Context, wa WasmAdapter, obj any) ([]uint64, utils.Cleaner, error)
-}
-
-type TypeHandlerInfo interface {
-	TypeName() string
-	TypeSize() uint32
-	EncodingLength() int
-	RuntimeType() reflect.Type
-	ZeroValue() any
-}
-
-func NewTypeHandlerInfo(typeName string, runtimeType reflect.Type, typeSize uint32, encodingLen int) TypeHandlerInfo {
-	zeroValue := reflect.Zero(runtimeType).Interface()
-	return &handlerInfo{typeName, runtimeType, zeroValue, typeSize, encodingLen, nil}
-}
-
-type handlerInfo struct {
-	typeName      string
-	runtimeType   reflect.Type
-	zeroValue     any
-	typeSize      uint32
-	encodingLen   int
-	innerHandlers []TypeHandler
-}
-
-func (h *handlerInfo) TypeName() string {
-	return h.typeName
-}
-
-func (h *handlerInfo) RuntimeType() reflect.Type {
-	return h.runtimeType
-}
-
-func (h *handlerInfo) ZeroValue() any {
-	return h.zeroValue
-}
-
-func (h *handlerInfo) TypeSize() uint32 {
-	return h.typeSize
-}
-
-func (h *handlerInfo) EncodingLength() int {
-	return h.encodingLen
-}
-
-func (h *handlerInfo) InnerHandlers() []TypeHandler {
-	return h.innerHandlers
-}
-
-func (h *handlerInfo) AddHandler(handler TypeHandler) {
-	h.innerHandlers = append(h.innerHandlers, handler)
 }

--- a/langsupport/typeinfo.go
+++ b/langsupport/typeinfo.go
@@ -4,23 +4,293 @@
 
 package langsupport
 
-import "context"
+import (
+	"context"
+	"reflect"
+
+	"hypruntime/plugins/metadata"
+)
 
 type TypeInfo interface {
-	GetListSubtype(typ string) string
-	GetMapSubtypes(typ string) (string, string)
-	GetNameForType(typ string) string
-	GetSizeOfType(ctx context.Context, typ string) (uint32, error)
-	GetAlignOfType(ctx context.Context, typ string) (uint32, error)
-	GetUnderlyingType(typ string) string
-	IsListType(typ string) bool
-	IsBooleanType(typ string) bool
-	IsByteSequenceType(v string) bool
-	IsFloatType(typ string) bool
-	IsIntegerType(typ string) bool
-	IsMapType(typ string) bool
-	IsNullable(typ string) bool
-	IsSignedIntegerType(typ string) bool
-	IsStringType(typ string) bool
-	IsTimestampType(typ string) bool
+	Name() string
+	ReflectedType() reflect.Type
+	ZeroValue() any
+	Size() uint32
+	Alignment() uint32
+	DataSize() uint32
+	EncodingLength() uint32
+
+	UnderlyingType() TypeInfo
+	ListElementType() TypeInfo
+	MapKeyType() TypeInfo
+	MapValueType() TypeInfo
+	ObjectFieldTypes() []TypeInfo
+	ObjectFieldOffsets() []uint32
+
+	IsBoolean() bool
+	IsByteSequence() bool
+	IsFloat() bool
+	IsInteger() bool
+	IsList() bool
+	IsMap() bool
+	IsNullable() bool
+	IsObject() bool
+	IsPointer() bool
+	IsPrimitive() bool
+	IsSignedInteger() bool
+	IsString() bool
+	IsTimestamp() bool
+}
+
+func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typeCache map[string]TypeInfo) (TypeInfo, error) {
+	if t, ok := typeCache[typeName]; ok {
+		return t, nil
+	}
+
+	info := &typeInfo{name: typeName}
+	typeCache[typeName] = info
+
+	flags := typeFlags(0)
+
+	if lti.IsPrimitiveType(typeName) {
+		flags |= tfPrimitive
+		if lti.IsBooleanType(typeName) {
+			flags |= tfBoolean
+		} else if lti.IsFloatType(typeName) {
+			flags |= tfFloat
+		} else if lti.IsIntegerType(typeName) {
+			flags |= tfInteger
+			if lti.IsSignedIntegerType(typeName) {
+				flags |= tfSignedInteger
+			}
+		}
+	}
+
+	if lti.IsPointerType(typeName) {
+		flags |= tfPointer
+		flags |= tfNullable
+
+		underlyingTypeName := lti.GetUnderlyingType(typeName)
+		if underlyingTypeName != typeName {
+			underlyingTypeInfo, err := GetTypeInfo(ctx, lti, underlyingTypeName, typeCache)
+			if err != nil {
+				return nil, err
+			}
+			info.underlyingType = underlyingTypeInfo
+		}
+	} else if lti.IsNullableType(typeName) {
+		flags |= tfNullable
+
+		underlyingTypeName := lti.GetUnderlyingType(typeName)
+		if underlyingTypeName != typeName {
+			underlyingTypeInfo, err := GetTypeInfo(ctx, lti, underlyingTypeName, typeCache)
+			if err != nil {
+				return nil, err
+			}
+			info.underlyingType = underlyingTypeInfo
+
+			// remaining tests are for the underlying (non-null) type
+			typeName = underlyingTypeName
+		}
+	}
+
+	if lti.IsByteSequenceType(typeName) {
+		flags |= tfByteSequence
+	} else if lti.IsStringType(typeName) {
+		flags |= tfString
+	} else if lti.IsTimestampType(typeName) {
+		flags |= tfTimestamp
+	}
+
+	if lti.IsListType(typeName) {
+		flags |= tfList
+		elementTypeName := lti.GetListSubtype(typeName)
+		elementTypeInfo, err := GetTypeInfo(ctx, lti, elementTypeName, typeCache)
+		if err != nil {
+			return nil, err
+		}
+		info.fieldTypes = []TypeInfo{elementTypeInfo}
+	} else if lti.IsMapType(typeName) {
+		flags |= tfMap
+		keyTypeName, keyValueName := lti.GetMapSubtypes(typeName)
+		keyTypeInfo, err := GetTypeInfo(ctx, lti, keyTypeName, typeCache)
+		if err != nil {
+			return nil, err
+		}
+		valueTypeInfo, err := GetTypeInfo(ctx, lti, keyValueName, typeCache)
+		if err != nil {
+			return nil, err
+		}
+		info.fieldTypes = []TypeInfo{keyTypeInfo, valueTypeInfo}
+	} else if lti.IsObjectType(typeName) {
+		flags |= tfObject
+
+		md, err := metadata.GetMetadataFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		def, err := md.GetTypeDefinition(typeName)
+		if err != nil {
+			return nil, err
+		}
+
+		offset := uint32(0)
+		maxAlignment := uint32(0)
+		info.fieldTypes = make([]TypeInfo, len(def.Fields))
+		info.fieldOffsets = make([]uint32, len(def.Fields))
+		for i, field := range def.Fields {
+			fti, err := GetTypeInfo(ctx, lti, field.Type, typeCache)
+			if err != nil {
+				return nil, err
+			}
+			info.fieldTypes[i] = fti
+
+			size := fti.Size()
+			alignment := fti.Alignment()
+			offset = AlignOffset(offset, alignment)
+			info.fieldOffsets[i] = offset
+			offset += size
+
+			if alignment > maxAlignment {
+				maxAlignment = alignment
+			}
+		}
+		info.dataSize = AlignOffset(offset, maxAlignment)
+		info.alignment = maxAlignment
+	}
+
+	info.flags = flags
+
+	reflectedType, err := lti.GetReflectedType(ctx, typeName)
+	if err != nil {
+		return nil, err
+	}
+	info.reflectedType = reflectedType
+	info.zeroValue = reflect.Zero(reflectedType).Interface()
+
+	if info.size == 0 {
+		size, err := lti.GetSizeOfType(ctx, typeName)
+		if err != nil {
+			return nil, err
+		}
+		info.size = size
+	}
+
+	if info.alignment == 0 {
+		alignment, err := lti.GetAlignmentOfType(ctx, typeName)
+		if err != nil {
+			return nil, err
+		}
+		info.alignment = alignment
+	}
+
+	if info.dataSize == 0 {
+		dataSize, err := lti.GetDataSizeOfType(ctx, typeName)
+		if err != nil {
+			return nil, err
+		}
+		info.dataSize = dataSize
+	}
+
+	if info.encodingLength == 0 {
+		encodingLength, err := lti.GetEncodingLengthOfType(ctx, typeName)
+		if err != nil {
+			return nil, err
+		}
+		info.encodingLength = encodingLength
+	}
+
+	return info, nil
+}
+
+type typeFlags uint32
+
+const (
+	_         typeFlags = 0
+	tfBoolean typeFlags = 1 << (iota - 1)
+	tfByteSequence
+	tfFloat
+	tfInteger
+	tfList
+	tfMap
+	tfNullable
+	tfObject
+	tfPointer
+	tfPrimitive
+	tfSignedInteger
+	tfString
+	tfTimestamp
+)
+
+type typeInfo struct {
+	name           string
+	flags          typeFlags
+	reflectedType  reflect.Type
+	zeroValue      any
+	size           uint32
+	alignment      uint32
+	dataSize       uint32
+	encodingLength uint32
+	underlyingType TypeInfo
+	fieldTypes     []TypeInfo
+	fieldOffsets   []uint32
+}
+
+func (h *typeInfo) Name() string                { return h.name }
+func (h *typeInfo) ReflectedType() reflect.Type { return h.reflectedType }
+func (h *typeInfo) ZeroValue() any              { return h.zeroValue }
+func (h *typeInfo) Size() uint32                { return h.size }
+func (h *typeInfo) Alignment() uint32           { return h.alignment }
+func (h *typeInfo) DataSize() uint32            { return h.dataSize }
+func (h *typeInfo) EncodingLength() uint32      { return h.encodingLength }
+
+func (h *typeInfo) IsBoolean() bool       { return h.flags&tfBoolean != 0 }
+func (h *typeInfo) IsByteSequence() bool  { return h.flags&tfByteSequence != 0 }
+func (h *typeInfo) IsFloat() bool         { return h.flags&tfFloat != 0 }
+func (h *typeInfo) IsInteger() bool       { return h.flags&tfInteger != 0 }
+func (h *typeInfo) IsList() bool          { return h.flags&tfList != 0 }
+func (h *typeInfo) IsMap() bool           { return h.flags&tfMap != 0 }
+func (h *typeInfo) IsNullable() bool      { return h.flags&tfNullable != 0 }
+func (h *typeInfo) IsObject() bool        { return h.flags&tfObject != 0 }
+func (h *typeInfo) IsPointer() bool       { return h.flags&tfPointer != 0 }
+func (h *typeInfo) IsPrimitive() bool     { return h.flags&tfPrimitive != 0 }
+func (h *typeInfo) IsSignedInteger() bool { return h.flags&tfSignedInteger != 0 }
+func (h *typeInfo) IsString() bool        { return h.flags&tfString != 0 }
+func (h *typeInfo) IsTimestamp() bool     { return h.flags&tfTimestamp != 0 }
+
+func (h *typeInfo) UnderlyingType() TypeInfo {
+	return h.underlyingType
+}
+
+func (h *typeInfo) ListElementType() TypeInfo {
+	if h.IsList() {
+		return h.fieldTypes[0]
+	}
+	return nil
+}
+
+func (h *typeInfo) MapKeyType() TypeInfo {
+	if h.IsMap() {
+		return h.fieldTypes[0]
+	}
+	return nil
+}
+
+func (h *typeInfo) MapValueType() TypeInfo {
+	if h.IsMap() {
+		return h.fieldTypes[1]
+	}
+	return nil
+}
+
+func (h *typeInfo) ObjectFieldTypes() []TypeInfo {
+	if h.IsObject() {
+		return h.fieldTypes
+	}
+	return nil
+}
+
+func (h *typeInfo) ObjectFieldOffsets() []uint32 {
+	return h.fieldOffsets
 }

--- a/langsupport/wasmadapter.go
+++ b/langsupport/wasmadapter.go
@@ -14,7 +14,7 @@ import (
 )
 
 type WasmAdapter interface {
-	TypeInfo() TypeInfo
+	TypeInfo() LanguageTypeInfo
 	Memory() wasm.Memory
 	AllocateMemory(ctx context.Context, size uint32) (uint32, utils.Cleaner, error)
 	GetFunction(name string) wasm.Function

--- a/languages/assemblyscript/adapter.go
+++ b/languages/assemblyscript/adapter.go
@@ -39,8 +39,8 @@ type wasmAdapter struct {
 	fnSetArgumentsLength wasm.Function
 }
 
-func (*wasmAdapter) TypeInfo() langsupport.TypeInfo {
-	return _typeInfo
+func (*wasmAdapter) TypeInfo() langsupport.LanguageTypeInfo {
+	return _langTypeInfo
 }
 
 func (wa *wasmAdapter) Memory() wasm.Memory {

--- a/languages/assemblyscript/handler_arraybuffers.go
+++ b/languages/assemblyscript/handler_arraybuffers.go
@@ -8,31 +8,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"hypruntime/langsupport"
 	"hypruntime/utils"
 )
 
-func (p *planner) NewArrayBufferHandler(typ string, rt reflect.Type) (langsupport.TypeHandler, error) {
-	handler := NewTypeHandler[arrayBufferHandler](p, typ)
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-	handler.nullable = _typeInfo.IsNullable(typ)
+func (p *planner) NewArrayBufferHandler(ti langsupport.TypeInfo) (langsupport.TypeHandler, error) {
+	handler := &arrayBufferHandler{*NewTypeHandler(ti)}
+	p.AddHandler(handler)
 	return handler, nil
 }
 
 type arrayBufferHandler struct {
-	info     langsupport.TypeHandlerInfo
-	nullable bool
-}
-
-func (h *arrayBufferHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
+	typeHandler
 }
 
 func (h *arrayBufferHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {
 	if offset == 0 {
-		return nil, fmt.Errorf("unexpected address 0 reading managed object of type %s", h.info.TypeName())
+		return nil, fmt.Errorf("unexpected address 0 reading managed object of type %s", h.typeInfo.Name())
 	}
 
 	ptr, ok := wa.Memory().ReadUint32Le(offset)
@@ -75,7 +68,7 @@ func (h *arrayBufferHandler) Encode(ctx context.Context, wa langsupport.WasmAdap
 
 func (h *arrayBufferHandler) doReadBytes(wa langsupport.WasmAdapter, offset uint32) ([]byte, error) {
 	if offset == 0 {
-		if h.nullable {
+		if h.typeInfo.IsNullable() {
 			return nil, nil
 		} else {
 			return nil, errors.New("unexpected null pointer for non-nullable ArrayBuffer")
@@ -105,7 +98,7 @@ func (h *arrayBufferHandler) doReadBytes(wa langsupport.WasmAdapter, offset uint
 
 func (h *arrayBufferHandler) doWriteBytes(ctx context.Context, wa langsupport.WasmAdapter, obj any) (uint32, utils.Cleaner, error) {
 	if utils.HasNil(obj) {
-		if h.nullable {
+		if h.typeInfo.IsNullable() {
 			return 0, nil, nil
 		} else {
 			return 0, nil, errors.New("unexpected nil value for non-nullable ArrayBuffer")

--- a/languages/assemblyscript/handler_classes.go
+++ b/languages/assemblyscript/handler_classes.go
@@ -15,60 +15,36 @@ import (
 	"hypruntime/utils"
 )
 
-func (p *planner) NewClassHandler(ctx context.Context, typ string, rt reflect.Type) (managedTypeHandler, error) {
-	handler := new(classHandler)
+func (p *planner) NewClassHandler(ctx context.Context, ti langsupport.TypeInfo) (managedTypeHandler, error) {
 
-	typ = _typeInfo.GetUnderlyingType(typ)
-	typeDef, err := p.metadata.GetTypeDefinition(typ)
+	handler := &classHandler{
+		typeHandler: *NewTypeHandler(ti),
+	}
+
+	typeDef, err := p.metadata.GetTypeDefinition(ti.Name())
 	if err != nil {
 		return nil, err
 	}
 	handler.typeDef = typeDef
 
-	offset := uint32(0)
-	maxAlignment := uint32(0)
-	fieldHandlers := make([]langsupport.TypeHandler, len(typeDef.Fields))
-	fieldOffsets := make([]uint32, len(typeDef.Fields))
-	for i, field := range typeDef.Fields {
-		fieldHandler, err := p.GetHandler(ctx, field.Type)
+	fieldTypes := ti.ObjectFieldTypes()
+	fieldHandlers := make([]langsupport.TypeHandler, len(fieldTypes))
+	for i, fieldType := range fieldTypes {
+		fieldHandler, err := p.GetHandler(ctx, fieldType.Name())
 		if err != nil {
 			return nil, err
 		}
 		fieldHandlers[i] = fieldHandler
-
-		fieldInfo := fieldHandler.Info()
-		size := fieldInfo.TypeSize()
-		alignment, err := _typeInfo.GetAlignOfType(ctx, field.Type)
-		if err != nil {
-			return nil, err
-		}
-
-		offset = langsupport.AlignOffset(offset, alignment)
-		fieldOffsets[i] = offset
-		offset += size
-
-		if alignment > maxAlignment {
-			maxAlignment = alignment
-		}
 	}
-	classSize := langsupport.AlignOffset(offset, maxAlignment)
 
 	handler.fieldHandlers = fieldHandlers
-	handler.fieldOffsets = fieldOffsets
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, classSize, 0)
-
 	return handler, nil
 }
 
 type classHandler struct {
-	info          langsupport.TypeHandlerInfo
+	typeHandler
 	typeDef       *metadata.TypeDefinition
 	fieldHandlers []langsupport.TypeHandler
-	fieldOffsets  []uint32
-}
-
-func (h *classHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
 }
 
 func (h *classHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {
@@ -76,10 +52,11 @@ func (h *classHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, off
 		return nil, nil
 	}
 
+	fieldOffsets := h.typeInfo.ObjectFieldOffsets()
 	m := make(map[string]any, len(h.fieldHandlers))
 	for i, field := range h.typeDef.Fields {
 		handler := h.fieldHandlers[i]
-		fieldOffset := offset + h.fieldOffsets[i]
+		fieldOffset := offset + fieldOffsets[i]
 		val, err := handler.Read(ctx, wa, fieldOffset)
 		if err != nil {
 			return nil, err
@@ -107,6 +84,7 @@ func (h *classHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 
 	cln := utils.NewCleanerN(len(h.fieldHandlers))
 
+	fieldOffsets := h.typeInfo.ObjectFieldOffsets()
 	for i, field := range h.typeDef.Fields {
 		var fieldObj any
 		if mapObj != nil {
@@ -117,7 +95,7 @@ func (h *classHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 			fieldObj = rvObj.FieldByNameFunc(func(s string) bool { return strings.EqualFold(s, field.Name) }).Interface()
 		}
 
-		fieldOffset := offset + h.fieldOffsets[i]
+		fieldOffset := offset + fieldOffsets[i]
 		handler := h.fieldHandlers[i]
 		c, err := handler.Write(ctx, wa, fieldOffset, fieldObj)
 		cln.AddCleaner(c)
@@ -130,7 +108,7 @@ func (h *classHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 }
 
 func (h *classHandler) getStructOutput(data map[string]any) (any, error) {
-	rt := h.info.RuntimeType()
+	rt := h.typeInfo.ReflectedType()
 	if rt.Kind() == reflect.Map {
 		return data, nil
 	}

--- a/languages/assemblyscript/handler_dates.go
+++ b/languages/assemblyscript/handler_dates.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"hypruntime/langsupport"
@@ -18,27 +17,24 @@ import (
 
 // Reference: https://github.com/AssemblyScript/assemblyscript/blob/main/std/assembly/date.ts
 
-func (p *planner) NewDateHandler(typ string, rt reflect.Type) (managedTypeHandler, error) {
-	handler := new(dateHandler)
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, 20, 0)
+func (p *planner) NewDateHandler(ti langsupport.TypeInfo) (managedTypeHandler, error) {
 
-	typ = _typeInfo.GetUnderlyingType(typ)
-	typeDef, err := p.metadata.GetTypeDefinition(typ)
+	typeDef, err := p.metadata.GetTypeDefinition(ti.Name())
 	if err != nil {
 		return nil, err
 	}
-	handler.typeDef = typeDef
+
+	handler := &dateHandler{
+		*NewTypeHandler(ti),
+		typeDef,
+	}
 
 	return handler, nil
 }
 
 type dateHandler struct {
-	info    langsupport.TypeHandlerInfo
+	typeHandler
 	typeDef *metadata.TypeDefinition
-}
-
-func (h *dateHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
 }
 
 func (h *dateHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {

--- a/languages/assemblyscript/handler_primitivearrays.go
+++ b/languages/assemblyscript/handler_primitivearrays.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"hypruntime/langsupport"
 	"hypruntime/langsupport/primitives"
@@ -18,74 +17,56 @@ import (
 
 // Reference: https://github.com/AssemblyScript/assemblyscript/blob/main/std/assembly/array.ts
 
-func (p *planner) NewPrimitiveArrayHandler(ctx context.Context, typ string, rt reflect.Type) (managedTypeHandler, error) {
-
-	typ = _typeInfo.GetUnderlyingType(typ)
-	typeDef, err := p.metadata.GetTypeDefinition(typ)
+func (p *planner) NewPrimitiveArrayHandler(ti langsupport.TypeInfo) (managedTypeHandler, error) {
+	typeDef, err := p.metadata.GetTypeDefinition(ti.Name())
 	if err != nil {
 		return nil, err
 	}
 
-	elementType := _typeInfo.GetListSubtype(typ)
-	if elementType == "" {
-		return nil, errors.New("array type must have a subtype")
-	}
-
-	info := langsupport.NewTypeHandlerInfo(typ, rt, 16, 0)
-
-	switch elementType {
+	switch ti.ListElementType().Name() {
 	case "bool":
-		converter := primitives.NewPrimitiveTypeConverter[bool]()
-		return &primitiveArrayHandler[bool]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[bool](ti, typeDef), nil
 	case "u8":
-		converter := primitives.NewPrimitiveTypeConverter[uint8]()
-		return &primitiveArrayHandler[uint8]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[uint8](ti, typeDef), nil
 	case "u16":
-		converter := primitives.NewPrimitiveTypeConverter[uint16]()
-		return &primitiveArrayHandler[uint16]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[uint16](ti, typeDef), nil
 	case "u32":
-		converter := primitives.NewPrimitiveTypeConverter[uint32]()
-		return &primitiveArrayHandler[uint32]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[uint32](ti, typeDef), nil
 	case "u64":
-		converter := primitives.NewPrimitiveTypeConverter[uint64]()
-		return &primitiveArrayHandler[uint64]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[uint64](ti, typeDef), nil
 	case "i8":
-		converter := primitives.NewPrimitiveTypeConverter[int8]()
-		return &primitiveArrayHandler[int8]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[int8](ti, typeDef), nil
 	case "i16":
-		converter := primitives.NewPrimitiveTypeConverter[int16]()
-		return &primitiveArrayHandler[int16]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[int16](ti, typeDef), nil
 	case "i32":
-		converter := primitives.NewPrimitiveTypeConverter[int32]()
-		return &primitiveArrayHandler[int32]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[int32](ti, typeDef), nil
 	case "i64":
-		converter := primitives.NewPrimitiveTypeConverter[int64]()
-		return &primitiveArrayHandler[int64]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[int64](ti, typeDef), nil
 	case "f32":
-		converter := primitives.NewPrimitiveTypeConverter[float32]()
-		return &primitiveArrayHandler[float32]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[float32](ti, typeDef), nil
 	case "f64":
-		converter := primitives.NewPrimitiveTypeConverter[float64]()
-		return &primitiveArrayHandler[float64]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[float64](ti, typeDef), nil
 	case "isize":
-		converter := primitives.NewPrimitiveTypeConverter[int]()
-		return &primitiveArrayHandler[int]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[int](ti, typeDef), nil
 	case "usize":
-		converter := primitives.NewPrimitiveTypeConverter[uint]()
-		return &primitiveArrayHandler[uint]{info, typeDef, converter}, nil
+		return newPrimitiveArrayHandler[uint](ti, typeDef), nil
 	default:
-		return nil, fmt.Errorf("unsupported primitive array type: %s", typ)
+		return nil, fmt.Errorf("unsupported primitive array type: %s", ti.Name())
+	}
+}
+
+func newPrimitiveArrayHandler[T primitive](ti langsupport.TypeInfo, typeDef *metadata.TypeDefinition) *primitiveArrayHandler[T] {
+	return &primitiveArrayHandler[T]{
+		*NewTypeHandler(ti),
+		typeDef,
+		primitives.NewPrimitiveTypeConverter[T](),
 	}
 }
 
 type primitiveArrayHandler[T primitive] struct {
-	info      langsupport.TypeHandlerInfo
+	typeHandler
 	typeDef   *metadata.TypeDefinition
 	converter primitives.TypeConverter[T]
-}
-
-func (h *primitiveArrayHandler[T]) Info() langsupport.TypeHandlerInfo {
-	return h.info
 }
 
 func (h *primitiveArrayHandler[T]) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {
@@ -139,7 +120,7 @@ func (h *primitiveArrayHandler[T]) Write(ctx context.Context, wa langsupport.Was
 
 	// write the buffer
 	if ok := wa.Memory().Write(bufferOffset, bytes); !ok {
-		return cln, fmt.Errorf("failed to write array data for %s", h.info.TypeName())
+		return cln, fmt.Errorf("failed to write array data for %s", h.typeInfo.Name())
 	}
 
 	// write array object

--- a/languages/assemblyscript/handler_primitives.go
+++ b/languages/assemblyscript/handler_primitives.go
@@ -7,7 +7,6 @@ package assemblyscript
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"hypruntime/langsupport"
 	"hypruntime/langsupport/primitives"
@@ -20,84 +19,61 @@ type primitive interface {
 	constraints.Integer | constraints.Float | ~bool
 }
 
-func (p *planner) NewPrimitiveHandler(typ string, rt reflect.Type) (h langsupport.TypeHandler, err error) {
+func (p *planner) NewPrimitiveHandler(ti langsupport.TypeInfo) (h langsupport.TypeHandler, err error) {
 	defer func() {
 		if err == nil {
-			p.typeHandlers[typ] = h
+			p.typeHandlers[ti.Name()] = h
 		}
 	}()
 
-	switch typ {
+	switch ti.Name() {
 	case "bool":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 1, 1)
-		converter := primitives.NewPrimitiveTypeConverter[bool]()
-		return &primitiveHandler[bool]{info, converter}, nil
+		return newPrimitiveHandler[bool](ti), nil
 	case "u8":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 1, 1)
-		converter := primitives.NewPrimitiveTypeConverter[uint8]()
-		return &primitiveHandler[uint8]{info, converter}, nil
+		return newPrimitiveHandler[uint8](ti), nil
 	case "u16":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 2, 1)
-		converter := primitives.NewPrimitiveTypeConverter[uint16]()
-		return &primitiveHandler[uint16]{info, converter}, nil
+		return newPrimitiveHandler[uint16](ti), nil
 	case "u32":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-		converter := primitives.NewPrimitiveTypeConverter[uint32]()
-		return &primitiveHandler[uint32]{info, converter}, nil
+		return newPrimitiveHandler[uint32](ti), nil
 	case "u64":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 8, 1)
-		converter := primitives.NewPrimitiveTypeConverter[uint64]()
-		return &primitiveHandler[uint64]{info, converter}, nil
+		return newPrimitiveHandler[uint64](ti), nil
 	case "i8":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 1, 1)
-		converter := primitives.NewPrimitiveTypeConverter[int8]()
-		return &primitiveHandler[int8]{info, converter}, nil
+		return newPrimitiveHandler[int8](ti), nil
 	case "i16":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 2, 1)
-		converter := primitives.NewPrimitiveTypeConverter[int16]()
-		return &primitiveHandler[int16]{info, converter}, nil
+		return newPrimitiveHandler[int16](ti), nil
 	case "i32":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-		converter := primitives.NewPrimitiveTypeConverter[int32]()
-		return &primitiveHandler[int32]{info, converter}, nil
+		return newPrimitiveHandler[int32](ti), nil
 	case "i64":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 8, 1)
-		converter := primitives.NewPrimitiveTypeConverter[int64]()
-		return &primitiveHandler[int64]{info, converter}, nil
+		return newPrimitiveHandler[int64](ti), nil
 	case "f32":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-		converter := primitives.NewPrimitiveTypeConverter[float32]()
-		return &primitiveHandler[float32]{info, converter}, nil
+		return newPrimitiveHandler[float32](ti), nil
 	case "f64":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 8, 1)
-		converter := primitives.NewPrimitiveTypeConverter[float64]()
-		return &primitiveHandler[float64]{info, converter}, nil
+		return newPrimitiveHandler[float64](ti), nil
 	case "isize":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-		converter := primitives.NewPrimitiveTypeConverter[int]()
-		return &primitiveHandler[int]{info, converter}, nil
+		return newPrimitiveHandler[int](ti), nil
 	case "usize":
-		info := langsupport.NewTypeHandlerInfo(typ, rt, 4, 1)
-		converter := primitives.NewPrimitiveTypeConverter[uint]()
-		return &primitiveHandler[uint]{info, converter}, nil
+		return newPrimitiveHandler[uint](ti), nil
 	default:
-		return nil, fmt.Errorf("unsupported primitive type: %s", typ)
+		return nil, fmt.Errorf("unsupported primitive type: %s", ti.Name())
+	}
+}
+
+func newPrimitiveHandler[T primitive](ti langsupport.TypeInfo) *primitiveHandler[T] {
+	return &primitiveHandler[T]{
+		*NewTypeHandler(ti),
+		primitives.NewPrimitiveTypeConverter[T](),
 	}
 }
 
 type primitiveHandler[T primitive] struct {
-	info      langsupport.TypeHandlerInfo
+	typeHandler
 	converter primitives.TypeConverter[T]
-}
-
-func (h *primitiveHandler[T]) Info() langsupport.TypeHandlerInfo {
-	return h.info
 }
 
 func (h *primitiveHandler[T]) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {
 	val, ok := h.converter.Read(wa.Memory(), offset)
 	if !ok {
-		return 0, fmt.Errorf("failed to read %s from memory", h.info.TypeName())
+		return 0, fmt.Errorf("failed to read %s from memory", h.typeInfo.Name())
 	}
 
 	return val, nil
@@ -110,7 +86,7 @@ func (h *primitiveHandler[T]) Write(ctx context.Context, wa langsupport.WasmAdap
 	}
 
 	if ok := h.converter.Write(wa.Memory(), offset, val); !ok {
-		return nil, fmt.Errorf("failed to write %s to memory", h.info.TypeName())
+		return nil, fmt.Errorf("failed to write %s to memory", h.typeInfo.Name())
 	}
 
 	return nil, nil

--- a/languages/golang/adapter.go
+++ b/languages/golang/adapter.go
@@ -41,8 +41,8 @@ type wasmAdapter struct {
 	fnWriteMap  wasm.Function
 }
 
-func (*wasmAdapter) TypeInfo() langsupport.TypeInfo {
-	return _typeInfo
+func (*wasmAdapter) TypeInfo() langsupport.LanguageTypeInfo {
+	return _langTypeInfo
 }
 
 func (wa *wasmAdapter) Memory() wasm.Memory {

--- a/languages/golang/handler_arrays.go
+++ b/languages/golang/handler_arrays.go
@@ -13,47 +13,38 @@ import (
 	"hypruntime/utils"
 )
 
-func (p *planner) NewArrayHandler(ctx context.Context, typ string, rt reflect.Type) (langsupport.TypeHandler, error) {
-	handler := NewTypeHandler[arrayHandler](p, typ)
+func (p *planner) NewArrayHandler(ctx context.Context, ti langsupport.TypeInfo) (langsupport.TypeHandler, error) {
+	handler := &arrayHandler{
+		typeHandler: *NewTypeHandler(ti),
+	}
+	p.AddHandler(handler)
 
-	elementType := _typeInfo.GetListSubtype(typ)
-	elementHandler, err := p.GetHandler(ctx, elementType)
+	elementHandler, err := p.GetHandler(ctx, ti.ListElementType().Name())
 	if err != nil {
 		return nil, err
 	}
 	handler.elementHandler = elementHandler
 
-	arrayLen, err := _typeInfo.ArrayLength(typ)
+	arrayLen, err := _langTypeInfo.ArrayLength(ti.Name())
 	if err != nil {
 		return nil, err
 	}
-
-	elementSize := elementHandler.Info().TypeSize()
-	typeSize := uint32(arrayLen) * elementSize
-	encodingLen := arrayLen * elementHandler.Info().EncodingLength()
-
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, typeSize, encodingLen)
 	handler.arrayLen = arrayLen
-	handler.elementSize = elementSize
 
 	return handler, nil
 }
 
 type arrayHandler struct {
-	info           langsupport.TypeHandlerInfo
+	typeHandler
 	elementHandler langsupport.TypeHandler
 	arrayLen       int
-	elementSize    uint32
-}
-
-func (h *arrayHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
 }
 
 func (h *arrayHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {
-	items := reflect.New(h.info.RuntimeType()).Elem()
+	elementSize := h.elementHandler.TypeInfo().Size()
+	items := reflect.New(h.typeInfo.ReflectedType()).Elem()
 	for i := 0; i < h.arrayLen; i++ {
-		itemOffset := offset + uint32(i)*h.elementSize
+		itemOffset := offset + uint32(i)*elementSize
 		item, err := h.elementHandler.Read(ctx, wa, itemOffset)
 		if err != nil {
 			return nil, err
@@ -71,6 +62,7 @@ func (h *arrayHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 	}
 
 	cln := utils.NewCleaner()
+	elementSize := h.elementHandler.TypeInfo().Size()
 
 	// write exactly the number of items that will fit in the array
 	for i := 0; i < h.arrayLen; i++ {
@@ -83,13 +75,13 @@ func (h *arrayHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 		if err != nil {
 			return cln, err
 		}
-		offset += h.elementSize
+		offset += elementSize
 	}
 
 	// zero out any remaining space in the array
 	remainingItems := h.arrayLen - len(items)
 	if remainingItems > 0 {
-		zeros := make([]byte, remainingItems*int(h.elementSize))
+		zeros := make([]byte, remainingItems*int(elementSize))
 		if ok := wa.Memory().Write(offset, zeros); !ok {
 			return nil, errors.New("failed to zero out remaining array space")
 		}
@@ -99,10 +91,10 @@ func (h *arrayHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, of
 }
 
 func (h *arrayHandler) Decode(ctx context.Context, wa langsupport.WasmAdapter, vals []uint64) (any, error) {
-	array := reflect.New(h.info.RuntimeType()).Elem()
-	itemEncLen := h.elementHandler.Info().EncodingLength()
+	array := reflect.New(h.typeInfo.ReflectedType()).Elem()
+	itemLen := int(h.elementHandler.TypeInfo().EncodingLength())
 	for i := 0; i < h.arrayLen; i++ {
-		data, err := h.elementHandler.Decode(ctx, wa, vals[i*itemEncLen:(i+1)*itemEncLen])
+		data, err := h.elementHandler.Decode(ctx, wa, vals[i*itemLen:(i+1)*itemLen])
 		if err != nil {
 			return nil, err
 		}
@@ -117,8 +109,8 @@ func (h *arrayHandler) Encode(ctx context.Context, wa langsupport.WasmAdapter, o
 		return nil, nil, err
 	}
 
-	itemLen := h.elementHandler.Info().EncodingLength()
-	res := make([]uint64, h.info.EncodingLength())
+	itemLen := int(h.elementHandler.TypeInfo().EncodingLength())
+	res := make([]uint64, h.typeInfo.EncodingLength())
 	cln := utils.NewCleaner()
 
 	// fill the array with the encoded values, too few will be zeroed, too many will be truncated

--- a/languages/golang/handler_strings.go
+++ b/languages/golang/handler_strings.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"hypruntime/langsupport"
@@ -17,20 +16,14 @@ import (
 	"github.com/spf13/cast"
 )
 
-func (p *planner) NewStringHandler(typ string, rt reflect.Type) (langsupport.TypeHandler, error) {
-	handler := NewTypeHandler[stringHandler](p, typ)
-
-	// string header is 2 fields: 4 byte pointer and 4 byte length
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, 8, 2)
+func (p *planner) NewStringHandler(ti langsupport.TypeInfo) (langsupport.TypeHandler, error) {
+	handler := &stringHandler{*NewTypeHandler(ti)}
+	p.AddHandler(handler)
 	return handler, nil
 }
 
 type stringHandler struct {
-	info langsupport.TypeHandlerInfo
-}
-
-func (h *stringHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
+	typeHandler
 }
 
 func (h *stringHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {

--- a/languages/golang/handler_time.go
+++ b/languages/golang/handler_time.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 	"unsafe"
 
@@ -16,20 +15,14 @@ import (
 	"hypruntime/utils"
 )
 
-func (p *planner) NewTimeHandler(typ string, rt reflect.Type) (langsupport.TypeHandler, error) {
-	handler := NewTypeHandler[timeHandler](p, typ)
-
-	// time.Time has 3 fields: 8 byte uint64, 8 byte int64, 4 byte pointer
-	handler.info = langsupport.NewTypeHandlerInfo(typ, rt, 20, 3)
+func (p *planner) NewTimeHandler(ti langsupport.TypeInfo) (langsupport.TypeHandler, error) {
+	handler := &timeHandler{*NewTypeHandler(ti)}
+	p.AddHandler(handler)
 	return handler, nil
 }
 
 type timeHandler struct {
-	info langsupport.TypeHandlerInfo
-}
-
-func (h *timeHandler) Info() langsupport.TypeHandlerInfo {
-	return h.info
+	typeHandler
 }
 
 func (h *timeHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offset uint32) (any, error) {

--- a/languages/golang/tests/planner_test.go
+++ b/languages/golang/tests/planner_test.go
@@ -27,15 +27,15 @@ func TestGetHandler_int(t *testing.T) {
 		t.Fatalf("expected 1 handler, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 4 {
-		t.Errorf("expected type size 4, got %d", info.TypeSize())
+	if info.Size() != 4 {
+		t.Errorf("expected type size 4, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 }
 
@@ -54,15 +54,15 @@ func TestGetHandler_intPtr(t *testing.T) {
 		t.Fatalf("expected 2 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 4 {
-		t.Errorf("expected type size 4, got %d", info.TypeSize())
+	if info.Size() != 4 {
+		t.Errorf("expected type size 4, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -73,15 +73,15 @@ func TestGetHandler_intPtr(t *testing.T) {
 	typInner := "int"
 	rtInner := reflect.TypeFor[int]()
 
-	innerInfo := innerHandlers[0].Info()
-	if innerInfo.TypeName() != typInner {
-		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.TypeName())
+	innerInfo := innerHandlers[0].TypeInfo()
+	if innerInfo.Name() != typInner {
+		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.Name())
 	}
-	if innerInfo.TypeSize() != 4 {
-		t.Errorf("expected inner type size 4, got %d", innerInfo.TypeSize())
+	if innerInfo.Size() != 4 {
+		t.Errorf("expected inner type size 4, got %d", innerInfo.Size())
 	}
-	if innerInfo.RuntimeType() != rtInner {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner, innerInfo.RuntimeType())
+	if innerInfo.ReflectedType() != rtInner {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner, innerInfo.ReflectedType())
 	}
 }
 
@@ -100,15 +100,15 @@ func TestGetHandler_string(t *testing.T) {
 		t.Fatalf("expected 1 handler, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 8 {
-		t.Errorf("expected type size 8, got %d", info.TypeSize())
+	if info.Size() != 8 {
+		t.Errorf("expected type size 8, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 }
 
@@ -127,15 +127,15 @@ func TestGetHandler_stringPtr(t *testing.T) {
 		t.Fatalf("expected 2 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 4 {
-		t.Errorf("expected type size 4, got %d", info.TypeSize())
+	if info.Size() != 4 {
+		t.Errorf("expected type size 4, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -146,15 +146,15 @@ func TestGetHandler_stringPtr(t *testing.T) {
 	typInner := "string"
 	rtInner := reflect.TypeFor[string]()
 
-	innerInfo := innerHandlers[0].Info()
-	if innerInfo.TypeName() != typInner {
-		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.TypeName())
+	innerInfo := innerHandlers[0].TypeInfo()
+	if innerInfo.Name() != typInner {
+		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.Name())
 	}
-	if innerInfo.TypeSize() != 8 {
-		t.Errorf("expected inner type size 8, got %d", innerInfo.TypeSize())
+	if innerInfo.Size() != 8 {
+		t.Errorf("expected inner type size 8, got %d", innerInfo.Size())
 	}
-	if innerInfo.RuntimeType() != rtInner {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner, innerInfo.RuntimeType())
+	if innerInfo.ReflectedType() != rtInner {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner, innerInfo.ReflectedType())
 	}
 }
 
@@ -173,15 +173,15 @@ func TestGetHandler_stringSlice(t *testing.T) {
 		t.Fatalf("expected 2 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 12 {
-		t.Errorf("expected type size 12, got %d", info.TypeSize())
+	if info.Size() != 12 {
+		t.Errorf("expected type size 12, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -192,15 +192,15 @@ func TestGetHandler_stringSlice(t *testing.T) {
 	typInner := "string"
 	rtInner := reflect.TypeFor[string]()
 
-	innerInfo := innerHandlers[0].Info()
-	if innerInfo.TypeName() != typInner {
-		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.TypeName())
+	innerInfo := innerHandlers[0].TypeInfo()
+	if innerInfo.Name() != typInner {
+		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.Name())
 	}
-	if innerInfo.TypeSize() != 8 {
-		t.Errorf("expected inner type size 8, got %d", innerInfo.TypeSize())
+	if innerInfo.Size() != 8 {
+		t.Errorf("expected inner type size 8, got %d", innerInfo.Size())
 	}
-	if innerInfo.RuntimeType() != rtInner {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner, innerInfo.RuntimeType())
+	if innerInfo.ReflectedType() != rtInner {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner, innerInfo.ReflectedType())
 	}
 }
 
@@ -219,15 +219,15 @@ func TestGetHandler_stringArray(t *testing.T) {
 		t.Fatalf("expected 2 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 16 {
-		t.Errorf("expected type size 16, got %d", info.TypeSize())
+	if info.Size() != 16 {
+		t.Errorf("expected type size 16, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -238,15 +238,15 @@ func TestGetHandler_stringArray(t *testing.T) {
 	typInner := "string"
 	rtInner := reflect.TypeFor[string]()
 
-	innerInfo := innerHandlers[0].Info()
-	if innerInfo.TypeName() != typInner {
-		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.TypeName())
+	innerInfo := innerHandlers[0].TypeInfo()
+	if innerInfo.Name() != typInner {
+		t.Errorf("expected inner type name %q, got %q", typInner, innerInfo.Name())
 	}
-	if innerInfo.TypeSize() != 8 {
-		t.Errorf("expected inner type size 8, got %d", innerInfo.TypeSize())
+	if innerInfo.Size() != 8 {
+		t.Errorf("expected inner type size 8, got %d", innerInfo.Size())
 	}
-	if innerInfo.RuntimeType() != rtInner {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner, innerInfo.RuntimeType())
+	if innerInfo.ReflectedType() != rtInner {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner, innerInfo.ReflectedType())
 	}
 }
 
@@ -265,15 +265,15 @@ func TestGetHandler_time(t *testing.T) {
 		t.Fatalf("expected 1 handler, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 20 {
-		t.Errorf("expected type size 20, got %d", info.TypeSize())
+	if info.Size() != 20 {
+		t.Errorf("expected type size 20, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 }
 
@@ -292,15 +292,15 @@ func TestGetHandler_duration(t *testing.T) {
 		t.Fatalf("expected 1 handler, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 8 {
-		t.Errorf("expected type size 8, got %d", info.TypeSize())
+	if info.Size() != 8 {
+		t.Errorf("expected type size 8, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 }
 
@@ -319,15 +319,15 @@ func TestGetHandler_map(t *testing.T) {
 		t.Fatalf("expected 3 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 4 {
-		t.Errorf("expected type size 4, got %d", info.TypeSize())
+	if info.Size() != 4 {
+		t.Errorf("expected type size 4, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -338,29 +338,29 @@ func TestGetHandler_map(t *testing.T) {
 	typInner0 := "[]string"
 	rtInner0 := reflect.TypeFor[[]string]()
 
-	innerInfo0 := innerHandlers[0].Info()
-	if innerInfo0.TypeName() != typInner0 {
-		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.TypeName())
+	innerInfo0 := innerHandlers[0].TypeInfo()
+	if innerInfo0.Name() != typInner0 {
+		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.Name())
 	}
-	if innerInfo0.TypeSize() != 12 {
-		t.Errorf("expected inner type size 12, got %d", innerInfo0.TypeSize())
+	if innerInfo0.Size() != 12 {
+		t.Errorf("expected inner type size 12, got %d", innerInfo0.Size())
 	}
-	if innerInfo0.RuntimeType() != rtInner0 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner0, innerInfo0.RuntimeType())
+	if innerInfo0.ReflectedType() != rtInner0 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner0, innerInfo0.ReflectedType())
 	}
 
 	typInner1 := "[]string"
 	rtInner1 := reflect.TypeFor[[]string]()
 
-	innerInfo1 := innerHandlers[1].Info()
-	if innerInfo1.TypeName() != typInner1 {
-		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.TypeName())
+	innerInfo1 := innerHandlers[1].TypeInfo()
+	if innerInfo1.Name() != typInner1 {
+		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.Name())
 	}
-	if innerInfo1.TypeSize() != 12 {
-		t.Errorf("expected inner type size 12, got %d", innerInfo1.TypeSize())
+	if innerInfo1.Size() != 12 {
+		t.Errorf("expected inner type size 12, got %d", innerInfo1.Size())
 	}
-	if innerInfo1.RuntimeType() != rtInner1 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner1, innerInfo1.RuntimeType())
+	if innerInfo1.ReflectedType() != rtInner1 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner1, innerInfo1.ReflectedType())
 	}
 }
 
@@ -379,15 +379,15 @@ func TestGetHandler_struct(t *testing.T) {
 		t.Fatalf("expected 4 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.TypeSize() != 16 {
-		t.Errorf("expected type size 16, got %d", info.TypeSize())
+	if info.Size() != 16 {
+		t.Errorf("expected type size 16, got %d", info.Size())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -398,43 +398,43 @@ func TestGetHandler_struct(t *testing.T) {
 	typInner0 := "bool"
 	rtInner0 := reflect.TypeFor[bool]()
 
-	innerInfo0 := innerHandlers[0].Info()
-	if innerInfo0.TypeName() != typInner0 {
-		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.TypeName())
+	innerInfo0 := innerHandlers[0].TypeInfo()
+	if innerInfo0.Name() != typInner0 {
+		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.Name())
 	}
-	if innerInfo0.TypeSize() != 1 {
-		t.Errorf("expected inner type size 1, got %d", innerInfo0.TypeSize())
+	if innerInfo0.Size() != 1 {
+		t.Errorf("expected inner type size 1, got %d", innerInfo0.Size())
 	}
-	if innerInfo0.RuntimeType() != rtInner0 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner0, innerInfo0.RuntimeType())
+	if innerInfo0.ReflectedType() != rtInner0 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner0, innerInfo0.ReflectedType())
 	}
 
 	typInner1 := "int"
 	rtInner1 := reflect.TypeFor[int]()
 
-	innerInfo1 := innerHandlers[1].Info()
-	if innerInfo1.TypeName() != typInner1 {
-		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.TypeName())
+	innerInfo1 := innerHandlers[1].TypeInfo()
+	if innerInfo1.Name() != typInner1 {
+		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.Name())
 	}
-	if innerInfo1.TypeSize() != 4 {
-		t.Errorf("expected inner type size 4, got %d", innerInfo1.TypeSize())
+	if innerInfo1.Size() != 4 {
+		t.Errorf("expected inner type size 4, got %d", innerInfo1.Size())
 	}
-	if innerInfo1.RuntimeType() != rtInner1 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner1, innerInfo1.RuntimeType())
+	if innerInfo1.ReflectedType() != rtInner1 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner1, innerInfo1.ReflectedType())
 	}
 
 	typInner2 := "string"
 	rtInner2 := reflect.TypeFor[string]()
 
-	innerInfo2 := innerHandlers[2].Info()
-	if innerInfo2.TypeName() != typInner2 {
-		t.Errorf("expected inner type name %q, got %q", typInner2, innerInfo2.TypeName())
+	innerInfo2 := innerHandlers[2].TypeInfo()
+	if innerInfo2.Name() != typInner2 {
+		t.Errorf("expected inner type name %q, got %q", typInner2, innerInfo2.Name())
 	}
-	if innerInfo2.TypeSize() != 8 {
-		t.Errorf("expected inner type size 8, got %d", innerInfo2.TypeSize())
+	if innerInfo2.Size() != 8 {
+		t.Errorf("expected inner type size 8, got %d", innerInfo2.Size())
 	}
-	if innerInfo2.RuntimeType() != rtInner2 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner2, innerInfo2.RuntimeType())
+	if innerInfo2.ReflectedType() != rtInner2 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner2, innerInfo2.ReflectedType())
 	}
 }
 
@@ -453,12 +453,12 @@ func TestGetHandler_recursiveStruct(t *testing.T) {
 		t.Fatalf("expected 3 handlers, got %d", totalHandlers)
 	}
 
-	info := handler.Info()
-	if info.TypeName() != typ {
-		t.Errorf("expected type name %q, got %q", typ, info.TypeName())
+	info := handler.TypeInfo()
+	if info.Name() != typ {
+		t.Errorf("expected type name %q, got %q", typ, info.Name())
 	}
-	if info.RuntimeType() != rt {
-		t.Errorf("expected runtime type %v, got %v", rt, info.RuntimeType())
+	if info.ReflectedType() != rt {
+		t.Errorf("expected reflected type %v, got %v", rt, info.ReflectedType())
 	}
 
 	innerHandlers := getInnerHandlers(handler)
@@ -469,23 +469,23 @@ func TestGetHandler_recursiveStruct(t *testing.T) {
 	typInner0 := "bool"
 	rtInner0 := reflect.TypeFor[bool]()
 
-	innerInfo0 := innerHandlers[0].Info()
-	if innerInfo0.TypeName() != typInner0 {
-		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.TypeName())
+	innerInfo0 := innerHandlers[0].TypeInfo()
+	if innerInfo0.Name() != typInner0 {
+		t.Errorf("expected inner type name %q, got %q", typInner0, innerInfo0.Name())
 	}
-	if innerInfo0.RuntimeType() != rtInner0 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner0, innerInfo0.RuntimeType())
+	if innerInfo0.ReflectedType() != rtInner0 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner0, innerInfo0.ReflectedType())
 	}
 
 	typInner1 := "*testdata.TestRecursiveStruct"
 	rtInner1 := reflect.TypeFor[*TestRecursiveStruct]()
 
-	innerInfo1 := innerHandlers[1].Info()
-	if innerInfo1.TypeName() != typInner1 {
-		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.TypeName())
+	innerInfo1 := innerHandlers[1].TypeInfo()
+	if innerInfo1.Name() != typInner1 {
+		t.Errorf("expected inner type name %q, got %q", typInner1, innerInfo1.Name())
 	}
-	if innerInfo1.RuntimeType() != rtInner1 {
-		t.Errorf("expected inner runtime type %v, got %v", rtInner1, innerInfo1.RuntimeType())
+	if innerInfo1.ReflectedType() != rtInner1 {
+		t.Errorf("expected inner reflected type %v, got %v", rtInner1, innerInfo1.ReflectedType())
 	}
 }
 

--- a/languages/languages.go
+++ b/languages/languages.go
@@ -14,14 +14,14 @@ import (
 
 var lang_AssemblyScript = langsupport.NewLanguage(
 	"AssemblyScript",
-	assemblyscript.TypeInfo(),
+	assemblyscript.LanguageTypeInfo(),
 	assemblyscript.NewPlanner,
 	assemblyscript.NewWasmAdapter,
 )
 
 var lang_Go = langsupport.NewLanguage(
 	"Go",
-	golang.TypeInfo(),
+	golang.LanguageTypeInfo(),
 	golang.NewPlanner,
 	golang.NewWasmAdapter,
 )

--- a/plugins/metadata/metadata.go
+++ b/plugins/metadata/metadata.go
@@ -5,9 +5,13 @@
 package metadata
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+
+	"hypruntime/utils"
 
 	"github.com/buger/jsonparser"
 )
@@ -163,4 +167,12 @@ func parseNameAndVersion(s string) (name string, version string) {
 		return s, ""
 	}
 	return s[:i], s[i+1:]
+}
+
+func GetMetadataFromContext(ctx context.Context) (*Metadata, error) {
+	v := ctx.Value(utils.MetadataContextKey)
+	if v == nil {
+		return nil, errors.New("metadata not found in context")
+	}
+	return v.(*Metadata), nil
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -95,9 +95,12 @@ func NewWasmTestFixture(wasmFilePath string, hostOpts ...func(wasmhost.WasmHost)
 	if err != nil {
 		panic(err)
 	}
+	ctx = context.WithValue(ctx, utils.MetadataContextKey, md)
 
 	filename := filepath.Base(wasmFilePath)
 	plugin := plugins.NewPlugin(cm, filename, md)
+	ctx = context.WithValue(ctx, utils.PluginContextKey, plugin)
+
 	registry := host.GetFunctionRegistry()
 	registry.RegisterImports(ctx, plugin)
 
@@ -107,8 +110,6 @@ func NewWasmTestFixture(wasmFilePath string, hostOpts ...func(wasmhost.WasmHost)
 		customTypes: make(map[string]reflect.Type),
 	}
 
-	ctx = context.WithValue(ctx, utils.PluginContextKey, plugin)
-	ctx = context.WithValue(ctx, utils.MetadataContextKey, md)
 	ctx = context.WithValue(ctx, utils.CustomTypesContextKey, f.customTypes)
 	f.Context = ctx
 

--- a/wasmhost/hostfns.go
+++ b/wasmhost/hostfns.go
@@ -351,8 +351,7 @@ func decodeParams(ctx context.Context, wa langsupport.WasmAdapter, fnInfo functi
 	}
 
 	for i, handler := range plan.ParamHandlers() {
-		hInfo := handler.Info()
-		encLength := hInfo.EncodingLength()
+		encLength := int(handler.TypeInfo().EncodingLength())
 		vals := stack[stackPos : stackPos+encLength]
 		stackPos += encLength
 
@@ -380,7 +379,7 @@ func decodeParams(ctx context.Context, wa langsupport.WasmAdapter, fnInfo functi
 		}
 
 		// special case for pointers that need to be dereferenced
-		if hInfo.RuntimeType().Kind() == reflect.Ptr && reflect.TypeOf(params[i]).Kind() != reflect.Ptr {
+		if handler.TypeInfo().ReflectedType().Kind() == reflect.Ptr && reflect.TypeOf(params[i]).Kind() != reflect.Ptr {
 			params[i] = utils.DereferencePointer(data)
 			continue
 		}
@@ -437,9 +436,9 @@ func writeIndirectResults(ctx context.Context, wa langsupport.WasmAdapter, plan 
 
 	fieldOffset := uint32(0)
 	for i, handler := range handlers {
-		size := handler.Info().TypeSize()
-		fieldType := handler.Info().TypeName()
-		alignment, err := wa.TypeInfo().GetAlignOfType(ctx, fieldType)
+		size := handler.TypeInfo().Size()
+		fieldType := handler.TypeInfo().Name()
+		alignment, err := wa.TypeInfo().GetAlignmentOfType(ctx, fieldType)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This consolidates some duplicated code from the individual language packages into the common `langsupport` package, and uses a common `TypeInfo` interface to represent a type from the surrogate type system of each language.

It is mostly a refactoring.  Several internal types have been renamed as well.