### PR TITLE
Fix AssemblyScript error unpinning objects from memory 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Fix AssemblyScript error unpinning objects from memory [#396](https://github.com/hypermodeAI/runtime/pull/396)
+
 ## 2024-09-26 - Version 0.12.4
 
 - Fix field alignment issue [#393](https://github.com/hypermodeAI/runtime/pull/393)

--- a/languages/assemblyscript/handler_objects.go
+++ b/languages/assemblyscript/handler_objects.go
@@ -186,12 +186,14 @@ func (h *managedObjectHandler) doWrite(ctx context.Context, wa langsupport.WasmA
 		return 0, cln, err
 	}
 
+	// TODO: the following should work, but it in some cases we are finding that the inner objects fail to unpin even though they were successfully pinned
+
 	// we can unpin the inner objects early, since they are now referenced by the managed object
-	if c != nil {
-		if err := c.Clean(); err != nil {
-			return 0, cln, err
-		}
-	}
+	// if c != nil {
+	// 	if err := c.Clean(); err != nil {
+	// 		return 0, cln, err
+	// 	}
+	// }
 
 	return ptr, cln, nil
 }


### PR DESCRIPTION
For some unknown reason, attempting to unpin an object is failing, even though it was successfully pinned.

It's good memory management, but it's not critical so for now I'll just comment it out.