### PR TITLE
feat: modus-sdk-as cli component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Change default for environment setting [#439](https://github.com/hypermodeinc/modus/pull/439)
 - Remove compatibility code for previous versions [#441](https://github.com/hypermodeinc/modus/pull/441)
 - Target Node 22 [#446](https://github.com/hypermodeinc/modus/pull/446)
+- Use cli component instead of direct node execution modus-sdk-as [#448](https://github.com/hypermodeinc/modus/pull/448)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/languages/assemblyscript/testdata/package.json
+++ b/runtime/languages/assemblyscript/testdata/package.json
@@ -2,7 +2,7 @@
   "name": "testdata",
   "private": true,
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js"
+    "build": "modus-as-build"
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../../../sdk/assemblyscript/src",

--- a/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/classification/package-lock.json
+++ b/sdk/assemblyscript/examples/classification/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/collection/package-lock.json
+++ b/sdk/assemblyscript/examples/collection/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/collection/package.json
+++ b/sdk/assemblyscript/examples/collection/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/dgraph/package-lock.json
+++ b/sdk/assemblyscript/examples/dgraph/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/embedding/package-lock.json
+++ b/sdk/assemblyscript/examples/embedding/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/graphql/package-lock.json
+++ b/sdk/assemblyscript/examples/graphql/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/http/package-lock.json
+++ b/sdk/assemblyscript/examples/http/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/postgresql/package-lock.json
+++ b/sdk/assemblyscript/examples/postgresql/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -32,6 +32,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/textgeneration/package-lock.json
+++ b/sdk/assemblyscript/examples/textgeneration/package-lock.json
@@ -33,6 +33,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/examples/vectors/package-lock.json
+++ b/sdk/assemblyscript/examples/vectors/package-lock.json
@@ -32,6 +32,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/examples/vectors/package.json
+++ b/sdk/assemblyscript/examples/vectors/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "build": "node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js",
+    "build": "modus-as-build",
     "lint": "eslint .",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * Copyright 2024 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0

--- a/sdk/assemblyscript/src/package-lock.json
+++ b/sdk/assemblyscript/src/package-lock.json
@@ -14,6 +14,9 @@
         "semver": "^7.6.3",
         "xid-ts": "^1.1.4"
       },
+      "bin": {
+        "modus-as-build": "bin/build-plugin.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@types/eslint__js": "^8.42.3",

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -5,6 +5,9 @@
   "author": "Hypermode Inc.",
   "license": "Apache-2.0",
   "type": "module",
+  "bin": {
+    "modus-as-build": "./bin/build-plugin.js"
+  },
   "scripts": {
     "test": "ast run",
     "pretest": "ast build && tsc -p ./tests",


### PR DESCRIPTION
This PR updates the way the sdk build process is done.
Before, `npm run build` would run `node ./node_modules/@hypermode/modus-sdk-as/bin/build-plugin.js`, but now it points to `modus-as-build`