### PR TITLE
Fix error on null or void response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improve bucket layout for FunctionExecutionDurationMilliseconds metric and add function_name label [#401](https://github.com/hypermodeAI/runtime/pull/401)
 - Improve JSON performance [#402](https://github.com/hypermodeAI/runtime/pull/402)
 - Misc performance improvements [#403](https://github.com/hypermodeAI/runtime/pull/403)
+- Fix error on void response [#404](https://github.com/hypermodeAI/runtime/pull/404)
 
 ## 2024-09-26 - Version 0.12.6
 

--- a/graphql/datasource/source.go
+++ b/graphql/datasource/source.go
@@ -125,9 +125,9 @@ func writeGraphQLResponse(ctx context.Context, out *bytes.Buffer, result any, gq
 		}
 	}
 
-	// Get the data as json from the result
+	// If there is any result data, or if the data is null without errors, serialize the data as json
 	var jsonData []byte
-	if result != nil {
+	if result != nil || len(gqlErrors) == 0 {
 		jsonResult, err := utils.JsonSerialize(result)
 		if err != nil {
 			if err, ok := err.(*json.UnsupportedValueError); ok {


### PR DESCRIPTION
Fix for a small bug created with #402 related to not returning data when the response is supposed to be `null` (or `void`)