### PR TITLE
Fix field alignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Fix field alignment issue [#393](https://github.com/hypermodeAI/runtime/pull/393)
+
 ## 2024-09-26 - Version 0.12.3
 
 - Arrays in collections host functions should be non-nil [#384](https://github.com/hypermodeAI/runtime/pull/384)

--- a/langsupport/typeinfo.go
+++ b/langsupport/typeinfo.go
@@ -136,7 +136,6 @@ func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typ
 		}
 
 		offset := uint32(0)
-		maxAlignment := uint32(0)
 		info.fieldTypes = make([]TypeInfo, len(def.Fields))
 		info.fieldOffsets = make([]uint32, len(def.Fields))
 		for i, field := range def.Fields {
@@ -151,13 +150,20 @@ func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typ
 			offset = AlignOffset(offset, alignment)
 			info.fieldOffsets[i] = offset
 			offset += size
-
-			if alignment > maxAlignment {
-				maxAlignment = alignment
-			}
 		}
-		info.dataSize = AlignOffset(offset, maxAlignment)
-		info.alignment = maxAlignment
+
+		if size, err := lti.GetDataSizeOfType(ctx, typeName); err != nil {
+			return nil, err
+		} else {
+			info.dataSize = size
+		}
+
+		if alignment, err := lti.GetAlignmentOfType(ctx, typeName); err != nil {
+			return nil, err
+		} else {
+			info.alignment = alignment
+		}
+
 	}
 
 	info.flags = flags


### PR DESCRIPTION
In Go, a struct's alignment is the maximum of any of its field's alignments.  But in AssemblyScript, a class's alignment is always the pointer word size (4 bytes), regardless of its fields.

We had this in the language implementations, but weren't using it correctly in the common langsupport code.
