### PR TITLE
Fix potential array out of bounds in the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Modus AssemblyScript SDK [#423](https://github.com/hypermodeinc/modus/pull/423)
 - Add models to Modus AssemblyScript SDK [#428](https://github.com/hypermodeinc/modus/pull/428)
 - Update Readme files [#432](https://github.com/hypermodeinc/modus/pull/432)
+- Fix potential array out of bounds in the runtime [#437](https://github.com/hypermodeinc/modus/pull/437)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/languages/golang/typeinfo.go
+++ b/runtime/languages/golang/typeinfo.go
@@ -12,6 +12,7 @@ package golang
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"

--- a/runtime/languages/golang/typeinfo.go
+++ b/runtime/languages/golang/typeinfo.go
@@ -117,7 +117,15 @@ func (lti *langTypeInfo) ArrayLength(typ string) (int, error) {
 		return -1, fmt.Errorf("invalid array type: %s", typ)
 	}
 
-	return strconv.Atoi(size)
+	parsedSize, err := strconv.Atoi(size)
+	if err != nil {
+		return -1, err
+	}
+	if parsedSize < 0 || parsedSize > math.MaxUint32 {
+		return -1, fmt.Errorf("array size out of bounds: %s", size)
+	}
+
+	return parsedSize, nil
 }
 
 func (lti *langTypeInfo) IsBooleanType(typ string) bool {


### PR DESCRIPTION
Fixes [https://github.com/hypermodeinc/modus/security/code-scanning/2](https://github.com/hypermodeinc/modus/security/code-scanning/2)

To fix the problem, we need to ensure that the value returned by `strconv.Atoi` is within the bounds of `uint32` before performing the conversion. This can be done by checking if the parsed integer is within the range of `0` to `math.MaxUint32`. If the value is out of bounds, we should return an error.

1. Modify the `ArrayLength` function to include bounds checking for the parsed integer.
2. Use `strconv.ParseUint` with a bit size of 32 to directly parse the string into a `uint32` if possible.


