### PR TITLE
Update error handling for function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Arrays in collections host functions should be non-nil [#384](https://github.com/hypermodeAI/runtime/pull/384)
+- Update error handling for function calls [#385](https://github.com/hypermodeAI/runtime/pull/385)
 
 ## 2024-09-24 - Version 0.12.2
 


### PR DESCRIPTION
Previously, any error returned from a function call was logged with `user_visible=true` so it would appear in the function run logs.  That's problematic because some errors, such as errors in the type handlers, are out of the user's direct control and actually need to be reported without user visibility so we get notice of them via Sentry.

Additionally, we were treating all `exit` responses as errors, even if they were exit code 0 - which is traditionally a non-error result code.

This PR updates the error handling such that:
- Runtime errors are not logged with user visibility
- Exit code 0 is a warning rather than an error

Errors caused via exception or panic in the user's code will already be logged by the SDK through a call to the `log` host function, and then exited with a non-zero exit code, so they don't need any special treatment here.