### PR TITLE
Fix vulnerability in AssemblyScript SDK install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Modus AssemblyScript SDK [#423](https://github.com/hypermodeinc/modus/pull/423)
 - Add models to Modus AssemblyScript SDK [#428](https://github.com/hypermodeinc/modus/pull/428)
 - Update Readme files [#432](https://github.com/hypermodeinc/modus/pull/432)
+- Fix vulnerability in AssemblyScript SDK install script [#435](https://github.com/hypermodeinc/modus/pull/435)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -37,9 +37,19 @@ await validatePackageJson();
 await validateAsJson();
 
 console.log(`Building ${pkg}.wasm ...`);
-const cmdArgs = [npmPath, 'exec', '--', 'asc', 'assembly/index.ts', '-o', `build/${pkg}.wasm`, '--target', target];
+const cmdArgs = [
+  npmPath,
+  "exec",
+  "--",
+  "asc",
+  "assembly/index.ts",
+  "-o",
+  `build/${pkg}.wasm`,
+  "--target",
+  target,
+];
 try {
-  execFileSync('node', cmdArgs, { stdio: "inherit" });
+  execFileSync("node", cmdArgs, { stdio: "inherit" });
 } catch {
   console.error("Build failed.\n");
   process.exit(1);

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import process from "process";
@@ -37,9 +37,9 @@ await validatePackageJson();
 await validateAsJson();
 
 console.log(`Building ${pkg}.wasm ...`);
-const cmd = `node "${npmPath}" exec -- asc assembly/index.ts -o build/${pkg}.wasm --target ${target}`;
+const cmdArgs = [npmPath, 'exec', '--', 'asc', 'assembly/index.ts', '-o', `build/${pkg}.wasm`, '--target', target];
 try {
-  execSync(cmd, { stdio: "inherit" });
+  execFileSync('node', cmdArgs, { stdio: "inherit" });
 } catch {
   console.error("Build failed.\n");
   process.exit(1);


### PR DESCRIPTION
Fixes [https://github.com/hypermodeinc/modus/security/code-scanning/1](https://github.com/hypermodeinc/modus/security/code-scanning/1)

To fix the problem, we should avoid using `execSync` with a concatenated command string that includes unsanitized environment variables. Instead, we can use `execFileSync` which accepts command arguments as an array of strings, thus avoiding the risk of command injection.

- Replace the `execSync` call with `execFileSync`.
- Construct the command arguments as an array, ensuring that each part of the command is a separate element in the array.
- Import the necessary `execFileSync` function from the `child_process` module.


