### PR TITLE
Update Sentry telemetry collection rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Make app path required [#457](https://github.com/hypermodeinc/modus/pull/457)
 - Improve `.env` file handling [#458](https://github.com/hypermodeinc/modus/pull/458)
 - Update command-line args and env variables [#459](https://github.com/hypermodeinc/modus/pull/459)
+- Update Sentry telemetry collection rules [#460](https://github.com/hypermodeinc/modus/pull/460)
 
 ## 2024-10-02 - Version 0.12.7
 


### PR DESCRIPTION
With this change, we will now only send errors and transactions to Sentry when the `SENTRY_DSN` environment variable has been set.  This means that there is no telemetry collected by default from a users development workstation or non-Hypermode environments.

The Hypermode environment can set the DSN needed to ensure telemetry is delivered for supportability of Modus applications running on Hypermode.

Additionally, we'll honor the `SENTRY_RELEASE` and `SENTRY_ENVIRONMENT` variables that the Sentry SDK uses, if they are set.  However they will default to the version number of the Modus runtime, and the environment set by `MODUS_ENV`.