### PR TITLE
narrow workflow runs

### DIFF
--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -7,10 +7,12 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - /runtime
-      - /lib
-      - /sdk/go
+    paths-ignore:
+      - /sdk/assemblyscript
+      - /tools/cli
+      - '**/*.md'
+      - '**/*.json'
+      - '.gitignore'
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -7,6 +7,9 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /runtime
+      - /sdk/go
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -9,6 +9,7 @@ on:
       - ready_for_review
     paths:
       - /runtime
+      - /lib
       - /sdk/go
 jobs:
   get-dirs:

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -7,12 +7,9 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths-ignore:
-      - /sdk/assemblyscript
-      - /tools/cli
-      - '**/*.md'
-      - '**/*.json'
-      - '.gitignore'
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -7,10 +7,12 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - /runtime
-      - /lib
-      - /sdk/go
+    paths-ignore:
+      - /sdk/assemblyscript
+      - /tools/cli
+      - '**/*.md'
+      - '**/*.json'
+      - '.gitignore'
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /runtime
+      - /lib
+      - /sdk/go
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -7,12 +7,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths-ignore:
-      - /sdk/assemblyscript
-      - /tools/cli
-      - '**/*.md'
-      - '**/*.json'
-      - '.gitignore'
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/testdata/**'
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-runtime-integration-tests.yml
+++ b/.github/workflows/ci-runtime-integration-tests.yml
@@ -6,6 +6,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /runtime
 jobs:
   runtime-integration-tests:
     name: test (runtime)

--- a/.github/workflows/ci-sdk-as-build.yml
+++ b/.github/workflows/ci-sdk-as-build.yml
@@ -6,6 +6,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /sdk/assemblyscript
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-sdk-as-lint.yml
+++ b/.github/workflows/ci-sdk-as-lint.yml
@@ -6,6 +6,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /sdk/assemblyscript
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-sdk-as-test.yml
+++ b/.github/workflows/ci-sdk-as-test.yml
@@ -8,6 +8,7 @@ on:
       - ready_for_review
     paths:
       - /sdk/assemblyscript
+      - /runtime
 jobs:
   sdk-as-test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-sdk-as-test.yml
+++ b/.github/workflows/ci-sdk-as-test.yml
@@ -8,7 +8,6 @@ on:
       - ready_for_review
     paths:
       - /sdk/assemblyscript
-      - /runtime
 jobs:
   sdk-as-test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-sdk-as-test.yml
+++ b/.github/workflows/ci-sdk-as-test.yml
@@ -6,6 +6,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /sdk/assemblyscript
 jobs:
   sdk-as-test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -6,6 +6,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths:
+      - /sdk/go
 jobs:
   get-dirs:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Description
Adding `paths` / `paths-ignore` parameters to CI workflows to remove unnecessary runs. Notably:
- go lint and test will ignore AssemblyScript SDK and CLI updates as well as .md and .json file types
- runtime integration tests will only run on changes to /runtime path
- AS SDK build and lint will only run on changes to /sdk/assemblyscript path; tests will also run on /runtime
- go SDK build will only run on changes to /sdk/go path

# Checklist
- [-] Code compiles correctly and linting passes locally
- [-] Tests for new functionality and regression tests for bug fixes added
- [-] Documentation added or updated
- [-] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
