### PR TITLE
Update command-line args and env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Remove AWS Secrets Manager client [#456](https://github.com/hypermodeinc/modus/pull/456)
 - Make app path required [#457](https://github.com/hypermodeinc/modus/pull/457)
 - Improve `.env` file handling [#458](https://github.com/hypermodeinc/modus/pull/458)
+- Update command-line args and env variables [#459](https://github.com/hypermodeinc/modus/pull/459)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,7 +23,7 @@ build:
 
 .PHONY: run
 run:
-	go run .
+	MODUS_ENV=dev go run .
 
 .PHONY: build-testdata
 build-testdata: build-testdata-assemblyscript build-testdata-golang

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,7 +23,13 @@ build:
 
 .PHONY: run
 run:
-	MODUS_ENV=dev go run .
+	@ARGS="$(filter-out $@,$(MAKECMDGOALS))" && \
+	MODUS_ENV=dev go run . $$ARGS
+
+.PHONY: runapp
+runapp:
+	@ARGS="$(filter-out $@,$(MAKECMDGOALS))" && \
+	MODUS_ENV=dev go run . -appPath $$ARGS
 
 .PHONY: build-testdata
 build-testdata: build-testdata-assemblyscript build-testdata-golang
@@ -71,3 +77,7 @@ clean:
 .PHONY: docker-build
 docker-build:
 	cd .. && docker build --build-arg RUNTIME_RELEASE_VERSION="$(VERSION)" -t modus_runtime .
+
+# Catch all rule to prevent make errors for non-target arguments
+%:
+	@true

--- a/runtime/config/commandline.go
+++ b/runtime/config/commandline.go
@@ -17,7 +17,6 @@ import (
 )
 
 var Port int
-var ModelHost string
 var AppPath string
 var UseAwsStorage bool
 var S3Bucket string
@@ -28,10 +27,11 @@ var UseJsonLogging bool
 func parseCommandLineFlags() {
 	flag.StringVar(&AppPath, "appPath", "", "REQUIRED - The path to the Modus app to load and run.")
 	flag.IntVar(&Port, "port", 8686, "The HTTP port to listen on.")
-	flag.StringVar(&ModelHost, "modelHost", "", "The base DNS of the host endpoint to the model server.")
+
 	flag.BoolVar(&UseAwsStorage, "useAwsStorage", false, "Use AWS S3 for storage instead of the local filesystem.")
 	flag.StringVar(&S3Bucket, "s3bucket", "", "The S3 bucket to use, if using AWS storage.")
 	flag.StringVar(&S3Path, "s3path", "", "The path within the S3 bucket to use, if using AWS storage.")
+
 	flag.DurationVar(&RefreshInterval, "refresh", time.Second*5, "The refresh interval to reload any changes.")
 	flag.BoolVar(&UseJsonLogging, "jsonlogs", false, "Use JSON format for logging.")
 

--- a/runtime/config/commandline_test.go
+++ b/runtime/config/commandline_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseCommandLineFlags(t *testing.T) {
+	tests := []struct {
+		name                    string
+		args                    []string
+		expectedPort            int
+		expectedAppPath         string
+		expectedUseAwsStorage   bool
+		expectedS3Bucket        string
+		expectedS3Path          string
+		expectedRefreshInterval time.Duration
+		expectedUseJsonLogging  bool
+	}{
+		{
+			name:                    "default values",
+			args:                    []string{},
+			expectedPort:            8686,
+			expectedAppPath:         "",
+			expectedUseAwsStorage:   false,
+			expectedS3Bucket:        "",
+			expectedS3Path:          "",
+			expectedRefreshInterval: time.Second * 5,
+			expectedUseJsonLogging:  false,
+		},
+		{
+			name: "custom values",
+			args: []string{
+				"-appPath=/path/to/app",
+				"-port=9090",
+				"-useAwsStorage=true",
+				"-s3bucket=my-bucket",
+				"-s3path=my-path",
+				"-refresh=10s",
+				"-jsonlogs=true",
+			},
+			expectedPort:            9090,
+			expectedAppPath:         "/path/to/app",
+			expectedUseAwsStorage:   true,
+			expectedS3Bucket:        "my-bucket",
+			expectedS3Path:          "my-path",
+			expectedRefreshInterval: 10 * time.Second,
+			expectedUseJsonLogging:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset flags and variables
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+			Port = 0
+			AppPath = ""
+			UseAwsStorage = false
+			S3Bucket = ""
+			S3Path = ""
+			RefreshInterval = 0
+			UseJsonLogging = false
+
+			// Set command line arguments
+			os.Args = append([]string{os.Args[0]}, tt.args...)
+
+			// Parse flags
+			parseCommandLineFlags()
+
+			// Check values
+			if Port != tt.expectedPort {
+				t.Errorf("expected Port %d, got %d", tt.expectedPort, Port)
+			}
+			if AppPath != tt.expectedAppPath {
+				t.Errorf("expected AppPath %s, got %s", tt.expectedAppPath, AppPath)
+			}
+			if UseAwsStorage != tt.expectedUseAwsStorage {
+				t.Errorf("expected UseAwsStorage %v, got %v", tt.expectedUseAwsStorage, UseAwsStorage)
+			}
+			if S3Bucket != tt.expectedS3Bucket {
+				t.Errorf("expected S3Bucket %s, got %s", tt.expectedS3Bucket, S3Bucket)
+			}
+			if S3Path != tt.expectedS3Path {
+				t.Errorf("expected S3Path %s, got %s", tt.expectedS3Path, S3Path)
+			}
+			if RefreshInterval != tt.expectedRefreshInterval {
+				t.Errorf("expected RefreshInterval %v, got %v", tt.expectedRefreshInterval, RefreshInterval)
+			}
+			if UseJsonLogging != tt.expectedUseJsonLogging {
+				t.Errorf("expected UseJsonLogging %v, got %v", tt.expectedUseJsonLogging, UseJsonLogging)
+			}
+		})
+	}
+}

--- a/runtime/config/config.go
+++ b/runtime/config/config.go
@@ -11,6 +11,5 @@ package config
 
 func Initialize() {
 	parseCommandLineFlags()
-	setEnvironmentName()
-	setNamespace()
+	readEnvironmentVariables()
 }

--- a/runtime/config/environment.go
+++ b/runtime/config/environment.go
@@ -10,9 +10,7 @@
 package config
 
 import (
-	"fmt"
 	"os"
-	"os/user"
 )
 
 /*
@@ -37,13 +35,16 @@ func GetEnvironmentName() string {
 	return environment
 }
 
-func setEnvironmentName() {
+func readEnvironmentVariables() {
 	environment = os.Getenv("MODUS_ENV")
 
 	// default to prod
 	if environment == "" {
 		environment = "prod"
 	}
+
+	// If running in Kubernetes, also capture the namespace environment variable.
+	namespace = os.Getenv("NAMESPACE")
 }
 
 func IsDevEnvironment() bool {
@@ -53,34 +54,4 @@ func IsDevEnvironment() bool {
 
 func GetNamespace() string {
 	return namespace
-}
-
-func setNamespace() {
-	var err error
-	namespace, err = getNamespaceFromOS()
-	if err != nil {
-		// We don't have our logger yet, so just log to stderr.
-		fmt.Fprintf(os.Stderr, "Error getting namespace: %v\n", err)
-		os.Exit(1)
-	}
-}
-
-func getNamespaceFromOS() (string, error) {
-
-	// In development, we'll use "dev/<username>" in lieu of the namespace.
-	if IsDevEnvironment() {
-		user, err := user.Current()
-		if err != nil {
-			return "", fmt.Errorf("could not get current user from the os: %w", err)
-		}
-		return "dev/" + user.Username, nil
-	}
-
-	// Otherwise, we'll use the NAMESPACE environment variable, which is required.
-	ns := os.Getenv("NAMESPACE")
-	if ns == "" {
-		return "", fmt.Errorf("NAMESPACE environment variable is not set")
-	}
-
-	return ns, nil
 }

--- a/runtime/config/environment_test.go
+++ b/runtime/config/environment_test.go
@@ -56,7 +56,7 @@ func TestEnvironmentNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Setenv("MODUS_ENV", tt.envValue)
-			setEnvironmentName()
+			readEnvironmentVariables()
 			result := GetEnvironmentName()
 			if result != tt.expectedResult {
 				t.Errorf("Expected environment to be %s, but got %s", tt.expectedResult, result)

--- a/runtime/models/hypermode.go
+++ b/runtime/models/hypermode.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package models
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hypermodeinc/modus/lib/manifest"
+	"github.com/hypermodeinc/modus/runtime/config"
+	"github.com/hypermodeinc/modus/runtime/secrets"
+)
+
+var _hypermodeModelHost string
+
+func getHypermodeModelEndpointUrl(model *manifest.ModelInfo) (string, error) {
+	// In development, use the shared Hypermode model server.
+	// Note: Authentication via the Hypermode CLI is required.
+	if config.IsDevEnvironment() {
+		if _, ok := localHypermodeModels[strings.ToLower(model.SourceModel)]; !ok {
+			return "", fmt.Errorf("model %s is not available in the local dev environment", model.SourceModel)
+		}
+		endpoint := fmt.Sprintf("https://models.hypermode.host/%s", strings.ToLower(model.SourceModel))
+		return endpoint, nil
+	}
+
+	// In production, use the Hypermode internal model endpoint.
+	// Access is protected by the Hypermode internal network.
+	if _hypermodeModelHost == "" {
+		_hypermodeModelHost = os.Getenv("HYPERMODE_MODEL_HOST")
+		if _hypermodeModelHost == "" {
+			return "", fmt.Errorf("Hypermode hosted models are not available in this environment")
+		}
+	}
+	endpoint := fmt.Sprintf("http://%s.%s/%[1]s:predict", strings.ToLower(model.Name), _hypermodeModelHost)
+	return endpoint, nil
+}
+
+func authenticateHypermodeModelRequest(ctx context.Context, req *http.Request, host *manifest.HTTPHostInfo) error {
+	// In development, Hypermode models require authentication.
+	if config.IsDevEnvironment() {
+		return secrets.ApplyAuthToLocalHypermodeModelRequest(ctx, host, req)
+	}
+
+	// In production, the Hypermode infrastructure protects the model server.
+	return nil
+}
+
+// cSpell:disable
+// These are the Hypermode models that are available in the local dev environment.
+// This list may be updated as new models are added.
+var localHypermodeModels = map[string]bool{
+	"meta-llama/meta-llama-3.1-8b-instruct":                      true,
+	"sentence-transformers/all-minilm-l6-v2":                     true,
+	"antoinemc/distilbart-mnli-github-issues":                    true,
+	"distilbert/distilbert-base-uncased-finetuned-sst-2-english": true,
+}

--- a/runtime/models/models.go
+++ b/runtime/models/models.go
@@ -73,7 +73,7 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 		return empty, err
 	}
 
-	endpoint, err := getModelEndpoint(model, host)
+	url, err := getModelEndpointUrl(model, host)
 	if err != nil {
 		var empty TResult
 		return empty, err
@@ -90,7 +90,7 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 		return nil
 	}
 
-	res, err := utils.PostHttp[TResult](ctx, endpoint, payload, bs)
+	res, err := utils.PostHttp[TResult](ctx, url, payload, bs)
 	if err != nil {
 		var empty TResult
 		return empty, err
@@ -101,7 +101,7 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 	return res.Data, nil
 }
 
-func getModelEndpoint(model *manifest.ModelInfo, host *manifest.HTTPHostInfo) (string, error) {
+func getModelEndpointUrl(model *manifest.ModelInfo, host *manifest.HTTPHostInfo) (string, error) {
 
 	if host.Name == hosts.HypermodeHost {
 		if config.IsDevEnvironment() {

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -88,7 +88,7 @@ func ApplyHostSecretsToHttpRequest(ctx context.Context, host *manifest.HTTPHostI
 	return nil
 }
 
-func ApplyAuthToLocalModelRequest(ctx context.Context, host manifest.HostInfo, req *http.Request) error {
+func ApplyAuthToLocalHypermodeModelRequest(ctx context.Context, host manifest.HostInfo, req *http.Request) error {
 
 	jwt := os.Getenv("HYP_JWT")
 	orgId := os.Getenv("HYP_ORG_ID")

--- a/runtime/storage/localstorage.go
+++ b/runtime/storage/localstorage.go
@@ -25,22 +25,22 @@ type localStorageProvider struct {
 
 func (stg *localStorageProvider) initialize(ctx context.Context) {
 	if config.AppPath == "" {
-		logger.Fatal(ctx).Msg("The -appPath command line argument is required when using local storage.  Exiting.")
+		logger.Fatal(ctx).Msg("The -appPath command line argument is required.  Exiting.")
 	}
 
 	if _, err := os.Stat(config.AppPath); os.IsNotExist(err) {
 		logger.Info(ctx).
 			Str("path", config.AppPath).
-			Msg("Creating local storage directory.")
+			Msg("Creating app directory.")
 		err := os.MkdirAll(config.AppPath, 0755)
 		if err != nil {
 			logger.Fatal(ctx).Err(err).
-				Msg("Failed to create local storage directory.  Exiting.")
+				Msg("Failed to create local app directory.  Exiting.")
 		}
 	} else {
 		logger.Info(ctx).
 			Str("path", config.AppPath).
-			Msg("Found local storage directory.")
+			Msg("Using local app directory.")
 	}
 }
 

--- a/runtime/utils/sentry.go
+++ b/runtime/utils/sentry.go
@@ -136,5 +136,9 @@ func sentryAddExtras(event *sentry.Event) {
 	if event.Extra == nil {
 		event.Extra = make(map[string]interface{})
 	}
-	event.Extra["backend"] = config.GetNamespace()
+
+	ns := config.GetNamespace()
+	if ns != "" {
+		event.Extra["namespace"] = ns
+	}
 }


### PR DESCRIPTION
# Description

- Makes the `NAMESPACE` environment variable (set by Kubernetes infrastructure) completely optional, and updates usage.
- Removes the `-modelHost` command line argument that was used only for Hypermode hosted models, replacing it with a `HYPERMODE_MODEL_HOST` environment variable.
- Refactoring and cleanup of related code

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [ ] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
