### PR TITLE
Update runtime release asset names

### DIFF
--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -28,6 +28,7 @@ archives:
   - files:
       - "../README.md"
       - "../LICENSE"
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: tar.gz
     # use zip for windows archives
     format_overrides:


### PR DESCRIPTION
Use `v` prefix on asset names for runtime release, to align with conventions of SDK releases.