### PR TITLE
Arrays in collections host functions should be non-nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- catch nil labels and output as empty in collections [#384](https://github.com/hypermodeAI/runtime/pull/384)
+
 ## 2024-09-24 - Version 0.12.2
 
 - Fix missing GraphQL type schema [#376](https://github.com/hypermodeAI/runtime/pull/376)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- catch nil labels and output as empty in collections [#384](https://github.com/hypermodeAI/runtime/pull/384)
+- Arrays in collections host functions should be non-nil [#384](https://github.com/hypermodeAI/runtime/pull/384)
 
 ## 2024-09-24 - Version 0.12.2
 

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -569,6 +569,9 @@ func GetTextsFromCollection(ctx context.Context, collectionName, namespace strin
 	if err != nil {
 		return nil, err
 	}
+	if textMap == nil {
+		return make(map[string]string), nil
+	}
 
 	return textMap, nil
 }

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -240,6 +240,9 @@ func SearchCollection(ctx context.Context, collectionName string, namespaces []s
 			if err != nil {
 				return nil, err
 			}
+			if labels == nil {
+				labels = []string{}
+			}
 			mergedObjects = append(mergedObjects, &CollectionSearchResultObject{
 				Namespace: ns,
 				Key:       object.GetIndex(),
@@ -305,6 +308,9 @@ func SearchCollectionByVector(ctx context.Context, collectionName string, namesp
 			labels, err := collNs.GetLabels(ctx, object.GetIndex())
 			if err != nil {
 				return nil, err
+			}
+			if labels == nil {
+				labels = []string{}
 			}
 			mergedObjects = append(mergedObjects, &CollectionSearchResultObject{
 				Namespace: ns,
@@ -423,6 +429,9 @@ func NnClassify(ctx context.Context, collectionName, namespace, searchMethod, te
 			if err != nil {
 				return nil, err
 			}
+			if labels == nil {
+				labels = []string{}
+			}
 			for _, label := range labels {
 				labelCounts[label]++
 				totalLabels++
@@ -499,6 +508,9 @@ func GetLabels(ctx context.Context, collectionName, namespace, key string) ([]st
 	labels, err := collNs.GetLabels(ctx, key)
 	if err != nil {
 		return nil, err
+	}
+	if labels == nil {
+		labels = []string{}
 	}
 
 	return labels, nil

--- a/collections/collections.go
+++ b/collections/collections.go
@@ -129,13 +129,7 @@ func UpsertToCollection(ctx context.Context, collectionName, namespace string, k
 		}
 	}
 
-	return &CollectionMutationResult{
-		Collection: collectionName,
-		Operation:  "upsert",
-		Status:     "success",
-		Keys:       keys,
-		Error:      "",
-	}, nil
+	return NewCollectionMutationResult(collectionName, "upsert", "success", keys, ""), nil
 }
 
 func DeleteFromCollection(ctx context.Context, collectionName, namespace, key string) (*CollectionMutationResult, error) {
@@ -170,13 +164,7 @@ func DeleteFromCollection(ctx context.Context, collectionName, namespace, key st
 
 	keys := []string{key}
 
-	return &CollectionMutationResult{
-		Collection: collectionName,
-		Operation:  "delete",
-		Status:     "success",
-		Keys:       keys,
-		Error:      "",
-	}, nil
+	return NewCollectionMutationResult(collectionName, "delete", "success", keys, ""), nil
 }
 
 func SearchCollection(ctx context.Context, collectionName string, namespaces []string, searchMethod, text string, limit int32, returnText bool) (*CollectionSearchResult, error) {
@@ -240,17 +228,7 @@ func SearchCollection(ctx context.Context, collectionName string, namespaces []s
 			if err != nil {
 				return nil, err
 			}
-			if labels == nil {
-				labels = []string{}
-			}
-			mergedObjects = append(mergedObjects, &CollectionSearchResultObject{
-				Namespace: ns,
-				Key:       object.GetIndex(),
-				Text:      text,
-				Labels:    labels,
-				Distance:  object.GetValue(),
-				Score:     1 - object.GetValue(),
-			})
+			mergedObjects = append(mergedObjects, NewCollectionSearchResultObject(ns, object.GetIndex(), text, labels, object.GetValue(), 1-object.GetValue()))
 		}
 	}
 
@@ -263,12 +241,7 @@ func SearchCollection(ctx context.Context, collectionName string, namespaces []s
 		mergedObjects = mergedObjects[:int(limit)]
 	}
 
-	return &CollectionSearchResult{
-		Collection:   collectionName,
-		SearchMethod: searchMethod,
-		Status:       "success",
-		Objects:      mergedObjects,
-	}, nil
+	return NewCollectionSearchResult(collectionName, searchMethod, "success", mergedObjects, ""), nil
 }
 
 func SearchCollectionByVector(ctx context.Context, collectionName string, namespaces []string, searchMethod string, vector []float32, limit int32, returnText bool) (*CollectionSearchResult, error) {
@@ -309,17 +282,7 @@ func SearchCollectionByVector(ctx context.Context, collectionName string, namesp
 			if err != nil {
 				return nil, err
 			}
-			if labels == nil {
-				labels = []string{}
-			}
-			mergedObjects = append(mergedObjects, &CollectionSearchResultObject{
-				Namespace: ns,
-				Key:       object.GetIndex(),
-				Text:      text,
-				Labels:    labels,
-				Distance:  object.GetValue(),
-				Score:     1 - object.GetValue(),
-			})
+			mergedObjects = append(mergedObjects, NewCollectionSearchResultObject(ns, object.GetIndex(), text, labels, object.GetValue(), 1-object.GetValue()))
 		}
 	}
 
@@ -332,12 +295,7 @@ func SearchCollectionByVector(ctx context.Context, collectionName string, namesp
 		mergedObjects = mergedObjects[:int(limit)]
 	}
 
-	return &CollectionSearchResult{
-		Collection:   collectionName,
-		SearchMethod: searchMethod,
-		Status:       "success",
-		Objects:      mergedObjects,
-	}, nil
+	return NewCollectionSearchResult(collectionName, searchMethod, "success", mergedObjects, ""), nil
 }
 
 func NnClassify(ctx context.Context, collectionName, namespace, searchMethod, text string) (*CollectionClassificationResult, error) {
@@ -413,13 +371,7 @@ func NnClassify(ctx context.Context, collectionName, namespace, searchMethod, te
 	// remove elements with score out of first standard deviation and return the most frequent label
 	labelCounts := make(map[string]int)
 
-	res := &CollectionClassificationResult{
-		Collection:   collectionName,
-		LabelsResult: make([]*CollectionClassificationLabelObject, 0),
-		SearchMethod: searchMethod,
-		Status:       "success",
-		Cluster:      make([]*CollectionClassificationResultObject, 0),
-	}
+	res := NewCollectionClassificationResult(collectionName, searchMethod, "success", []*CollectionClassificationLabelObject{}, []*CollectionClassificationResultObject{}, "")
 
 	totalLabels := 0
 
@@ -429,30 +381,19 @@ func NnClassify(ctx context.Context, collectionName, namespace, searchMethod, te
 			if err != nil {
 				return nil, err
 			}
-			if labels == nil {
-				labels = []string{}
-			}
 			for _, label := range labels {
 				labelCounts[label]++
 				totalLabels++
 			}
 
-			res.Cluster = append(res.Cluster, &CollectionClassificationResultObject{
-				Key:      nn.GetIndex(),
-				Labels:   labels,
-				Score:    1 - nn.GetValue(),
-				Distance: nn.GetValue(),
-			})
+			res.Cluster = append(res.Cluster, NewCollectionClassificationResultObject(nn.GetIndex(), labels, nn.GetValue(), 1-nn.GetValue()))
 		}
 	}
 
 	// Create a slice of pairs
 	labelsResult := make([]*CollectionClassificationLabelObject, 0, len(labelCounts))
 	for label, count := range labelCounts {
-		labelsResult = append(labelsResult, &CollectionClassificationLabelObject{
-			Label:      label,
-			Confidence: float64(count) / float64(totalLabels),
-		})
+		labelsResult = append(labelsResult, NewCollectionClassificationLabelObject(label, float64(count)/float64(totalLabels)))
 	}
 
 	// Sort the pairs by count in descending order
@@ -509,9 +450,6 @@ func GetLabels(ctx context.Context, collectionName, namespace, key string) ([]st
 	if err != nil {
 		return nil, err
 	}
-	if labels == nil {
-		labels = []string{}
-	}
 
 	return labels, nil
 }
@@ -560,14 +498,7 @@ func ComputeDistance(ctx context.Context, collectionName, namespace, searchMetho
 		return nil, err
 	}
 
-	return &CollectionSearchResultObject{
-		Namespace: namespace,
-		Key:       "",
-		Text:      "",
-		Labels:    []string{},
-		Distance:  distance,
-		Score:     1 - distance,
-	}, nil
+	return NewCollectionSearchResultObject(namespace, "", "", []string{}, distance, 1-distance), nil
 }
 
 func RecomputeSearchMethod(ctx context.Context, collectionName, namespace, searchMethod string) (*SearchMethodMutationResult, error) {
@@ -596,12 +527,7 @@ func RecomputeSearchMethod(ctx context.Context, collectionName, namespace, searc
 		return nil, err
 	}
 
-	return &SearchMethodMutationResult{
-		Collection: collectionName,
-		Operation:  "recompute",
-		Status:     "success",
-		Error:      "",
-	}, nil
+	return NewSearchMethodMutationResult(collectionName, searchMethod, "recompute", "success", ""), nil
 }
 
 func GetTextFromCollection(ctx context.Context, collectionName, namespace, key string) (string, error) {

--- a/collections/types.go
+++ b/collections/types.go
@@ -4,12 +4,35 @@
 
 package collections
 
+func NewCollectionMutationResult(collection, operation, status string, keys []string, err string) *CollectionMutationResult {
+	if keys == nil {
+		keys = []string{}
+	}
+	return &CollectionMutationResult{
+		Collection: collection,
+		Operation:  operation,
+		Status:     status,
+		Keys:       keys,
+		Error:      err,
+	}
+}
+
 type CollectionMutationResult struct {
 	Collection string
 	Operation  string
 	Status     string
 	Keys       []string
 	Error      string
+}
+
+func NewSearchMethodMutationResult(collection, searchMethod, operation, status, err string) *SearchMethodMutationResult {
+	return &SearchMethodMutationResult{
+		Collection:   collection,
+		SearchMethod: searchMethod,
+		Operation:    operation,
+		Status:       status,
+		Error:        err,
+	}
 }
 
 type SearchMethodMutationResult struct {
@@ -20,12 +43,39 @@ type SearchMethodMutationResult struct {
 	Error        string
 }
 
+func NewCollectionSearchResult(collection, searchMethod, status string, objects []*CollectionSearchResultObject, err string) *CollectionSearchResult {
+	if objects == nil {
+		objects = []*CollectionSearchResultObject{}
+	}
+	return &CollectionSearchResult{
+		Collection:   collection,
+		SearchMethod: searchMethod,
+		Status:       status,
+		Objects:      objects,
+		Error:        err,
+	}
+}
+
 type CollectionSearchResult struct {
 	Collection   string
 	SearchMethod string
 	Status       string
 	Objects      []*CollectionSearchResultObject
 	Error        string
+}
+
+func NewCollectionSearchResultObject(namespace, key, text string, labels []string, distance, score float64) *CollectionSearchResultObject {
+	if labels == nil {
+		labels = []string{}
+	}
+	return &CollectionSearchResultObject{
+		Namespace: namespace,
+		Key:       key,
+		Text:      text,
+		Labels:    labels,
+		Distance:  distance,
+		Score:     score,
+	}
 }
 
 type CollectionSearchResultObject struct {
@@ -37,6 +87,23 @@ type CollectionSearchResultObject struct {
 	Score     float64
 }
 
+func NewCollectionClassificationResult(collection, searchMethod, status string, labelsResult []*CollectionClassificationLabelObject, cluster []*CollectionClassificationResultObject, err string) *CollectionClassificationResult {
+	if labelsResult == nil {
+		labelsResult = []*CollectionClassificationLabelObject{}
+	}
+	if cluster == nil {
+		cluster = []*CollectionClassificationResultObject{}
+	}
+	return &CollectionClassificationResult{
+		Collection:   collection,
+		SearchMethod: searchMethod,
+		Status:       status,
+		LabelsResult: labelsResult,
+		Cluster:      cluster,
+		Error:        err,
+	}
+}
+
 type CollectionClassificationResult struct {
 	Collection   string
 	SearchMethod string
@@ -46,9 +113,28 @@ type CollectionClassificationResult struct {
 	Error        string
 }
 
+func NewCollectionClassificationLabelObject(label string, confidence float64) *CollectionClassificationLabelObject {
+	return &CollectionClassificationLabelObject{
+		Label:      label,
+		Confidence: confidence,
+	}
+}
+
 type CollectionClassificationLabelObject struct {
 	Label      string
 	Confidence float64
+}
+
+func NewCollectionClassificationResultObject(key string, labels []string, distance, score float64) *CollectionClassificationResultObject {
+	if labels == nil {
+		labels = []string{}
+	}
+	return &CollectionClassificationResultObject{
+		Key:      key,
+		Labels:   labels,
+		Distance: distance,
+		Score:    score,
+	}
 }
 
 type CollectionClassificationResultObject struct {


### PR DESCRIPTION
HYP-2258
assemblyscript collections sdk is reporting this error on search:
`"error":"failed to write array item: unexpected nil value for non-nullable type`
This is because labels slices are nullable in golang, but assemblyscript arrays are non nullable. To fix this, we're catching all nil arrays and returning that as empty arrays in the collection host functions