### PR TITLE
Change environment variable name and default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
       "preLaunchTask": "go: generate code",
       "program": "${workspaceFolder}/runtime",
       "env": {
+        "MODUS_ENV": "dev",
         "MODUS_DEBUG": "true",
         "MODUS_DB": "postgresql://postgres:postgres@localhost:5433/my-runtime-db?sslmode=disable"
       },
@@ -22,6 +23,7 @@
       "preLaunchTask": "go: generate code",
       "program": "${workspaceFolder}/runtime",
       "env": {
+        "MODUS_ENV": "dev",
         "MODUS_DEBUG": "true",
         "AWS_REGION": "us-west-2",
         "AWS_PROFILE": "sandbox",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## UNRELEASED
+## UNRELEASED (work in progress)
+
+_NOTE: This is the first fully open-source release, using the name "Modus" for the framework.
+"Hypermode" still refers to the company and the commercial hosting platform - but not the framework.
+In previous releases, the name "Hypermode" was used for all three._
 
 - Migrate from Hypermode to Modus [#412](https://github.com/hypermodeinc/modus/pull/412)
 - Import WasmExtractor code [#415](https://github.com/hypermodeinc/modus/pull/415)
@@ -14,6 +18,8 @@
 - Update Readme files [#432](https://github.com/hypermodeinc/modus/pull/432)
 - Fix vulnerability in AssemblyScript SDK install script [#435](https://github.com/hypermodeinc/modus/pull/435)
 - Fix potential array out of bounds in the runtime [#437](https://github.com/hypermodeinc/modus/pull/437)
+- Set minimum Go version to 1.23.0 [#438](https://github.com/hypermodeinc/modus/pull/438)
+- Change default for environment setting [#439](https://github.com/hypermodeinc/modus/pull/439)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/config/environment.go
+++ b/runtime/config/environment.go
@@ -15,7 +15,20 @@ import (
 	"os/user"
 )
 
-const devEnvironmentName = "dev"
+/*
+
+DESIGN NOTES:
+
+- The MODUS_ENV environment variable is used to determine the environment name.
+- We prefer to use short names, "prod", "stage", "dev", etc, but the actual value is arbitrary, so you can use longer names if you prefer.
+- If it is not set, the default environment name is "prod".  This is a safe-by-default approach.
+- It is preferable to actually set the MODUS_ENV to the appropriate environment when running the application.
+- During development, the Modus CLI will set the MODUS_ENV to "dev" automatically.
+- The "dev" environment is special in several ways, such as relaxed security requirements, and omitting certain telemetry.
+- There is nothing special about "prod", other than it is the default.
+- You can also use "stage", "test", etc, as needed - but they will behave like "prod".  The only difference is the name returned by the health endpoint, logs, and telemetry.
+
+*/
 
 var environment string
 var namespace string
@@ -25,14 +38,17 @@ func GetEnvironmentName() string {
 }
 
 func setEnvironmentName() {
-	environment = os.Getenv("ENVIRONMENT")
+	environment = os.Getenv("MODUS_ENV")
+
+	// default to prod
 	if environment == "" {
-		environment = devEnvironmentName
+		environment = "prod"
 	}
 }
 
 func IsDevEnvironment() bool {
-	return environment == devEnvironmentName
+	// support either name (but prefer "dev")
+	return environment == "dev" || environment == "development"
 }
 
 func GetNamespace() string {

--- a/runtime/config/environment_test.go
+++ b/runtime/config/environment_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestEnvironmentNames(t *testing.T) {
+	tests := []struct {
+		name           string
+		envValue       string
+		expectedResult string
+		isDev          bool
+	}{
+		{
+			name:           "Environment variable not set",
+			envValue:       "",
+			expectedResult: "prod",
+			isDev:          false,
+		},
+		{
+			name:           "Environment variable set to dev",
+			envValue:       "dev",
+			expectedResult: "dev",
+			isDev:          true,
+		},
+		{
+			name:           "Environment variable set to development",
+			envValue:       "development",
+			expectedResult: "development",
+			isDev:          true,
+		},
+		{
+			name:           "Environment variable set to stage",
+			envValue:       "stage",
+			expectedResult: "stage",
+			isDev:          false,
+		},
+		{
+			name:           "Environment variable set to test",
+			envValue:       "test",
+			expectedResult: "test",
+			isDev:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("MODUS_ENV", tt.envValue)
+			setEnvironmentName()
+			result := GetEnvironmentName()
+			if result != tt.expectedResult {
+				t.Errorf("Expected environment to be %s, but got %s", tt.expectedResult, result)
+			}
+			if IsDevEnvironment() != tt.isDev {
+				t.Errorf("Expected IsDevEnvironment to be %v, but got %v", tt.isDev, IsDevEnvironment())
+			}
+		})
+	}
+}

--- a/runtime/main.go
+++ b/runtime/main.go
@@ -35,6 +35,7 @@ func main() {
 	log := logger.Initialize()
 	log.Info().
 		Str("version", config.GetVersionNumber()).
+		Str("environment", config.GetEnvironmentName()).
 		Msg("Starting Modus Runtime.")
 
 	// Load environment variables from plugins path


### PR DESCRIPTION
# Description
- Changed the environment variable name from `ENVIRONMENT` to `MODUS_ENV`, to avoid conflicts with other software.
- Changed the default environment from "dev" to "prod".
- Added notes explaining the rationale for the change.
- Added tests
- Add the environment name to the starting log message
- Updated the changelog

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
