### PR TITLE
Fix object/map field stitching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Change default for environment setting [#439](https://github.com/hypermodeinc/modus/pull/439)
 - Remove compatibility code for previous versions [#441](https://github.com/hypermodeinc/modus/pull/441)
 - Target Node 22 [#446](https://github.com/hypermodeinc/modus/pull/446)
+- Fix object/map field stitching [#447](https://github.com/hypermodeinc/modus/pull/447)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/graphql/datasource/planner.go
+++ b/runtime/graphql/datasource/planner.go
@@ -124,8 +124,8 @@ func (p *HypDSPlanner) stitchFields(f *fieldInfo) {
 	f.Fields = make([]fieldInfo, len(f.fieldRefs))
 	for i, ref := range f.fieldRefs {
 		field := p.fields[ref]
-		f.Fields[i] = field
 		p.stitchFields(&field)
+		f.Fields[i] = field
 	}
 }
 


### PR DESCRIPTION
# Description
Fixes an issue where an output object with a nested output object wasn't being materialized correctly.

For example, a function returning a map of maps:

```ts
export function testMapOfMaps(): Map<string, Map<string, f64>> {
  const m = new Map<string, Map<string, f64>>();
  const inner = new Map<string, f64>();
  inner.set("a", 1);
  inner.set("b", 2);
  m.set("inner", inner);
  return m;
}
```

The error caused the internal input template to only provide the _root_ map's key and value fields.  The result of filling that template would then be a GraphQL error, such as:

```json
{ "errors": [
        {
            "message": "Array cannot represent non-array value.",
            "path": [
                "testMapOfMaps",
                0,
                "value",
                "value"
            ]
        }
    ]
}
```

The root cause turned out to be a simple struct copy issue.

No tests, because we still need to make a test suite for the GraphQL datasource.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [ ] Tests for new functionality and regression tests for bug fixes added
- [ ] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

