### PR TITLE
Trap JSON unsupported value errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update error handling for function calls [#385](https://github.com/hypermodeAI/runtime/pull/385)
 - Fix array-like types passed via interface wrappers [#386](https://github.com/hypermodeAI/runtime/pull/386)
 - Cast slice values to handle json.Number and others [#387](https://github.com/hypermodeAI/runtime/pull/387)
-
+- Trap JSON unsupported value errors [#388](https://github.com/hypermodeAI/runtime/pull/388)
 
 ## 2024-09-24 - Version 0.12.2
 


### PR DESCRIPTION
If a function completes successfully, but its result is a floating point value of `Nan`, `Infinity` or `-Infinity`, or it is an object (class, struct, slice, array, map, etc.) that contains such a value, then we will get an error when trying to serialize the response, such as:

```
json: unsupported value: NaN
```

This is due to default behavior of Go's `json` encoder.  See https://github.com/golang/go/issues/3480

We can, however, trap this error and give a more useful warning in the logs, and a more useful GraphQL error response.