### PR TITLE
Improve env file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Remove `go generate` and fix docker build [#455](https://github.com/hypermodeinc/modus/pull/455)
 - Remove AWS Secrets Manager client [#456](https://github.com/hypermodeinc/modus/pull/456)
 - Make app path required [#457](https://github.com/hypermodeinc/modus/pull/457)
+- Improve `.env` file handling [#458](https://github.com/hypermodeinc/modus/pull/458)
 
 ## 2024-10-02 - Version 0.12.7
 


### PR DESCRIPTION
# Description
With this change,  we now support similar handling of `.env` files found in other frameworks.

In order of precedence from top to bottom:

- pre-assigned environment variables
- `.env.[environment].local`
- `.env.local`
- `.env.[environment]`
- `.env`

For example, if a variable is set both in `.env.local` and `.env`, then one in `.env.local` should apply, and the one in `.env` should be ignored.  However _other_ variables from `.env` should still apply, if they haven't been set yet.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [ ] Tests for new functionality and regression tests for bug fixes added
- [ ] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR