### PR TITLE
Use reader-writer lock on AWS secrets cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Use reader-writer lock on AWS secrets cache [#400](https://github.com/hypermodeAI/runtime/pull/400)
+
 ## 2024-09-26 - Version 0.12.6
 
 - Revert #393 and #396, then apply correct fix for field alignment issue [#397](https://github.com/hypermodeAI/runtime/pull/397)


### PR DESCRIPTION
This will ensure that any calls to read secrets from the cache will block until the cache is fully populated on initialization, and whenever its being updated.

That should hopefully resolve the intermittent `secret HYPERMODE_METADATA_DB not found` errors we've been seeing.