### PR TITLE
Fix plan creation / registration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add FunctionExecutionDurationMillisecondsSummary metric [#377](https://github.com/hypermodeAI/runtime/pull/377)
 - Fix field alignment issue [#378](https://github.com/hypermodeAI/runtime/pull/378)
 - Improve execution plan creation [#379](https://github.com/hypermodeAI/runtime/pull/379)
+- Fix plan creation / registration bug [#380](https://github.com/hypermodeAI/runtime/pull/380)
 
 ## 2024-09-18 - Version 0.12.1
 

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -17,7 +17,6 @@ import (
 	collection_utils "hypruntime/collections/utils"
 	"hypruntime/functions"
 	"hypruntime/manifestdata"
-	"hypruntime/plugins"
 	"hypruntime/utils"
 	"hypruntime/wasmhost"
 )
@@ -690,7 +689,7 @@ func validateEmbedder(ctx context.Context, embedder string) error {
 		return errInvalidEmbedderSignature
 	}
 
-	lti := plugins.GetPlugin(ctx).Language.TypeInfo()
+	lti := info.Plugin().Language.TypeInfo()
 
 	p := fn.Parameters[0]
 	if !lti.IsListType(p.Type) || !lti.IsStringType(lti.GetListSubtype(p.Type)) {

--- a/db/db.go
+++ b/db/db.go
@@ -257,7 +257,7 @@ func WriteInferenceHistory(ctx context.Context, model *manifest.ModelInfo, input
 	defer span.Finish()
 
 	var pluginId *string
-	if plugin, ok := ctx.Value(utils.PluginContextKey).(*plugins.Plugin); ok {
+	if plugin, ok := plugins.GetPluginFromContext(ctx); ok {
 		pluginId = &plugin.Id
 	}
 

--- a/functions/fninfo.go
+++ b/functions/fninfo.go
@@ -12,35 +12,41 @@ import (
 
 type FunctionInfo interface {
 	Name() string
+	IsImport() bool
 	Plugin() *plugins.Plugin
 	Metadata() *metadata.Function
 	ExecutionPlan() langsupport.ExecutionPlan
 }
 
-func NewFunctionInfo(plugin *plugins.Plugin, plan langsupport.ExecutionPlan) FunctionInfo {
-	return &functionInfo{
-		plugin:        plugin,
-		executionPlan: plan,
+func NewFunctionInfo(fnName string, plugin *plugins.Plugin, isImport bool) (FunctionInfo, bool) {
+
+	var fnMap metadata.FunctionMap
+	if isImport {
+		fnMap = plugin.Metadata.FnImports
+	} else {
+		fnMap = plugin.Metadata.FnExports
 	}
+
+	fnMeta := fnMap[fnName]
+	plan := plugin.ExecutionPlans[fnName]
+	if fnMeta == nil || plan == nil {
+		return nil, false
+	}
+
+	info := &functionInfo{fnName, isImport, plugin, fnMeta, plan}
+	return info, true
 }
 
 type functionInfo struct {
-	plugin        *plugins.Plugin
-	executionPlan langsupport.ExecutionPlan
+	fnName   string
+	isImport bool
+	plugin   *plugins.Plugin
+	fnMeta   *metadata.Function
+	plan     langsupport.ExecutionPlan
 }
 
-func (f *functionInfo) Name() string {
-	return f.Metadata().Name
-}
-
-func (f *functionInfo) Plugin() *plugins.Plugin {
-	return f.plugin
-}
-
-func (f *functionInfo) Metadata() *metadata.Function {
-	return f.executionPlan.FnMetadata()
-}
-
-func (f *functionInfo) ExecutionPlan() langsupport.ExecutionPlan {
-	return f.executionPlan
-}
+func (f *functionInfo) Name() string                             { return f.fnName }
+func (f *functionInfo) IsImport() bool                           { return f.isImport }
+func (f *functionInfo) Plugin() *plugins.Plugin                  { return f.plugin }
+func (f *functionInfo) Metadata() *metadata.Function             { return f.fnMeta }
+func (f *functionInfo) ExecutionPlan() langsupport.ExecutionPlan { return f.plan }

--- a/languages/assemblyscript/tests/hostfns_test.go
+++ b/languages/assemblyscript/tests/hostfns_test.go
@@ -105,16 +105,16 @@ func TestHostFn_echoObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := map[string]any{
-		"A": int32(2),
-		"B": false,
-		"C": "hello!",
+	expected := &TestHostObject{
+		A: 2,
+		B: false,
+		C: "hello!",
 	}
 
 	if result == nil {
 		t.Error("expected a result")
-	} else if r, ok := result.(map[string]any); !ok {
-		t.Errorf("expected a map[string]any, got %T", result)
+	} else if r, ok := result.(TestHostObject); !ok {
+		t.Errorf("expected %T, got %T", expected, result)
 	} else if reflect.DeepEqual(expected, r) {
 		t.Errorf("expected %+v, got %+v", expected, r)
 	}

--- a/languages/assemblyscript/tests/maps_test.go
+++ b/languages/assemblyscript/tests/maps_test.go
@@ -140,12 +140,12 @@ func TestMapLookup_string_string(t *testing.T) {
 	}
 }
 
-type testClassWithMap struct {
+type TestClassWithMap struct {
 	M map[string]string
 }
 
 func TestClassContainingMapInput_string_string(t *testing.T) {
-	s := testClassWithMap{M: map[string]string{
+	s := TestClassWithMap{M: map[string]string{
 		"a": "1",
 		"b": "2",
 		"c": "3",
@@ -162,7 +162,7 @@ func TestClassContainingMapOutput_string_string(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := testClassWithMap{M: map[string]string{
+	expected := TestClassWithMap{M: map[string]string{
 		"a": "1",
 		"b": "2",
 		"c": "3",
@@ -170,7 +170,7 @@ func TestClassContainingMapOutput_string_string(t *testing.T) {
 
 	if result == nil {
 		t.Error("expected a result")
-	} else if r, ok := result.(testClassWithMap); !ok {
+	} else if r, ok := result.(TestClassWithMap); !ok {
 		t.Errorf("expected %T, got %T", expected, result)
 	} else if !reflect.DeepEqual(expected, r) {
 		t.Errorf("expected %v, got %v", expected, r)

--- a/languages/assemblyscript/tests/setup_test.go
+++ b/languages/assemblyscript/tests/setup_test.go
@@ -23,16 +23,18 @@ var fixture *testutils.WasmTestFixture
 
 func TestMain(m *testing.M) {
 	path := filepath.Join(basePath, "..", "testdata", "build", "testdata.wasm")
-	registrations := getTestHostFunctionRegistrations()
-	fixture = testutils.NewWasmTestFixture(path, registrations...)
 
-	fixture.AddCustomType("assembly/classes/TestClass1", reflect.TypeFor[TestClass1]())
-	fixture.AddCustomType("assembly/classes/TestClass2", reflect.TypeFor[TestClass2]())
-	fixture.AddCustomType("assembly/classes/TestClass3", reflect.TypeFor[TestClass3]())
-	fixture.AddCustomType("assembly/classes/TestClass4", reflect.TypeFor[TestClass4]())
-	fixture.AddCustomType("assembly/classes/TestClass5", reflect.TypeFor[TestClass5]())
-	fixture.AddCustomType("assembly/hostfns/TestHostObject", reflect.TypeFor[TestHostObject]())
-	fixture.AddCustomType("assembly/maps/TestClassWithMap", reflect.TypeFor[testClassWithMap]())
+	customTypes := make(map[string]reflect.Type)
+	customTypes["assembly/classes/TestClass1"] = reflect.TypeFor[TestClass1]()
+	customTypes["assembly/classes/TestClass2"] = reflect.TypeFor[TestClass2]()
+	customTypes["assembly/classes/TestClass3"] = reflect.TypeFor[TestClass3]()
+	customTypes["assembly/classes/TestClass4"] = reflect.TypeFor[TestClass4]()
+	customTypes["assembly/classes/TestClass5"] = reflect.TypeFor[TestClass5]()
+	customTypes["assembly/hostfns/TestHostObject"] = reflect.TypeFor[TestHostObject]()
+	customTypes["assembly/maps/TestClassWithMap"] = reflect.TypeFor[TestClassWithMap]()
+
+	registrations := getTestHostFunctionRegistrations()
+	fixture = testutils.NewWasmTestFixture(path, customTypes, registrations)
 
 	exitVal := m.Run()
 

--- a/languages/golang/tests/maps_test.go
+++ b/languages/golang/tests/maps_test.go
@@ -107,12 +107,12 @@ func TestMapLookup_string_string(t *testing.T) {
 	}
 }
 
-type testStructWithMap struct {
+type TestStructWithMap struct {
 	M map[string]string
 }
 
 func TestStructContainingMapInput_string_string(t *testing.T) {
-	s := testStructWithMap{M: map[string]string{
+	s := TestStructWithMap{M: map[string]string{
 		"a": "1",
 		"b": "2",
 		"c": "3",
@@ -129,7 +129,7 @@ func TestStructContainingMapOutput_string_string(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := testStructWithMap{M: map[string]string{
+	expected := TestStructWithMap{M: map[string]string{
 		"a": "1",
 		"b": "2",
 		"c": "3",
@@ -137,7 +137,7 @@ func TestStructContainingMapOutput_string_string(t *testing.T) {
 
 	if result == nil {
 		t.Error("expected a result")
-	} else if r, ok := result.(testStructWithMap); !ok {
+	} else if r, ok := result.(TestStructWithMap); !ok {
 		t.Errorf("expected %T, got %T", expected, result)
 	} else if !reflect.DeepEqual(expected, r) {
 		t.Errorf("expected %v, got %v", expected, r)

--- a/languages/golang/tests/setup_test.go
+++ b/languages/golang/tests/setup_test.go
@@ -23,16 +23,18 @@ var fixture *testutils.WasmTestFixture
 
 func TestMain(m *testing.M) {
 	path := filepath.Join(basePath, "..", "testdata", "build", "testdata.wasm")
-	registrations := getTestHostFunctionRegistrations()
-	fixture = testutils.NewWasmTestFixture(path, registrations...)
 
-	fixture.AddCustomType("testdata.TestStruct1", reflect.TypeFor[TestStruct1]())
-	fixture.AddCustomType("testdata.TestStruct2", reflect.TypeFor[TestStruct2]())
-	fixture.AddCustomType("testdata.TestStruct3", reflect.TypeFor[TestStruct3]())
-	fixture.AddCustomType("testdata.TestStruct4", reflect.TypeFor[TestStruct4]())
-	fixture.AddCustomType("testdata.TestStruct5", reflect.TypeFor[TestStruct5]())
-	fixture.AddCustomType("testdata.TestStructWithMap", reflect.TypeFor[testStructWithMap]())
-	fixture.AddCustomType("testdata.TestRecursiveStruct", reflect.TypeFor[TestRecursiveStruct]())
+	customTypes := make(map[string]reflect.Type)
+	customTypes["testdata.TestStruct1"] = reflect.TypeFor[TestStruct1]()
+	customTypes["testdata.TestStruct2"] = reflect.TypeFor[TestStruct2]()
+	customTypes["testdata.TestStruct3"] = reflect.TypeFor[TestStruct3]()
+	customTypes["testdata.TestStruct4"] = reflect.TypeFor[TestStruct4]()
+	customTypes["testdata.TestStruct5"] = reflect.TypeFor[TestStruct5]()
+	customTypes["testdata.TestStructWithMap"] = reflect.TypeFor[TestStructWithMap]()
+	customTypes["testdata.TestRecursiveStruct"] = reflect.TypeFor[TestRecursiveStruct]()
+
+	registrations := getTestHostFunctionRegistrations()
+	fixture = testutils.NewWasmTestFixture(path, customTypes, registrations)
 
 	exitVal := m.Run()
 

--- a/pluginmanager/loader.go
+++ b/pluginmanager/loader.go
@@ -78,7 +78,10 @@ func loadPlugin(ctx context.Context, filename string) error {
 	}
 
 	// Make the plugin object.
-	plugin := plugins.NewPlugin(cm, filename, md)
+	plugin, err := plugins.NewPlugin(ctx, cm, filename, md)
+	if err != nil {
+		return err
+	}
 
 	// Write the plugin info to the database.
 	// Note, this may update the ID if a plugin with the same BuildID is in the db already.

--- a/pluginmanager/pluginmanager.go
+++ b/pluginmanager/pluginmanager.go
@@ -21,7 +21,7 @@ func Initialize(ctx context.Context) {
 func configureLogger() {
 	logger.AddAdapter(func(ctx context.Context, lc zerolog.Context) zerolog.Context {
 
-		if plugin := plugins.GetPlugin(ctx); plugin != nil {
+		if plugin, ok := plugins.GetPluginFromContext(ctx); ok {
 			if buildId := plugin.BuildId(); buildId != "" {
 				lc = lc.Str("build_id", buildId)
 			}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -6,9 +6,13 @@ package plugins
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"hypruntime/hostfunctions/compatibility"
 	"hypruntime/langsupport"
 	"hypruntime/languages"
+	"hypruntime/logger"
 	"hypruntime/plugins/metadata"
 	"hypruntime/utils"
 
@@ -16,27 +20,101 @@ import (
 )
 
 type Plugin struct {
-	Id       string
-	Module   wazero.CompiledModule
-	Metadata *metadata.Metadata
-	FileName string
-	Language langsupport.Language
-	Planner  langsupport.Planner
+	Id             string
+	Module         wazero.CompiledModule
+	Metadata       *metadata.Metadata
+	FileName       string
+	Language       langsupport.Language
+	ExecutionPlans map[string]langsupport.ExecutionPlan
 }
 
-func NewPlugin(cm wazero.CompiledModule, filename string, md *metadata.Metadata) *Plugin {
+func NewPlugin(ctx context.Context, cm wazero.CompiledModule, filename string, md *metadata.Metadata) (*Plugin, error) {
 
 	language := languages.GetLanguageForSDK(md.SDK)
 	planner := language.NewPlanner(md)
+	imports := cm.ImportedFunctions()
+	exports := cm.ExportedFunctions()
+	plans := make(map[string]langsupport.ExecutionPlan, len(imports)+len(exports))
 
-	return &Plugin{
-		Id:       utils.GenerateUUIDv7(),
-		Module:   cm,
-		Metadata: md,
-		FileName: filename,
-		Language: language,
-		Planner:  planner,
+	ctx = context.WithValue(ctx, utils.MetadataContextKey, md)
+
+	for fnName, fnMeta := range md.FnExports {
+		fnDef, ok := exports[fnName]
+		if !ok {
+			return nil, fmt.Errorf("no wasm function definition found for %s", fnName)
+		}
+
+		plan, err := planner.GetPlan(ctx, fnMeta, fnDef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get execution plan for %s: %w", fnName, err)
+		}
+		plans[fnName] = plan
 	}
+
+	warn := true
+	for _, fnDef := range imports {
+		modName, fnName, _ := fnDef.Import()
+		impName := fmt.Sprintf("%s.%s", modName, fnName)
+
+		fnMeta, err := getImportMetadata(ctx, modName, fnName, md, &warn)
+		if err != nil {
+			return nil, err
+		} else if fnMeta == nil {
+			continue
+		}
+
+		plan, err := planner.GetPlan(ctx, fnMeta, fnDef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get execution plan for %s: %w", impName, err)
+		}
+		plans[impName] = plan
+	}
+
+	plugin := &Plugin{
+		Id:             utils.GenerateUUIDv7(),
+		Module:         cm,
+		Metadata:       md,
+		FileName:       filename,
+		Language:       language,
+		ExecutionPlans: plans,
+	}
+
+	return plugin, nil
+}
+
+func getImportMetadata(ctx context.Context, modName, fnName string, md *metadata.Metadata, warn *bool) (*metadata.Function, error) {
+	impName := fmt.Sprintf("%s.%s", modName, fnName)
+	if fnMeta, ok := md.FnImports[impName]; ok {
+		return fnMeta, nil
+	}
+
+	if modName == "hypermode" {
+		if *warn {
+			*warn = false
+			logger.Warn(ctx).
+				Str("plugin", md.Name()).
+				Str("build_id", md.BuildId).
+				Msg("Hypermode function imports are missing from the metadata. Using compatibility shims. Please update your SDK to the latest version.")
+		}
+		if fnMeta, err := compatibility.GetImportMetadataShim(impName); err != nil {
+			return nil, fmt.Errorf("error creating compatibility shim for %s: %w", impName, err)
+		} else {
+			return fnMeta, nil
+		}
+	} else if shouldIgnoreModule(modName) {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("no metadata found for import %s", impName)
+}
+
+func shouldIgnoreModule(name string) bool {
+	switch name {
+	case "wasi_snapshot_preview1", "wasi", "env", "runtime", "syscall", "test":
+		return true
+	}
+
+	return strings.HasPrefix(name, "wasi_")
 }
 
 func (p *Plugin) NameAndVersion() (name string, version string) {
@@ -55,10 +133,7 @@ func (p *Plugin) BuildId() string {
 	return p.Metadata.BuildId
 }
 
-func GetPlugin(ctx context.Context) *Plugin {
-	if p, ok := ctx.Value(utils.PluginContextKey).(*Plugin); ok {
-		return p
-	}
-
-	return nil
+func GetPluginFromContext(ctx context.Context) (*Plugin, bool) {
+	p, ok := ctx.Value(utils.PluginContextKey).(*Plugin)
+	return p, ok
 }

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -39,20 +39,12 @@ func (f *WasmTestFixture) AddCustomType(name string, typ reflect.Type) {
 func (f *WasmTestFixture) CallFunction(t *testing.T, name string, paramValues ...any) (any, error) {
 	ctx := context.WithValue(f.Context, testContextKey{}, t)
 
-	fnMeta, ok := f.Plugin.Metadata.FnExports[name]
+	fnInfo, ok := functions.NewFunctionInfo(name, f.Plugin, false)
 	if !ok {
-		return nil, fmt.Errorf("function %s not found", name)
+		return nil, fmt.Errorf("no function registered named %s", name)
 	}
 
-	fnDef := f.Plugin.Module.ExportedFunctions()[name]
-	plan, err := f.Plugin.Planner.GetPlan(ctx, fnMeta, fnDef)
-	if err != nil {
-		return nil, err
-	}
-
-	fnInfo := functions.NewFunctionInfo(f.Plugin, plan)
-
-	params, err := functions.CreateParametersMap(fnMeta, paramValues...)
+	params, err := functions.CreateParametersMap(fnInfo.Metadata(), paramValues...)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func GetTestT(ctx context.Context) *testing.T {
 	return ctx.Value(testContextKey{}).(*testing.T)
 }
 
-func NewWasmTestFixture(wasmFilePath string, hostOpts ...func(wasmhost.WasmHost) error) *WasmTestFixture {
+func NewWasmTestFixture(wasmFilePath string, customTypes map[string]reflect.Type, registrations []func(wasmhost.WasmHost) error) *WasmTestFixture {
 	logger.Initialize()
 
 	content, err := os.ReadFile(wasmFilePath)
@@ -84,7 +76,7 @@ func NewWasmTestFixture(wasmFilePath string, hostOpts ...func(wasmhost.WasmHost)
 	}
 
 	ctx := context.Background()
-	host := wasmhost.NewWasmHost(ctx, hostOpts...)
+	host := wasmhost.NewWasmHost(ctx, registrations...)
 
 	cm, err := host.CompileModule(ctx, content)
 	if err != nil {
@@ -96,22 +88,23 @@ func NewWasmTestFixture(wasmFilePath string, hostOpts ...func(wasmhost.WasmHost)
 		panic(err)
 	}
 	ctx = context.WithValue(ctx, utils.MetadataContextKey, md)
+	ctx = context.WithValue(ctx, utils.CustomTypesContextKey, customTypes)
 
 	filename := filepath.Base(wasmFilePath)
-	plugin := plugins.NewPlugin(cm, filename, md)
+	plugin, err := plugins.NewPlugin(ctx, cm, filename, md)
+	if err != nil {
+		panic(err)
+	}
+
 	ctx = context.WithValue(ctx, utils.PluginContextKey, plugin)
 
 	registry := host.GetFunctionRegistry()
 	registry.RegisterImports(ctx, plugin)
 
-	f := &WasmTestFixture{
+	return &WasmTestFixture{
+		Context:     ctx,
 		WasmHost:    host,
 		Plugin:      plugin,
-		customTypes: make(map[string]reflect.Type),
+		customTypes: customTypes,
 	}
-
-	ctx = context.WithValue(ctx, utils.CustomTypesContextKey, f.customTypes)
-	f.Context = ctx
-
-	return f
 }

--- a/wasmhost/fncall.go
+++ b/wasmhost/fncall.go
@@ -55,7 +55,7 @@ func CallFunction(ctx context.Context, fnName string, paramValues ...any) (Execu
 }
 
 func (host *wasmHost) CallFunctionByName(ctx context.Context, fnName string, paramValues ...any) (ExecutionInfo, error) {
-	info, err := host.fnRegistry.GetFunctionInfo(fnName)
+	info, err := host.GetFunctionInfo(fnName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There were some issues with retrieving the correct execution plan that came down to how functions were registered.

Previously, the plugin loader would create a plugin and then register all of the functions in it.  Each function would separately be registered and an execution plan created and associated with it at that time.  The registration is done by function name.

The problem was that if a plugin was reloaded, and the names hadn't changed but the metadata changed in a way that would modify the execution plan (ie., SDK language, signatures, type ids, etc.) then the _old_ plan was still in the registry and was being used with the new plugin - resulting in a runtime error when the function was called.

The fix was to have the execution plans created at the same time the plugin object is associated, then update all the related places where we register functions or retrieve them.  That way, a plugin's functions, it's metadata, and its execution plan can never become disassociated.  This also affords some optimizations.  In particular, when a host function is invoked, we no longer have to ask the registry for the execution plan.  Instead we can get it directly from the active plugin.

There were a few other minor bugs that surfaced while fixing this, which are also fixed in this PR.