### PR TITLE
Increase AWS retry settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,6 +93,7 @@
     "ptrs",
     "reindex",
     "renameio",
+    "retryer",
     "rtti",
     "schemagen",
     "sqlclient",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Increase AWS retry settings [#383](https://github.com/hypermodeAI/runtime/pull/383)
+
 ## 2024-09-24 - Version 0.12.2
 
 - Fix missing GraphQL type schema [#376](https://github.com/hypermodeAI/runtime/pull/376)


### PR DESCRIPTION
Double the default `MaxAttempts` and `MaxBackoff` values for AWS settings.  Hopefully this eliminates or reduces some of the transient startup errors we've seen.