### PR TITLE
Sign MacOS runtime releases

### DIFF
--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -28,3 +28,8 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
+          MACOS_SIGN_P12: "${{ secrets.MACOS_SIGN_P12 }}"
+          MACOS_SIGN_PASSWORD: "${{ secrets.MACOS_SIGN_PASSWORD }}"
+          MACOS_NOTARY_ISSUER_ID: "${{ secrets.MACOS_NOTARY_ISSUER_ID }}"
+          MACOS_NOTARY_KEY_ID: "${{ secrets.MACOS_NOTARY_KEY_ID }}"
+          MACOS_NOTARY_KEY: "${{ secrets.MACOS_NOTARY_KEY }}"

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -14,6 +14,7 @@ jobs:
         run: 'echo "Modus Runtime version must start with `runtime/v` && exit 1'
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           ref: "${{ github.ref_name }}"
       - uses: actions/setup-go@v5
         with:

--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -24,6 +24,16 @@ builds:
       - arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags: -s -w -X github.com/hypermodeinc/modus/runtime/config.version={{.Version}}
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      sign:
+        certificate: "{{.Env.MACOS_SIGN_P12}}"
+        password: "{{.Env.MACOS_SIGN_PASSWORD}}"
+      notarize:
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
 archives:
   - files:
       - "../README.md"


### PR DESCRIPTION
Configures GoReleaser to sign and notarize the MacOS binaries of the Modus runtime.

Also updates the checkout to _not_ use a shallow clone, which will clear the warning that GoReleaser [is currently giving](https://github.com/hypermodeinc/modus/actions/runs/11397552711/job/31713183190#step:6:25)