### PR TITLE
Revert #393 and #396, then apply correct fix for field alignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Revert #393 and #396, then apply correct fix for field alignment issue [#397](https://github.com/hypermodeAI/runtime/pull/397)
+
 ## 2024-09-26 - Version 0.12.5
 
 - Fix AssemblyScript error unpinning objects from memory [#396](https://github.com/hypermodeAI/runtime/pull/396)

--- a/langsupport/langtypeinfo.go
+++ b/langsupport/langtypeinfo.go
@@ -15,6 +15,7 @@ type LanguageTypeInfo interface {
 	GetAlignmentOfType(ctx context.Context, typ string) (uint32, error)
 	GetDataSizeOfType(ctx context.Context, typ string) (uint32, error)
 	GetEncodingLengthOfType(ctx context.Context, typ string) (uint32, error)
+	ObjectsUseMaxFieldAlignment() bool
 
 	GetListSubtype(typ string) string
 	GetMapSubtypes(typ string) (string, string)

--- a/langsupport/typeinfo.go
+++ b/langsupport/typeinfo.go
@@ -136,6 +136,7 @@ func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typ
 		}
 
 		offset := uint32(0)
+		maxAlignment := uint32(0)
 		info.fieldTypes = make([]TypeInfo, len(def.Fields))
 		info.fieldOffsets = make([]uint32, len(def.Fields))
 		for i, field := range def.Fields {
@@ -150,20 +151,13 @@ func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typ
 			offset = AlignOffset(offset, alignment)
 			info.fieldOffsets[i] = offset
 			offset += size
-		}
 
-		if size, err := lti.GetDataSizeOfType(ctx, typeName); err != nil {
-			return nil, err
-		} else {
-			info.dataSize = size
+			if alignment > maxAlignment {
+				maxAlignment = alignment
+			}
 		}
-
-		if alignment, err := lti.GetAlignmentOfType(ctx, typeName); err != nil {
-			return nil, err
-		} else {
-			info.alignment = alignment
-		}
-
+		info.dataSize = AlignOffset(offset, maxAlignment)
+		info.alignment = maxAlignment
 	}
 
 	info.flags = flags

--- a/langsupport/typeinfo.go
+++ b/langsupport/typeinfo.go
@@ -157,7 +157,10 @@ func GetTypeInfo(ctx context.Context, lti LanguageTypeInfo, typeName string, typ
 			}
 		}
 		info.dataSize = AlignOffset(offset, maxAlignment)
-		info.alignment = maxAlignment
+
+		if lti.ObjectsUseMaxFieldAlignment() {
+			info.alignment = maxAlignment
+		}
 	}
 
 	info.flags = flags

--- a/languages/assemblyscript/handler_objects.go
+++ b/languages/assemblyscript/handler_objects.go
@@ -186,14 +186,12 @@ func (h *managedObjectHandler) doWrite(ctx context.Context, wa langsupport.WasmA
 		return 0, cln, err
 	}
 
-	// TODO: the following should work, but it in some cases we are finding that the inner objects fail to unpin even though they were successfully pinned
-
 	// we can unpin the inner objects early, since they are now referenced by the managed object
-	// if c != nil {
-	// 	if err := c.Clean(); err != nil {
-	// 		return 0, cln, err
-	// 	}
-	// }
+	if c != nil {
+		if err := c.Clean(); err != nil {
+			return 0, cln, err
+		}
+	}
 
 	return ptr, cln, nil
 }

--- a/languages/assemblyscript/typeinfo.go
+++ b/languages/assemblyscript/typeinfo.go
@@ -206,6 +206,11 @@ func (lti *langTypeInfo) GetAlignmentOfType(ctx context.Context, typ string) (ui
 	return lti.GetSizeOfType(ctx, typ)
 }
 
+func (lti *langTypeInfo) ObjectsUseMaxFieldAlignment() bool {
+	// AssemblyScript classes are aligned to the pointer size (4 bytes), not the max field alignment.
+	return false
+}
+
 func (lti *langTypeInfo) GetDataSizeOfType(ctx context.Context, typ string) (uint32, error) {
 	switch typ {
 	case "u64", "i64", "f64":

--- a/languages/golang/typeinfo.go
+++ b/languages/golang/typeinfo.go
@@ -316,6 +316,11 @@ func (lti *langTypeInfo) GetAlignmentOfType(ctx context.Context, typ string) (ui
 	return lti.getAlignmentOfStruct(ctx, typ)
 }
 
+func (lti *langTypeInfo) ObjectsUseMaxFieldAlignment() bool {
+	// Go structs are aligned to the maximum alignment of their fields
+	return true
+}
+
 func (lti *langTypeInfo) getAlignmentOfStruct(ctx context.Context, typ string) (uint32, error) {
 	def, err := lti.GetTypeDefinition(ctx, typ)
 	if err != nil {


### PR DESCRIPTION
After getting even more errors, a closer look showed that the fix in #393 was in error, and the cause of #396.  Reverted the both, and fixed the original issue properly.