### PR TITLE
Fix AssemblyScript build failure when not in Git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Update to use new Modus manifest [#462](https://github.com/hypermodeinc/modus/pull/462)
 - Enable GraphQL endpoints to be defined in the manifest [#464](https://github.com/hypermodeinc/modus/pull/464)
 - Publish SDKs and templates via release workflows [#465](https://github.com/hypermodeinc/modus/pull/465)
+- Fix AssemblyScript build failure when no Git repo is present [#475](https://github.com/hypermodeinc/modus/pull/475)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/sdk/assemblyscript/src/transform/src/metadata.ts
+++ b/sdk/assemblyscript/src/transform/src/metadata.ts
@@ -112,6 +112,7 @@ export class Metadata {
     };
 
     const writeTable = (rows: string[][]) => {
+      rows = rows.filter((r) => !!r);
       const pad = rows.reduce(
         (max, row) => [
           Math.max(max[0], row[0].length),


### PR DESCRIPTION
When building an AssemblyScript app, if the app is not in a folder initialized for Git, then an error occurs:

```
FAILURE TypeError: Cannot read properties of undefined (reading '0')
    at <anonymous> (/Users/matt/Code/hypermodeinc/modus/sdk/assemblyscript/src/transform/src/metadata.ts:117:31)
    at Array.reduce (<anonymous>)
    at writeTable (/Users/matt/Code/hypermodeinc/modus/sdk/assemblyscript/src/transform/src/metadata.ts:115:24)
    at Metadata.logToStream (/Users/matt/Code/hypermodeinc/modus/sdk/assemblyscript/src/transform/src/metadata.ts:143:5)
    at ModusTransform.afterCompile (/Users/matt/Code/hypermodeinc/modus/sdk/assemblyscript/src/transform/src/index.ts:28:7)
    at applyTransform (/Users/matt/Code/modustemp/astest3/node_modules/assemblyscript/cli/index.js:477:31)
    at Module.Me (/Users/matt/Code/modustemp/astest3/node_modules/assemblyscript/cli/index.js:753:23)
    at async file:///Users/matt/Code/modustemp/astest3/node_modules/assemblyscript/bin/asc.js:33:22
Build failed.
```

This PR fixes this issue.