### PR TITLE
add Discord to GitHub New Issue page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Modus Community Support
+    url: https://discord.hypermode.com
+    about: Please ask and answer questions here


### PR DESCRIPTION
# Description
This will add a link to our Discord community for Modus Community Support for the page available at https://github.com/hypermodeinc/modus/issues/new/choose.

# Checklist
- [-] Code compiles correctly and linting passes locally
- [-] Tests for new functionality and regression tests for bug fixes added
- [-] Documentation added or updated
- [-] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
