### PR TITLE
Remove extra comma

### DIFF
--- a/pkg/manifest/collection.go
+++ b/pkg/manifest/collection.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/dgraph.go
+++ b/pkg/manifest/dgraph.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/http.go
+++ b/pkg/manifest/http.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/model.go
+++ b/pkg/manifest/model.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/postgresql.go
+++ b/pkg/manifest/postgresql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/manifest/test/manifest_test.go
+++ b/pkg/manifest/test/manifest_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/pkg/wasmextractor/wasmextractor.go
+++ b/pkg/wasmextractor/wasmextractor.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -14,7 +14,7 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime
 
 # build the container image
 FROM ubuntu:22.04
-LABEL maintainer="Hypermode, Inc. <hello@hypermode.com>"
+LABEL maintainer="Hypermode Inc. <hello@hypermode.com>"
 
 # add common tools
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/runtime/aws/config.go
+++ b/runtime/aws/config.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/collection.go
+++ b/runtime/collections/collection.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/collections.go
+++ b/runtime/collections/collections.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/factory.go
+++ b/runtime/collections/factory.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/hnsw/vector_index.go
+++ b/runtime/collections/in_mem/hnsw/vector_index.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/hnsw/vector_index_test.go
+++ b/runtime/collections/in_mem/hnsw/vector_index_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/sequential/vector_index.go
+++ b/runtime/collections/in_mem/sequential/vector_index.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/sequential/vector_index_test.go
+++ b/runtime/collections/in_mem/sequential/vector_index_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/text_index.go
+++ b/runtime/collections/in_mem/text_index.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/in_mem/text_index_test.go
+++ b/runtime/collections/in_mem/text_index_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/index/helper.go
+++ b/runtime/collections/index/helper.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/index/index.go
+++ b/runtime/collections/index/index.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/index/interfaces/interfaces.go
+++ b/runtime/collections/index/interfaces/interfaces.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/index/search_path.go
+++ b/runtime/collections/index/search_path.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/types.go
+++ b/runtime/collections/types.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/utils/heap.go
+++ b/runtime/collections/utils/heap.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/utils/heap_test.go
+++ b/runtime/collections/utils/heap_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/utils/helper.go
+++ b/runtime/collections/utils/helper.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/utils/helper_test.go
+++ b/runtime/collections/utils/helper_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/collections/vector.go
+++ b/runtime/collections/vector.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/config/commandline.go
+++ b/runtime/config/commandline.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/config/config.go
+++ b/runtime/config/config.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/config/environment.go
+++ b/runtime/config/environment.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/config/version.go
+++ b/runtime/config/version.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/db/db.go
+++ b/runtime/db/db.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/dgraphclient/dgraph.go
+++ b/runtime/dgraphclient/dgraph.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/dgraphclient/dgraphclient.go
+++ b/runtime/dgraphclient/dgraphclient.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/dgraphclient/registry.go
+++ b/runtime/dgraphclient/registry.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/dgraphclient/types.go
+++ b/runtime/dgraphclient/types.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/functions/events.go
+++ b/runtime/functions/events.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/functions/fninfo.go
+++ b/runtime/functions/fninfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/functions/helpers.go
+++ b/runtime/functions/helpers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/functions/registration.go
+++ b/runtime/functions/registration.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/datasource/configuration.go
+++ b/runtime/graphql/datasource/configuration.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/datasource/factory.go
+++ b/runtime/graphql/datasource/factory.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/datasource/planner.go
+++ b/runtime/graphql/datasource/planner.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/datasource/source.go
+++ b/runtime/graphql/datasource/source.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/engine/engine.go
+++ b/runtime/graphql/engine/engine.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/engine/logging.go
+++ b/runtime/graphql/engine/logging.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/graphql.go
+++ b/runtime/graphql/graphql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/schemagen/filters.go
+++ b/runtime/graphql/schemagen/filters.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/schemagen/schemagen.go
+++ b/runtime/graphql/schemagen/schemagen.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/schemagen/schemagen_as_test.go
+++ b/runtime/graphql/schemagen/schemagen_as_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphql/schemagen/schemagen_go_test.go
+++ b/runtime/graphql/schemagen/schemagen_go_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/graphqlclient/graphqlclient.go
+++ b/runtime/graphqlclient/graphqlclient.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/collections.go
+++ b/runtime/hostfunctions/collections.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/compatibility/compatibility.go
+++ b/runtime/hostfunctions/compatibility/compatibility.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/compatibility/compatibility_test.go
+++ b/runtime/hostfunctions/compatibility/compatibility_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/database.go
+++ b/runtime/hostfunctions/database.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/dgraph.go
+++ b/runtime/hostfunctions/dgraph.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/graphql.go
+++ b/runtime/hostfunctions/graphql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/hostfunctions.go
+++ b/runtime/hostfunctions/hostfunctions.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/http.go
+++ b/runtime/hostfunctions/http.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/legacy.go
+++ b/runtime/hostfunctions/legacy.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/log.go
+++ b/runtime/hostfunctions/log.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hostfunctions/models.go
+++ b/runtime/hostfunctions/models.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/hosts/hosts.go
+++ b/runtime/hosts/hosts.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/httpclient/fetch.go
+++ b/runtime/httpclient/fetch.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/httpclient/types.go
+++ b/runtime/httpclient/types.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/httpserver/server.go
+++ b/runtime/httpserver/server.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/integration_tests/postgresql_integration_test.go
+++ b/runtime/integration_tests/postgresql_integration_test.go
@@ -1,11 +1,11 @@
 //go:build integration
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/executionplan.go
+++ b/runtime/langsupport/executionplan.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/langtypeinfo.go
+++ b/runtime/langsupport/langtypeinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/language.go
+++ b/runtime/langsupport/language.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/planner.go
+++ b/runtime/langsupport/planner.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/primitives/converters.go
+++ b/runtime/langsupport/primitives/converters.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/primitives/decoders.go
+++ b/runtime/langsupport/primitives/decoders.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/primitives/encoders.go
+++ b/runtime/langsupport/primitives/encoders.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/primitives/readers.go
+++ b/runtime/langsupport/primitives/readers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/primitives/writers.go
+++ b/runtime/langsupport/primitives/writers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/typehandler.go
+++ b/runtime/langsupport/typehandler.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/typeinfo.go
+++ b/runtime/langsupport/typeinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/utils.go
+++ b/runtime/langsupport/utils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/langsupport/wasmadapter.go
+++ b/runtime/langsupport/wasmadapter.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/adapter.go
+++ b/runtime/languages/assemblyscript/adapter.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_arraybuffers.go
+++ b/runtime/languages/assemblyscript/handler_arraybuffers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_arrays.go
+++ b/runtime/languages/assemblyscript/handler_arrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_classes.go
+++ b/runtime/languages/assemblyscript/handler_classes.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_dates.go
+++ b/runtime/languages/assemblyscript/handler_dates.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_maps.go
+++ b/runtime/languages/assemblyscript/handler_maps.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_objects.go
+++ b/runtime/languages/assemblyscript/handler_objects.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_primitivearrays.go
+++ b/runtime/languages/assemblyscript/handler_primitivearrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_primitives.go
+++ b/runtime/languages/assemblyscript/handler_primitives.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_strings.go
+++ b/runtime/languages/assemblyscript/handler_strings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/handler_typedarrays.go
+++ b/runtime/languages/assemblyscript/handler_typedarrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/hash/hash.go
+++ b/runtime/languages/assemblyscript/hash/hash.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/planner.go
+++ b/runtime/languages/assemblyscript/planner.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/testdata/assembly/arraybuffers.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/arraybuffers.ts
@@ -1,27 +1,27 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function testArrayBufferInput(buffer: ArrayBuffer): void {
-    const view = Uint8Array.wrap(buffer);
-    assert(view.length == 4);
-    assert(view[0] == 1);
-    assert(view[1] == 2);
-    assert(view[2] == 3);
-    assert(view[3] == 4);
+  const view = Uint8Array.wrap(buffer);
+  assert(view.length == 4);
+  assert(view[0] == 1);
+  assert(view[1] == 2);
+  assert(view[2] == 3);
+  assert(view[3] == 4);
 }
 
 export function testArrayBufferOutput(): ArrayBuffer {
-    const buffer = new ArrayBuffer(4);
-    const view = Uint8Array.wrap(buffer);
-    view[0] = 1;
-    view[1] = 2;
-    view[2] = 3;
-    view[3] = 4;
-    return buffer;
+  const buffer = new ArrayBuffer(4);
+  const view = Uint8Array.wrap(buffer);
+  view[0] = 1;
+  view[1] = 2;
+  view[2] = 3;
+  view[3] = 4;
+  return buffer;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/arrays.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/arrays.ts
@@ -1,107 +1,111 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function testArrayOutput_i8(): i8[] {
-    return [1, 2, 3];
+  return [1, 2, 3];
 }
 
 export function testArrayInput_i8(arr: i8[]): void {
-    assert(arr.length == 3);
-    assert(arr[0] == 1);
-    assert(arr[1] == 2);
-    assert(arr[2] == 3);
+  assert(arr.length == 3);
+  assert(arr[0] == 1);
+  assert(arr[1] == 2);
+  assert(arr[2] == 3);
 }
 
 export function testArrayOutput_i8_empty(): i8[] {
-    return [];
+  return [];
 }
 
 export function testArrayInput_i8_empty(arr: i8[]): void {
-    assert(arr.length == 0);
+  assert(arr.length == 0);
 }
 
 export function testArrayOutput_i8_null(): i8[] | null {
-    return null;
+  return null;
 }
 
 export function testArrayInput_i8_null(arr: i8[] | null): void {
-    assert(arr == null);
+  assert(arr == null);
 }
 
 export function testArrayInput_i32(arr: i32[]): void {
-    assert(arr.length == 3);
-    assert(arr[0] == 1);
-    assert(arr[1] == 2);
-    assert(arr[2] == 3);
+  assert(arr.length == 3);
+  assert(arr[0] == 1);
+  assert(arr[1] == 2);
+  assert(arr[2] == 3);
 }
 
 export function testArrayOutput_i32(): i32[] {
-    return [1, 2, 3];
+  return [1, 2, 3];
 }
 
 export function testArrayInput_f32(arr: f32[]): void {
-    assert(arr.length == 3);
-    assert(arr[0] == 1);
-    assert(arr[1] == 2);
-    assert(arr[2] == 3);
+  assert(arr.length == 3);
+  assert(arr[0] == 1);
+  assert(arr[1] == 2);
+  assert(arr[2] == 3);
 }
 
 export function testArrayOutput_f32(): f32[] {
-    return [1, 2, 3];
+  return [1, 2, 3];
 }
 
 export function testArrayInput_string(arr: string[]): void {
-    assert(arr.length == 3);
-    assert(arr[0] == "abc");
-    assert(arr[1] == "def");
-    assert(arr[2] == "ghi");
+  assert(arr.length == 3);
+  assert(arr[0] == "abc");
+  assert(arr[1] == "def");
+  assert(arr[2] == "ghi");
 }
 
 export function testArrayOutput_string(): string[] {
-    return ["abc", "def", "ghi"];
+  return ["abc", "def", "ghi"];
 }
 
 export function testArrayInput_string_2d(arr: string[][]): void {
-    assert(arr.length == 3);
-    assert(arr[0].length == 3);
-    assert(arr[0][0] == "abc");
-    assert(arr[0][1] == "def");
-    assert(arr[0][2] == "ghi");
-    assert(arr[1].length == 3);
-    assert(arr[1][0] == "jkl");
-    assert(arr[1][1] == "mno");
-    assert(arr[1][2] == "pqr");
-    assert(arr[2].length == 3);
-    assert(arr[2][0] == "stu");
-    assert(arr[2][1] == "vwx");
-    assert(arr[2][2] == "yz");
+  assert(arr.length == 3);
+  assert(arr[0].length == 3);
+  assert(arr[0][0] == "abc");
+  assert(arr[0][1] == "def");
+  assert(arr[0][2] == "ghi");
+  assert(arr[1].length == 3);
+  assert(arr[1][0] == "jkl");
+  assert(arr[1][1] == "mno");
+  assert(arr[1][2] == "pqr");
+  assert(arr[2].length == 3);
+  assert(arr[2][0] == "stu");
+  assert(arr[2][1] == "vwx");
+  assert(arr[2][2] == "yz");
 }
 
 export function testArrayOutput_string_2d(): string[][] {
-    return [["abc", "def", "ghi"], ["jkl", "mno", "pqr"], ["stu", "vwx", "yz"]];
+  return [
+    ["abc", "def", "ghi"],
+    ["jkl", "mno", "pqr"],
+    ["stu", "vwx", "yz"],
+  ];
 }
 
 export function testArrayInput_string_2d_empty(arr: string[][]): void {
-    assert(arr.length == 0);
+  assert(arr.length == 0);
 }
 
 export function testArrayOutput_string_2d_empty(): string[][] {
-    return [];
+  return [];
 }
 
 class TestObject1 {
-    constructor(public a: i32, public b: i32) { }
+  constructor(public a: i32, public b: i32) {}
 }
 
 export function testArrayIteration(arr: TestObject1[]): void {
-    for (let i = 0; i < arr.length; i++) {
-        let obj = arr[i];
-        console.log(`[${i}]: a=${obj.a}, b=${obj.b}`);
-    }
+  for (let i = 0; i < arr.length; i++) {
+    let obj = arr[i];
+    console.log(`[${i}]: a=${obj.a}, b=${obj.b}`);
+  }
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/classes.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/classes.ts
@@ -1,72 +1,72 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 class TestClass1 {
-    a!: bool;
+  a!: bool;
 }
 
 class TestClass1_map {
-    a!: bool;
+  a!: bool;
 }
 
 class TestClass2 {
-    a!: bool;
-    b!: isize;
+  a!: bool;
+  b!: isize;
 }
 
 class TestClass2_map {
-    a!: bool;
-    b!: isize;
+  a!: bool;
+  b!: isize;
 }
 
 class TestClass3 {
-    a!: bool;
-    b!: isize;
-    c!: string;
+  a!: bool;
+  b!: isize;
+  c!: string;
 }
 
 class TestClass3_map {
-    a!: bool;
-    b!: isize;
-    c!: string;
+  a!: bool;
+  b!: isize;
+  c!: string;
 }
 
 class TestClass4 {
-    a!: bool;
-    b!: isize;
-    c!: string | null;
+  a!: bool;
+  b!: isize;
+  c!: string | null;
 }
 
 class TestClass4_map {
-    a!: bool;
-    b!: isize;
-    c!: string | null;
+  a!: bool;
+  b!: isize;
+  c!: string | null;
 }
 
 class TestClass5 {
-    a!: bool;
-    b!: TestClass3;
+  a!: bool;
+  b!: TestClass3;
 }
 
 class TestClass5_map {
-    a!: bool;
-    b!: TestClass3_map;
+  a!: bool;
+  b!: TestClass3_map;
 }
 
 class TestRecursiveClass {
-    a!: bool;
-    b!: TestRecursiveClass | null;
+  a!: bool;
+  b!: TestRecursiveClass | null;
 }
 
 class TestRecursiveClass_map {
-    a!: bool;
-    b!: TestRecursiveClass_map | null;
+  a!: bool;
+  b!: TestRecursiveClass_map | null;
 }
 
 const testClass1 = <TestClass1>{ a: true };
@@ -90,110 +90,109 @@ const testRecursiveClass_map = <TestRecursiveClass_map>{ a: true };
 testRecursiveClass_map.b = testRecursiveClass_map;
 
 export function testClassInput1(o: TestClass1): void {
-    assert(o.a == testClass1.a);
+  assert(o.a == testClass1.a);
 }
 
 export function testClassOutput1(): TestClass1 {
-    return testClass1;
+  return testClass1;
 }
 
 export function testClassOutput1_map(): TestClass1_map {
-    return testClass1_map;
+  return testClass1_map;
 }
 
 export function testClassInput2(o: TestClass2): void {
-    assert(o.a == testClass2.a);
-    assert(o.b == testClass2.b);
+  assert(o.a == testClass2.a);
+  assert(o.b == testClass2.b);
 }
 
 export function testClassOutput2(): TestClass2 {
-    return testClass2;
+  return testClass2;
 }
 
 export function testClassOutput2_map(): TestClass2_map {
-    return testClass2_map;
+  return testClass2_map;
 }
 
 export function testClassInput3(o: TestClass3): void {
-    assert(o.a == testClass3.a);
-    assert(o.b == testClass3.b);
-    assert(o.c == testClass3.c);
+  assert(o.a == testClass3.a);
+  assert(o.b == testClass3.b);
+  assert(o.c == testClass3.c);
 }
 
 export function testClassOutput3(): TestClass3 {
-    return testClass3;
+  return testClass3;
 }
 
 export function testClassOutput3_map(): TestClass3_map {
-    return testClass3_map;
+  return testClass3_map;
 }
 
-
 export function testClassInput4_withNull(o: TestClass4): void {
-    assert(o.a == testClass4_withNull.a);
-    assert(o.b == testClass4_withNull.b);
-    assert(o.c == testClass4_withNull.c);
+  assert(o.a == testClass4_withNull.a);
+  assert(o.b == testClass4_withNull.b);
+  assert(o.c == testClass4_withNull.c);
 }
 
 export function testClassOutput4(): TestClass4 {
-    return testClass4;
+  return testClass4;
 }
 
 export function testClassOutput4_map(): TestClass4_map {
-    return testClass4_map;
+  return testClass4_map;
 }
 
 export function testClassInput4(o: TestClass4): void {
-    assert(o.a == testClass4.a);
-    assert(o.b == testClass4.b);
-    assert(o.c == testClass4.c);
+  assert(o.a == testClass4.a);
+  assert(o.b == testClass4.b);
+  assert(o.c == testClass4.c);
 }
 
 export function testClassOutput4_withNull(): TestClass4 {
-    return testClass4_withNull;
+  return testClass4_withNull;
 }
 
 export function testClassOutput4_map_withNull(): TestClass4_map {
-    return testClass4_map_withNull;
+  return testClass4_map_withNull;
 }
 
 export function testClassInput5(o: TestClass5): void {
-    assert(o.a == testClass5.a);
-    assert(o.b.a == testClass5.b.a);
-    assert(o.b.b == testClass5.b.b);
-    assert(o.b.c == testClass5.b.c);
+  assert(o.a == testClass5.a);
+  assert(o.b.a == testClass5.b.a);
+  assert(o.b.b == testClass5.b.b);
+  assert(o.b.c == testClass5.b.c);
 }
 
 export function testClassOutput5(): TestClass5 {
-    return testClass5;
+  return testClass5;
 }
 
 export function testClassOutput5_map(): TestClass5_map {
-    return testClass5_map;
+  return testClass5_map;
 }
 
 export function testRecursiveClassInput(o: TestRecursiveClass): void {
-    assert(o.a == testRecursiveClass.a);
-    assert(o.b == testRecursiveClass.b);
+  assert(o.a == testRecursiveClass.a);
+  assert(o.b == testRecursiveClass.b);
 }
 
 export function testRecursiveClassOutput(): TestRecursiveClass {
-    return testRecursiveClass;
+  return testRecursiveClass;
 }
 
 export function testNullableClassInput1(o: TestClass1 | null): void {
-    assert(o != null);
-    assert(o!.a == testClass1.a);
+  assert(o != null);
+  assert(o!.a == testClass1.a);
 }
 
 export function testNullableClassOutput1(): TestClass1 | null {
-    return testClass1;
+  return testClass1;
 }
 
 export function testNullableClassInput1_null(o: TestClass1 | null): void {
-    assert(o == null);
+  assert(o == null);
 }
 
 export function testNullableClassOutput1_null(): TestClass1 | null {
-    return null;
+  return null;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/dates.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/dates.ts
@@ -1,38 +1,38 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 const testTime = Date.parse("2024-12-31T23:59:59.999Z").getTime();
 
 export function testDateInput(d: Date): void {
-    const ts = d.getTime();
-    assert(ts == testTime, `Expected ${testTime}, got ${ts}`);
+  const ts = d.getTime();
+  assert(ts == testTime, `Expected ${testTime}, got ${ts}`);
 }
 
 export function testDateOutput(): Date {
-    return new Date(testTime);
+  return new Date(testTime);
 }
 
 export function testNullDateInput(d: Date | null): void {
-    assert(d != null, `Expected non-null, got null`);
+  assert(d != null, `Expected non-null, got null`);
 
-    const ts = d!.getTime();
-    assert(ts == testTime, `Expected ${testTime}, got ${ts}`);
+  const ts = d!.getTime();
+  assert(ts == testTime, `Expected ${testTime}, got ${ts}`);
 }
 
 export function testNullDateOutput(): Date | null {
-    return new Date(testTime);
+  return new Date(testTime);
 }
 
 export function testNullDateInput_null(d: Date | null): void {
-    assert(d == null, `Expected null, got ${d!.getTime()}`);
+  assert(d == null, `Expected null, got ${d!.getTime()}`);
 }
 
 export function testNullDateOutput_null(): Date | null {
-    return null;
+  return null;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/env.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/env.ts
@@ -1,25 +1,25 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function now(): i64 {
-    return Date.now();
+  return Date.now();
 }
 
 export function spin(duration: i64): i64 {
-    const start = performance.now();
+  const start = performance.now();
 
-    let d = Date.now();
-    while (Date.now() - d <= duration) {
-        // do nothing
-    }
+  let d = Date.now();
+  while (Date.now() - d <= duration) {
+    // do nothing
+  }
 
-    const end = performance.now();
+  const end = performance.now();
 
-    return i64(end - start);
+  return i64(end - start);
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/hostfns.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/hostfns.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/testdata/assembly/index.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/testdata/assembly/maps.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/maps.ts
@@ -1,125 +1,140 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function testMapInput_u8_string(m: Map<u8, string>): void {
-    assert(m.size == 3, "expected size 3");
+  assert(m.size == 3, "expected size 3");
 
-    assert(m.has(1), "expected key 1 to be present");
-    assert(m.get(1) == "a", "expected value for key 1 to be 'a'");
+  assert(m.has(1), "expected key 1 to be present");
+  assert(m.get(1) == "a", "expected value for key 1 to be 'a'");
 
-    assert(m.has(2), "expected key 2 to be present");
-    assert(m.get(2) == "b", "expected value for key 2 to be 'b'");
+  assert(m.has(2), "expected key 2 to be present");
+  assert(m.get(2) == "b", "expected value for key 2 to be 'b'");
 
-    assert(m.has(3), "expected key 3 to be present");
-    assert(m.get(3) == "c", "expected value for key 3 to be 'c'");
+  assert(m.has(3), "expected key 3 to be present");
+  assert(m.get(3) == "c", "expected value for key 3 to be 'c'");
 }
 
 export function testMapOutput_u8_string(): Map<u8, string> {
-    const m = new Map<u8, string>();
-    m.set(1, "a");
-    m.set(2, "b");
-    m.set(3, "c");
-    return m;
+  const m = new Map<u8, string>();
+  m.set(1, "a");
+  m.set(2, "b");
+  m.set(3, "c");
+  return m;
 }
 
 export function testMapInput_string_string(m: Map<string, string>): void {
-    assert(m.size == 3, "expected size 3");
+  assert(m.size == 3, "expected size 3");
 
-    assert(m.has("a"), "expected key 'a' to be present");
-    assert(m.get("a") == "1", "expected value for key 'a' to be '1'");
+  assert(m.has("a"), "expected key 'a' to be present");
+  assert(m.get("a") == "1", "expected value for key 'a' to be '1'");
 
-    assert(m.has("b"), "expected key 'b' to be present");
-    assert(m.get("b") == "2", "expected value for key 'b' to be '2'");
+  assert(m.has("b"), "expected key 'b' to be present");
+  assert(m.get("b") == "2", "expected value for key 'b' to be '2'");
 
-    assert(m.has("c"), "expected key 'c' to be present");
-    assert(m.get("c") == "3", "expected value for key 'c' to be '3'");
+  assert(m.has("c"), "expected key 'c' to be present");
+  assert(m.get("c") == "3", "expected value for key 'c' to be '3'");
 }
 
 export function testMapOutput_string_string(): Map<string, string> {
-    const m = new Map<string, string>();
-    m.set("a", "1");
-    m.set("b", "2");
-    m.set("c", "3");
-    return m;
+  const m = new Map<string, string>();
+  m.set("a", "1");
+  m.set("b", "2");
+  m.set("c", "3");
+  return m;
 }
 
-export function testNullableMapInput_string_string(m: Map<string, string> | null): void {
-    assert(m != null, "expected non-null map");
-    assert(m!.size == 3, "expected size 3");
+export function testNullableMapInput_string_string(
+  m: Map<string, string> | null
+): void {
+  assert(m != null, "expected non-null map");
+  assert(m!.size == 3, "expected size 3");
 
-    assert(m!.has("a"), "expected key 'a' to be present");
-    assert(m!.get("a") == "1", "expected value for key 'a' to be '1'");
+  assert(m!.has("a"), "expected key 'a' to be present");
+  assert(m!.get("a") == "1", "expected value for key 'a' to be '1'");
 
-    assert(m!.has("b"), "expected key 'b' to be present");
-    assert(m!.get("b") == "2", "expected value for key 'b' to be '2'");
+  assert(m!.has("b"), "expected key 'b' to be present");
+  assert(m!.get("b") == "2", "expected value for key 'b' to be '2'");
 
-    assert(m!.has("c"), "expected key 'c' to be present");
-    assert(m!.get("c") == "3", "expected value for key 'c' to be '3'");
+  assert(m!.has("c"), "expected key 'c' to be present");
+  assert(m!.get("c") == "3", "expected value for key 'c' to be '3'");
 }
 
-export function testNullableMapInput_string_string_null(m: Map<string, string> | null): void {
-    assert(m == null, "expected null map");
+export function testNullableMapInput_string_string_null(
+  m: Map<string, string> | null
+): void {
+  assert(m == null, "expected null map");
 }
 
-export function testNullableMapOutput_string_string(): Map<string, string> | null {
-    const m = new Map<string, string>();
-    m.set("a", "1");
-    m.set("b", "2");
-    m.set("c", "3");
-    return m;
+export function testNullableMapOutput_string_string(): Map<
+  string,
+  string
+> | null {
+  const m = new Map<string, string>();
+  m.set("a", "1");
+  m.set("b", "2");
+  m.set("c", "3");
+  return m;
 }
 
-export function testNullableMapOutput_string_string_null(): Map<string, string> | null {
-    return null;
+export function testNullableMapOutput_string_string_null(): Map<
+  string,
+  string
+> | null {
+  return null;
 }
 
 export function testIterateMap_string_string(m: Map<string, string>): void {
-    const keys = m.keys();
-    const values = m.values();
-    for (let i = 0; i < m.size; i++) {
-        const key = keys[i];
-        const value = values[i];
-        console.log(key + " => " + value);
-    }
+  const keys = m.keys();
+  const values = m.values();
+  for (let i = 0; i < m.size; i++) {
+    const key = keys[i];
+    const value = values[i];
+    console.log(key + " => " + value);
+  }
 }
 
-export function testMapLookup_string_string(m: Map<string, string>, key: string): string | null {
-    if (m.has(key)) {
-        return m.get(key);
-    }
-    return null;
+export function testMapLookup_string_string(
+  m: Map<string, string>,
+  key: string
+): string | null {
+  if (m.has(key)) {
+    return m.get(key);
+  }
+  return null;
 }
 
 class TestClassWithMap {
-    m!: Map<string, string>;
+  m!: Map<string, string>;
 }
 
-export function testClassContainingMapInput_string_string(c: TestClassWithMap): void {
-    assert(c != null, "expected non-null class");
-    assert(c.m != null, "expected non-null map");
-    assert(c.m.size == 3, "expected size 3");
+export function testClassContainingMapInput_string_string(
+  c: TestClassWithMap
+): void {
+  assert(c != null, "expected non-null class");
+  assert(c.m != null, "expected non-null map");
+  assert(c.m.size == 3, "expected size 3");
 
-    assert(c.m.has("a"), "expected key 'a' to be present");
-    assert(c.m.get("a") == "1", "expected value for key 'a' to be '1'");
+  assert(c.m.has("a"), "expected key 'a' to be present");
+  assert(c.m.get("a") == "1", "expected value for key 'a' to be '1'");
 
-    assert(c.m.has("b"), "expected key 'b' to be present");
-    assert(c.m.get("b") == "2", "expected value for key 'b' to be '2'");
+  assert(c.m.has("b"), "expected key 'b' to be present");
+  assert(c.m.get("b") == "2", "expected value for key 'b' to be '2'");
 
-    assert(c.m.has("c"), "expected key 'c' to be present");
-    assert(c.m.get("c") == "3", "expected value for key 'c' to be '3'");
+  assert(c.m.has("c"), "expected key 'c' to be present");
+  assert(c.m.get("c") == "3", "expected value for key 'c' to be '3'");
 }
 
 export function testClassContainingMapOutput_string_string(): TestClassWithMap {
-    const c = new TestClassWithMap();
-    c.m = new Map<string, string>();
-    c.m.set("a", "1");
-    c.m.set("b", "2");
-    c.m.set("c", "3");
-    return c;
+  const c = new TestClassWithMap();
+  c.m = new Map<string, string>();
+  c.m.set("a", "1");
+  c.m.set("b", "2");
+  c.m.set("c", "3");
+  return c;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/primitives.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/primitives.ts
@@ -1,216 +1,216 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function testBoolInput_false(b: bool): void {
-    assert(b == false);
+  assert(b == false);
 }
 
 export function testBoolInput_true(b: bool): void {
-    assert(b == true);
+  assert(b == true);
 }
 
 export function testBoolOutput_false(): bool {
-    return false;
+  return false;
 }
 
 export function testBoolOutput_true(): bool {
-    return true;
+  return true;
 }
 
 export function testI8Input_min(n: i8): void {
-    assert(n == i8.MIN_VALUE);
+  assert(n == i8.MIN_VALUE);
 }
 
 export function testI8Input_max(n: i8): void {
-    assert(n == i8.MAX_VALUE);
+  assert(n == i8.MAX_VALUE);
 }
 
 export function testI8Output_min(): i8 {
-    return i8.MIN_VALUE;
+  return i8.MIN_VALUE;
 }
 
 export function testI8Output_max(): i8 {
-    return i8.MAX_VALUE;
+  return i8.MAX_VALUE;
 }
 
 export function testI16Input_min(n: i16): void {
-    assert(n == i16.MIN_VALUE);
+  assert(n == i16.MIN_VALUE);
 }
 
 export function testI16Input_max(n: i16): void {
-    assert(n == i16.MAX_VALUE);
+  assert(n == i16.MAX_VALUE);
 }
 
 export function testI16Output_min(): i16 {
-    return i16.MIN_VALUE;
+  return i16.MIN_VALUE;
 }
 
 export function testI16Output_max(): i16 {
-    return i16.MAX_VALUE;
+  return i16.MAX_VALUE;
 }
 
 export function testI32Input_min(n: i32): void {
-    assert(n == i32.MIN_VALUE);
+  assert(n == i32.MIN_VALUE);
 }
 
 export function testI32Input_max(n: i32): void {
-    assert(n == i32.MAX_VALUE);
+  assert(n == i32.MAX_VALUE);
 }
 
 export function testI32Output_min(): i32 {
-    return i32.MIN_VALUE;
+  return i32.MIN_VALUE;
 }
 
 export function testI32Output_max(): i32 {
-    return i32.MAX_VALUE;
+  return i32.MAX_VALUE;
 }
 
 export function testI64Input_min(n: i64): void {
-    assert(n == i64.MIN_VALUE);
+  assert(n == i64.MIN_VALUE);
 }
 
 export function testI64Input_max(n: i64): void {
-    assert(n == i64.MAX_VALUE);
+  assert(n == i64.MAX_VALUE);
 }
 
 export function testI64Output_min(): i64 {
-    return i64.MIN_VALUE;
+  return i64.MIN_VALUE;
 }
 
 export function testI64Output_max(): i64 {
-    return i64.MAX_VALUE;
+  return i64.MAX_VALUE;
 }
 
 export function testISizeInput_min(n: isize): void {
-    assert(n == isize.MIN_VALUE);
+  assert(n == isize.MIN_VALUE);
 }
 
 export function testISizeInput_max(n: isize): void {
-    assert(n == isize.MAX_VALUE);
+  assert(n == isize.MAX_VALUE);
 }
 
 export function testISizeOutput_min(): isize {
-    return isize.MIN_VALUE;
+  return isize.MIN_VALUE;
 }
 
 export function testISizeOutput_max(): isize {
-    return isize.MAX_VALUE;
+  return isize.MAX_VALUE;
 }
 
 export function testU8Input_min(n: u8): void {
-    assert(n == u8.MIN_VALUE);
+  assert(n == u8.MIN_VALUE);
 }
 
 export function testU8Input_max(n: u8): void {
-    assert(n == u8.MAX_VALUE);
+  assert(n == u8.MAX_VALUE);
 }
 
 export function testU8Output_min(): u8 {
-    return u8.MIN_VALUE;
+  return u8.MIN_VALUE;
 }
 
 export function testU8Output_max(): u8 {
-    return u8.MAX_VALUE;
+  return u8.MAX_VALUE;
 }
 
 export function testU16Input_min(n: u16): void {
-    assert(n == u16.MIN_VALUE);
+  assert(n == u16.MIN_VALUE);
 }
 
 export function testU16Input_max(n: u16): void {
-    assert(n == u16.MAX_VALUE);
+  assert(n == u16.MAX_VALUE);
 }
 
 export function testU16Output_min(): u16 {
-    return u16.MIN_VALUE;
+  return u16.MIN_VALUE;
 }
 
 export function testU16Output_max(): u16 {
-    return u16.MAX_VALUE;
+  return u16.MAX_VALUE;
 }
 
 export function testU32Input_min(n: u32): void {
-    assert(n == u32.MIN_VALUE);
+  assert(n == u32.MIN_VALUE);
 }
 
 export function testU32Input_max(n: u32): void {
-    assert(n == u32.MAX_VALUE);
+  assert(n == u32.MAX_VALUE);
 }
 
 export function testU32Output_min(): u32 {
-    return u32.MIN_VALUE;
+  return u32.MIN_VALUE;
 }
 
 export function testU32Output_max(): u32 {
-    return u32.MAX_VALUE;
+  return u32.MAX_VALUE;
 }
 
 export function testU64Input_min(n: u64): void {
-    assert(n == u64.MIN_VALUE);
+  assert(n == u64.MIN_VALUE);
 }
 
 export function testU64Input_max(n: u64): void {
-    assert(n == u64.MAX_VALUE);
+  assert(n == u64.MAX_VALUE);
 }
 
 export function testU64Output_min(): u64 {
-    return u64.MIN_VALUE;
+  return u64.MIN_VALUE;
 }
 
 export function testU64Output_max(): u64 {
-    return u64.MAX_VALUE;
+  return u64.MAX_VALUE;
 }
 
 export function testUSizeInput_min(n: usize): void {
-    assert(n == usize.MIN_VALUE);
+  assert(n == usize.MIN_VALUE);
 }
 
 export function testUSizeInput_max(n: usize): void {
-    assert(n == usize.MAX_VALUE);
+  assert(n == usize.MAX_VALUE);
 }
 
 export function testUSizeOutput_min(): usize {
-    return usize.MIN_VALUE;
+  return usize.MIN_VALUE;
 }
 
 export function testUSizeOutput_max(): usize {
-    return usize.MAX_VALUE;
+  return usize.MAX_VALUE;
 }
 
 export function testF32Input_min(n: f32): void {
-    assert(n == f32.MIN_VALUE);
+  assert(n == f32.MIN_VALUE);
 }
 
 export function testF32Input_max(n: f32): void {
-    assert(n == f32.MAX_VALUE);
+  assert(n == f32.MAX_VALUE);
 }
 
 export function testF32Output_min(): f32 {
-    return f32.MIN_VALUE;
+  return f32.MIN_VALUE;
 }
 
 export function testF32Output_max(): f32 {
-    return f32.MAX_VALUE;
+  return f32.MAX_VALUE;
 }
 
 export function testF64Input_min(n: f64): void {
-    assert(n == f64.MIN_VALUE);
+  assert(n == f64.MIN_VALUE);
 }
 
 export function testF64Input_max(n: f64): void {
-    assert(n == f64.MAX_VALUE);
+  assert(n == f64.MAX_VALUE);
 }
 
 export function testF64Output_min(): f64 {
-    return f64.MIN_VALUE;
+  return f64.MIN_VALUE;
 }
 
 export function testF64Output_max(): f64 {
-    return f64.MAX_VALUE;
+  return f64.MAX_VALUE;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/strings.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/strings.ts
@@ -1,51 +1,51 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 // "Hello World" in Japanese
-const testString = "こんにちは、世界"
+const testString = "こんにちは、世界";
 
 export function testStringInput(s: string): void {
-    assert(s == testString);
+  assert(s == testString);
 }
 
 export function testStringOutput(): string {
-    return testString;
+  return testString;
 }
 
 export function testStringInput_empty(s: string): void {
-    assert(s == "");
+  assert(s == "");
 }
 
 export function testStringOutput_empty(): string {
-    return "";
+  return "";
 }
 
 export function testNullStringInput(s: string | null): void {
-    assert(s == testString);
+  assert(s == testString);
 }
 
 export function testNullStringOutput(): string | null {
-    return testString;
+  return testString;
 }
 
 export function testNullStringInput_empty(s: string | null): void {
-    assert(s == "");
+  assert(s == "");
 }
 
 export function testNullStringOutput_empty(): string | null {
-    return "";
+  return "";
 }
 
 export function testNullStringInput_null(s: string | null): void {
-    assert(s == null);
+  assert(s == null);
 }
 
 export function testNullStringOutput_null(): string | null {
-    return null;
+  return null;
 }

--- a/runtime/languages/assemblyscript/testdata/assembly/typedarrays.ts
+++ b/runtime/languages/assemblyscript/testdata/assembly/typedarrays.ts
@@ -1,178 +1,178 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
 export function testInt8ArrayInput(view: Int8Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testInt8ArrayOutput(): Int8Array {
-    const view = new Int8Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Int8Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testInt16ArrayInput(view: Int16Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testInt16ArrayOutput(): Int16Array {
-    const view = new Int16Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Int16Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testInt32ArrayInput(view: Int32Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testInt32ArrayOutput(): Int32Array {
-    const view = new Int32Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Int32Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testInt64ArrayInput(view: Int64Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testInt64ArrayOutput(): Int64Array {
-    const view = new Int64Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Int64Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testUint8ArrayInput(view: Uint8Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testUint8ArrayInput_empty(view: Uint8Array): void {
-    assert(view.length == 0);
+  assert(view.length == 0);
 }
 
 export function testUint8ArrayInput_null(view: Uint8Array | null): void {
-    assert(view == null);
+  assert(view == null);
 }
 
 export function testUint8ArrayOutput(): Uint8Array {
-    const view = new Uint8Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Uint8Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testUint8ArrayOutput_empty(): Uint8Array {
-    return new Uint8Array(0);
+  return new Uint8Array(0);
 }
 
 export function testUint8ArrayOutput_null(): Uint8Array | null {
-    return null;
+  return null;
 }
 
 export function testUint8ClampedArrayInput(view: Uint8ClampedArray): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testUint8ClampedArrayOutput(): Uint8ClampedArray {
-    const view = new Uint8ClampedArray(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Uint8ClampedArray(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testUint16ArrayInput(view: Uint16Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testUint16ArrayOutput(): Uint16Array {
-    const view = new Uint16Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Uint16Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testUint32ArrayInput(view: Uint32Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testUint32ArrayOutput(): Uint32Array {
-    const view = new Uint32Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Uint32Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testUint64ArrayInput(view: Uint64Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testUint64ArrayOutput(): Uint64Array {
-    const view = new Uint64Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Uint64Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testFloat32ArrayInput(view: Float32Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testFloat32ArrayOutput(): Float32Array {
-    const view = new Float32Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Float32Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }
 
 export function testFloat64ArrayInput(view: Float64Array): void {
-    assert(view.length == 4);
-    assert(view[0] == 0);
-    assert(view[1] == 1);
-    assert(view[2] == 2);
-    assert(view[3] == 3);
+  assert(view.length == 4);
+  assert(view[0] == 0);
+  assert(view[1] == 1);
+  assert(view[2] == 2);
+  assert(view[3] == 3);
 }
 
 export function testFloat64ArrayOutput(): Float64Array {
-    const view = new Float64Array(4);
-    view.set([0, 1, 2, 3]);
-    return view;
+  const view = new Float64Array(4);
+  view.set([0, 1, 2, 3]);
+  return view;
 }

--- a/runtime/languages/assemblyscript/tests/arraybuffers_test.go
+++ b/runtime/languages/assemblyscript/tests/arraybuffers_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/arrays_test.go
+++ b/runtime/languages/assemblyscript/tests/arrays_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/classes_test.go
+++ b/runtime/languages/assemblyscript/tests/classes_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/dates_test.go
+++ b/runtime/languages/assemblyscript/tests/dates_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/env_test.go
+++ b/runtime/languages/assemblyscript/tests/env_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/hostfns_test.go
+++ b/runtime/languages/assemblyscript/tests/hostfns_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/maps_test.go
+++ b/runtime/languages/assemblyscript/tests/maps_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/primitives_test.go
+++ b/runtime/languages/assemblyscript/tests/primitives_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/setup_test.go
+++ b/runtime/languages/assemblyscript/tests/setup_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/special_test.go
+++ b/runtime/languages/assemblyscript/tests/special_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/strings_test.go
+++ b/runtime/languages/assemblyscript/tests/strings_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/tests/typedarrays_test.go
+++ b/runtime/languages/assemblyscript/tests/typedarrays_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/assemblyscript/typeinfo.go
+++ b/runtime/languages/assemblyscript/typeinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/adapter.go
+++ b/runtime/languages/golang/adapter.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_arrays.go
+++ b/runtime/languages/golang/handler_arrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_maps.go
+++ b/runtime/languages/golang/handler_maps.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_pointers.go
+++ b/runtime/languages/golang/handler_pointers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_primitivearrays.go
+++ b/runtime/languages/golang/handler_primitivearrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_primitives.go
+++ b/runtime/languages/golang/handler_primitives.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_primitiveslices.go
+++ b/runtime/languages/golang/handler_primitiveslices.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_slices.go
+++ b/runtime/languages/golang/handler_slices.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_strings.go
+++ b/runtime/languages/golang/handler_strings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_structs.go
+++ b/runtime/languages/golang/handler_structs.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/handler_time.go
+++ b/runtime/languages/golang/handler_time.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/planner.go
+++ b/runtime/languages/golang/planner.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/arrays.go
+++ b/runtime/languages/golang/testdata/arrays.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/hostfns.go
+++ b/runtime/languages/golang/testdata/hostfns.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/http.go
+++ b/runtime/languages/golang/testdata/http.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/imports_mock.go
+++ b/runtime/languages/golang/testdata/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/imports_wasi.go
+++ b/runtime/languages/golang/testdata/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/maps.go
+++ b/runtime/languages/golang/testdata/maps.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/primitives.go
+++ b/runtime/languages/golang/testdata/primitives.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/slices.go
+++ b/runtime/languages/golang/testdata/slices.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/special.go
+++ b/runtime/languages/golang/testdata/special.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/strings.go
+++ b/runtime/languages/golang/testdata/strings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/structs.go
+++ b/runtime/languages/golang/testdata/structs.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/time.go
+++ b/runtime/languages/golang/testdata/time.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/testdata/utils.go
+++ b/runtime/languages/golang/testdata/utils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/arrays_test.go
+++ b/runtime/languages/golang/tests/arrays_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/hostfns_test.go
+++ b/runtime/languages/golang/tests/hostfns_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/http_test.go
+++ b/runtime/languages/golang/tests/http_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/maps_test.go
+++ b/runtime/languages/golang/tests/maps_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/planner_test.go
+++ b/runtime/languages/golang/tests/planner_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/primitives_test.go
+++ b/runtime/languages/golang/tests/primitives_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/recursivestructs_test.go
+++ b/runtime/languages/golang/tests/recursivestructs_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/setup_test.go
+++ b/runtime/languages/golang/tests/setup_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/slices_test.go
+++ b/runtime/languages/golang/tests/slices_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/special_test.go
+++ b/runtime/languages/golang/tests/special_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/strings_test.go
+++ b/runtime/languages/golang/tests/strings_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/structs_test.go
+++ b/runtime/languages/golang/tests/structs_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/tests/time_test.go
+++ b/runtime/languages/golang/tests/time_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/golang/typeinfo.go
+++ b/runtime/languages/golang/typeinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/languages/languages.go
+++ b/runtime/languages/languages.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/logger/logger.go
+++ b/runtime/logger/logger.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/logger/logwriter.go
+++ b/runtime/logger/logwriter.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/main.go
+++ b/runtime/main.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/manifestdata/events.go
+++ b/runtime/manifestdata/events.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/manifestdata/manifestdata.go
+++ b/runtime/manifestdata/manifestdata.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/metrics/metrics_test.go
+++ b/runtime/metrics/metrics_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/bedrock.go
+++ b/runtime/models/bedrock.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/legacymodels/classifier.go
+++ b/runtime/models/legacymodels/classifier.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/legacymodels/common.go
+++ b/runtime/models/legacymodels/common.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/legacymodels/embeddings.go
+++ b/runtime/models/legacymodels/embeddings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/legacymodels/openai.go
+++ b/runtime/models/legacymodels/openai.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/legacymodels/textgeneration.go
+++ b/runtime/models/legacymodels/textgeneration.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/models.go
+++ b/runtime/models/models.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/models_test.go
+++ b/runtime/models/models_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/models/types.go
+++ b/runtime/models/types.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/pluginmanager/events.go
+++ b/runtime/pluginmanager/events.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/pluginmanager/loader.go
+++ b/runtime/pluginmanager/loader.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/pluginmanager/pluginmanager.go
+++ b/runtime/pluginmanager/pluginmanager.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/pluginmanager/pluginregistry.go
+++ b/runtime/pluginmanager/pluginregistry.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/builder.go
+++ b/runtime/plugins/metadata/builder.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/compat.go
+++ b/runtime/plugins/metadata/compat.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/extras.go
+++ b/runtime/plugins/metadata/extras.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/legacy/v1/metadata.go
+++ b/runtime/plugins/metadata/legacy/v1/metadata.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/metadata.go
+++ b/runtime/plugins/metadata/metadata.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/metadata/reader.go
+++ b/runtime/plugins/metadata/reader.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/plugins/plugins.go
+++ b/runtime/plugins/plugins.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/secrets/awssecrets.go
+++ b/runtime/secrets/awssecrets.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/secrets/localsecrets.go
+++ b/runtime/secrets/localsecrets.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/services/services.go
+++ b/runtime/services/services.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/sqlclient/pooling.go
+++ b/runtime/sqlclient/pooling.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/sqlclient/postgresql.go
+++ b/runtime/sqlclient/postgresql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/sqlclient/registry.go
+++ b/runtime/sqlclient/registry.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/sqlclient/sqlclient.go
+++ b/runtime/sqlclient/sqlclient.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/sqlclient/types.go
+++ b/runtime/sqlclient/types.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/storage/awsstorage.go
+++ b/runtime/storage/awsstorage.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/storage/localstorage.go
+++ b/runtime/storage/localstorage.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/storage/storage.go
+++ b/runtime/storage/storage.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/storage/storagemonitor.go
+++ b/runtime/storage/storagemonitor.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/testutils/testutils.go
+++ b/runtime/testutils/testutils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/tools/generate_version/genversion.go
+++ b/runtime/tools/generate_version/genversion.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/buffers.go
+++ b/runtime/utils/buffers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/cast.go
+++ b/runtime/utils/cast.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/cleaner.go
+++ b/runtime/utils/cleaner.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/console.go
+++ b/runtime/utils/console.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/context.go
+++ b/runtime/utils/context.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/http.go
+++ b/runtime/utils/http.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/http_test.go
+++ b/runtime/utils/http_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/json.go
+++ b/runtime/utils/json.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/maps.go
+++ b/runtime/utils/maps.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/mapstructure.go
+++ b/runtime/utils/mapstructure.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/pointers.go
+++ b/runtime/utils/pointers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/sentry.go
+++ b/runtime/utils/sentry.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/slices.go
+++ b/runtime/utils/slices.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/strings.go
+++ b/runtime/utils/strings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/strings_test.go
+++ b/runtime/utils/strings_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/time.go
+++ b/runtime/utils/time.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/utils.go
+++ b/runtime/utils/utils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/utils/wasm.go
+++ b/runtime/utils/wasm.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/wasmhost/env.go
+++ b/runtime/wasmhost/env.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/wasmhost/fncall.go
+++ b/runtime/wasmhost/fncall.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/wasmhost/hostfns.go
+++ b/runtime/wasmhost/hostfns.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/wasmhost/initialization.go
+++ b/runtime/wasmhost/initialization.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/runtime/wasmhost/wasmhost.go
+++ b/runtime/wasmhost/wasmhost.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -2,7 +2,7 @@
   "name": "anthropic-functions-example",
   "private": true,
   "description": "Hypermode Function Calling Example using Anthropic",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -2,7 +2,7 @@
   "name": "classification-example",
   "private": true,
   "description": "Modus AssemblyScript Classification Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/collection/package.json
+++ b/sdk/assemblyscript/examples/collection/package.json
@@ -2,7 +2,7 @@
   "name": "collection-example",
   "private": true,
   "description": "Modus AssemblyScript Collection Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -2,7 +2,7 @@
   "name": "dgraph-example",
   "private": true,
   "description": "Modus AssemblyScript Dgraph Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -2,7 +2,7 @@
   "name": "embedding-example",
   "private": true,
   "description": "Modus AssemblyScript Embedding Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -2,7 +2,7 @@
   "name": "graphql-example",
   "private": true,
   "description": "Modus AssemblyScript GraphQL Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -2,7 +2,7 @@
   "name": "http-example",
   "private": true,
   "description": "Modus AssemblyScript HTTP Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -2,7 +2,7 @@
   "name": "postgresql-example",
   "private": true,
   "description": "Modus AssemblyScript Example using PostgreSQL database",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -2,7 +2,7 @@
   "name": "simple-example",
   "private": true,
   "description": "Modus AssemblyScript Simple Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -2,7 +2,7 @@
   "name": "text-generation-example",
   "private": true,
   "description": "Modus AssemblyScript Text Generation Example",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/src/assembly/__tests__/graphql.spec.ts
+++ b/sdk/assemblyscript/src/assembly/__tests__/graphql.spec.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/__tests__/http.spec.ts
+++ b/sdk/assemblyscript/src/assembly/__tests__/http.spec.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/collections.ts
+++ b/sdk/assemblyscript/src/assembly/collections.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/compat.ts
+++ b/sdk/assemblyscript/src/assembly/compat.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/database.ts
+++ b/sdk/assemblyscript/src/assembly/database.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/dgraph.ts
+++ b/sdk/assemblyscript/src/assembly/dgraph.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/graphql.ts
+++ b/sdk/assemblyscript/src/assembly/graphql.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/http.ts
+++ b/sdk/assemblyscript/src/assembly/http.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/index.ts
+++ b/sdk/assemblyscript/src/assembly/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/inference.ts
+++ b/sdk/assemblyscript/src/assembly/inference.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/models.ts
+++ b/sdk/assemblyscript/src/assembly/models.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/overrides/modus_abort.ts
+++ b/sdk/assemblyscript/src/assembly/overrides/modus_abort.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/overrides/modus_console.ts
+++ b/sdk/assemblyscript/src/assembly/overrides/modus_console.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/overrides/modus_trace.ts
+++ b/sdk/assemblyscript/src/assembly/overrides/modus_trace.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/postgresql.ts
+++ b/sdk/assemblyscript/src/assembly/postgresql.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/assembly/utils.ts
+++ b/sdk/assemblyscript/src/assembly/utils.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/index.ts
+++ b/sdk/assemblyscript/src/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/anthropic/messages.ts
+++ b/sdk/assemblyscript/src/models/anthropic/messages.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/experimental/classification.ts
+++ b/sdk/assemblyscript/src/models/experimental/classification.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/experimental/embeddings.ts
+++ b/sdk/assemblyscript/src/models/experimental/embeddings.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/gemini/generate.ts
+++ b/sdk/assemblyscript/src/models/gemini/generate.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/meta/llama.ts
+++ b/sdk/assemblyscript/src/models/meta/llama.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/models/openai/embeddings.ts
+++ b/sdk/assemblyscript/src/models/openai/embeddings.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -2,7 +2,7 @@
   "name": "@hypermode/modus-sdk-as",
   "version": "0.12.0",
   "description": "Modus SDK for AssemblyScript",
-  "author": "Hypermode, Inc.",
+  "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/sdk/assemblyscript/src/tests/graphql.run.ts
+++ b/sdk/assemblyscript/src/tests/graphql.run.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/tests/http.run.ts
+++ b/sdk/assemblyscript/src/tests/http.run.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/tools/assemblyscript-eslint.js
+++ b/sdk/assemblyscript/src/tools/assemblyscript-eslint.js
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/transform/src/extractor.ts
+++ b/sdk/assemblyscript/src/transform/src/extractor.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/transform/src/index.ts
+++ b/sdk/assemblyscript/src/transform/src/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/transform/src/logo.ts
+++ b/sdk/assemblyscript/src/transform/src/logo.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/transform/src/metadata.ts
+++ b/sdk/assemblyscript/src/transform/src/metadata.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/assemblyscript/src/transform/src/types.ts
+++ b/sdk/assemblyscript/src/transform/src/types.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/collections/collections.go
+++ b/sdk/go/pkg/collections/collections.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/collections/collections_test.go
+++ b/sdk/go/pkg/collections/collections_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/collections/imports_mock.go
+++ b/sdk/go/pkg/collections/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/collections/imports_wasi.go
+++ b/sdk/go/pkg/collections/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/console/console.go
+++ b/sdk/go/pkg/console/console.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/console/console_test.go
+++ b/sdk/go/pkg/console/console_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/console/imports_mock.go
+++ b/sdk/go/pkg/console/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/console/imports_wasi.go
+++ b/sdk/go/pkg/console/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/console/timers.go
+++ b/sdk/go/pkg/console/timers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/db/db.go
+++ b/sdk/go/pkg/db/db.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/db/db_test.go
+++ b/sdk/go/pkg/db/db_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/db/imports_mock.go
+++ b/sdk/go/pkg/db/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/db/imports_wasi.go
+++ b/sdk/go/pkg/db/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/dgraph/dgraph.go
+++ b/sdk/go/pkg/dgraph/dgraph.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/dgraph/dgraph_test.go
+++ b/sdk/go/pkg/dgraph/dgraph_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/dgraph/imports_mock.go
+++ b/sdk/go/pkg/dgraph/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/dgraph/imports_wasi.go
+++ b/sdk/go/pkg/dgraph/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/graphql/graphql.go
+++ b/sdk/go/pkg/graphql/graphql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/graphql/graphql_test.go
+++ b/sdk/go/pkg/graphql/graphql_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/graphql/imports_mock.go
+++ b/sdk/go/pkg/graphql/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/graphql/imports_wasi.go
+++ b/sdk/go/pkg/graphql/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/content.go
+++ b/sdk/go/pkg/http/content.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/headers.go
+++ b/sdk/go/pkg/http/headers.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/http.go
+++ b/sdk/go/pkg/http/http.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/http_test.go
+++ b/sdk/go/pkg/http/http_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/imports_mock.go
+++ b/sdk/go/pkg/http/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/imports_wasi.go
+++ b/sdk/go/pkg/http/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/request.go
+++ b/sdk/go/pkg/http/request.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/http/response.go
+++ b/sdk/go/pkg/http/response.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/experimental/classification.go
+++ b/sdk/go/pkg/models/experimental/classification.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/experimental/embeddings.go
+++ b/sdk/go/pkg/models/experimental/embeddings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/imports_mock.go
+++ b/sdk/go/pkg/models/imports_mock.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/imports_wasi.go
+++ b/sdk/go/pkg/models/imports_wasi.go
@@ -1,11 +1,11 @@
 //go:build wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/models.go
+++ b/sdk/go/pkg/models/models.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/models_test.go
+++ b/sdk/go/pkg/models/models_test.go
@@ -1,11 +1,11 @@
 //go:build !wasip1
 
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/openai/chat.go
+++ b/sdk/go/pkg/models/openai/chat.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/openai/common.go
+++ b/sdk/go/pkg/models/openai/common.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/models/openai/embeddings.go
+++ b/sdk/go/pkg/models/openai/embeddings.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/postgresql/location.go
+++ b/sdk/go/pkg/postgresql/location.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/postgresql/location_test.go
+++ b/sdk/go/pkg/postgresql/location_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/postgresql/point.go
+++ b/sdk/go/pkg/postgresql/point.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/postgresql/point_test.go
+++ b/sdk/go/pkg/postgresql/point_test.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/postgresql/postgresql.go
+++ b/sdk/go/pkg/postgresql/postgresql.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/testutils/stack.go
+++ b/sdk/go/pkg/testutils/stack.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/pkg/utils/utils.go
+++ b/sdk/go/pkg/utils/utils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/codegen/codegen.go
+++ b/sdk/go/tools/modus-go-build/codegen/codegen.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/codegen/postprocess.go
+++ b/sdk/go/tools/modus-go-build/codegen/postprocess.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/codegen/preprocess.go
+++ b/sdk/go/tools/modus-go-build/codegen/preprocess.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/compiler/compiler.go
+++ b/sdk/go/tools/modus-go-build/compiler/compiler.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/config/config.go
+++ b/sdk/go/tools/modus-go-build/config/config.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/extractor/extractor.go
+++ b/sdk/go/tools/modus-go-build/extractor/extractor.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/extractor/functions.go
+++ b/sdk/go/tools/modus-go-build/extractor/functions.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/extractor/packages.go
+++ b/sdk/go/tools/modus-go-build/extractor/packages.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/extractor/transform.go
+++ b/sdk/go/tools/modus-go-build/extractor/transform.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/gitinfo/gitinfo.go
+++ b/sdk/go/tools/modus-go-build/gitinfo/gitinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/main.go
+++ b/sdk/go/tools/modus-go-build/main.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/metadata/metadata.go
+++ b/sdk/go/tools/modus-go-build/metadata/metadata.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/metagen/metagen.go
+++ b/sdk/go/tools/modus-go-build/metagen/metagen.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/metagen/output.go
+++ b/sdk/go/tools/modus-go-build/metagen/output.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/modinfo/modinfo.go
+++ b/sdk/go/tools/modus-go-build/modinfo/modinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/utils/typeinfo.go
+++ b/sdk/go/tools/modus-go-build/utils/typeinfo.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/utils/utils.go
+++ b/sdk/go/tools/modus-go-build/utils/utils.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/sdk/go/tools/modus-go-build/wasm/wasm.go
+++ b/sdk/go/tools/modus-go-build/wasm/wasm.go
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode, Inc.
+ * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode, Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Fix our copyright statements to be "Hypermode Inc." rather than "Hypermode, Inc."