### PR TITLE
Update .goreleaser.yaml

### DIFF
--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -34,6 +34,8 @@ archives:
         format: zip
 checksum:
   name_template: "checksums.txt"
+release:
+  prerelease: auto
 changelog:
   # TODO: decide how to generate changelog
   disable: true


### PR DESCRIPTION
Configures GoReleaser to automatically set tags with a prerelease suffix as pre-releases on GitHub.

See https://goreleaser.com/customization/release/