### PR TITLE
Add release pipeline for Runtime

### DIFF
--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -1,0 +1,31 @@
+name: "Release Runtime"
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag to release"
+        required: true
+        type: string
+permissions:
+  contents: "write"
+jobs:
+  release:
+    runs-on: warp-ubuntu-latest-x64-4x
+    steps:
+    - name: "Validate version"
+      if: ${{ !startsWith(github.event.inputs.tag, 'runtime/v') }}
+      run: 'echo "Modus Runtime version must start with `runtime/v` && exit 1'
+    - uses: actions/checkout@v4
+      with:
+        ref: "${{ github.event.inputs.tag }}"
+    - uses: actions/setup-go@v5
+      with:
+        go-version: 1.23
+    - uses: goreleaser/goreleaser-action@v6
+      with:
+        distribution: goreleaser-pro
+        version: "2.3.2"
+        args: release --clean -f ./runtime/.goreleaser.yaml
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -1,11 +1,8 @@
 name: "Release Runtime"
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "The tag to release"
-        required: true
-        type: string
+  push:
+    tags:
+      - 'runtime/v*'
 permissions:
   contents: "write"
 jobs:
@@ -13,11 +10,11 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
     - name: "Validate version"
-      if: ${{ !startsWith(github.event.inputs.tag, 'runtime/v') }}
+      if: ${{ !startsWith(github.ref_name, 'runtime/v') }}
       run: 'echo "Modus Runtime version must start with `runtime/v` && exit 1'
     - uses: actions/checkout@v4
       with:
-        ref: "${{ github.event.inputs.tag }}"
+        ref: "${{ github.ref_name }}"
     - uses: actions/setup-go@v5
       with:
         go-version: 1.23

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ node_modules/
 pnpm-lock.yaml
 yarn.lock
 bun.lockb
+
+dist/

--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+version: 2
+project_name: runtime
+monorepo:
+  tag_prefix: runtime/
+  dir: runtime
+git:
+  tag_sort: "-version:creatordate"
+  prerelease_suffix: "-"
+before:
+  hooks:
+    - sh -c "cd runtime && go generate ./... && go mod tidy"
+builds:
+  - main: .
+    binary: modus_runtime
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+archives:
+  - files:
+      - "../README.md"
+      - "../LICENSE"
+    format: tar.gz
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "checksums.txt"
+changelog:
+  # TODO: decide how to generate changelog
+  disable: true


### PR DESCRIPTION
# Description
This PR adds a release pipeline for the Modus Runtime using [GoReleaser](https://goreleaser.com/). This pipeline runs automatically on every new tag with the pattern `'runtime/v*'`. 

This pipeline generates the Go binary for six targets: `{linux,darwin,windows}-{amd64,arm64}`. Each binary is then archived together with the README and LICENSE files into a `tar.gz` (`zip` for windows) file.

GoReleaser will then create a GitHub release with the current tag, upload all the artifacts and optionally generate the changelog based on the new commits since the previous tag. We can explore automatic changelog generation at a later time.

Signing and notarizing binaries are out of the scope of this PR, and will be explored separately. The side-effect of this is for macOS at least, the first time someone downloads it and try to execute the binary, they will be prompted with a message saying "`modus_runtime` cannot be opened because the developer cannot be verified".