### PR TITLE
More CLI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _NOTE: This is the first fully open-source release, using the name "Modus" for t
 "Hypermode" still refers to the company and the commercial hosting platform - but not the framework.
 In previous releases, the name "Hypermode" was used for all three._
 
-- Add Modus CLI [#389](https://github.com/hypermodeinc/modus/pull/389) [#483](https://github.com/hypermodeinc/modus/pull/483) [#484](https://github.com/hypermodeinc/modus/pull/484)
+- Add Modus CLI [#389](https://github.com/hypermodeinc/modus/pull/389) [#483](https://github.com/hypermodeinc/modus/pull/483) [#484](https://github.com/hypermodeinc/modus/pull/484) [#454](https://github.com/hypermodeinc/modus/pull/485)
 - Support user defined jwt auth and sdk functions [#405](https://github.com/hypermodeinc/modus/pull/405)
 - Migrate from Hypermode to Modus [#412](https://github.com/hypermodeinc/modus/pull/412)
 - Import WasmExtractor code [#415](https://github.com/hypermodeinc/modus/pull/415)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ _NOTE: This is the first fully open-source release, using the name "Modus" for t
 "Hypermode" still refers to the company and the commercial hosting platform - but not the framework.
 In previous releases, the name "Hypermode" was used for all three._
 
-- Add Modus CLI [#389](https://github.com/hypermodeinc/modus/pull/389) [#483](https://github.com/hypermodeinc/modus/pull/483) [#484](https://github.com/hypermodeinc/modus/pull/484) [#454](https://github.com/hypermodeinc/modus/pull/485)
+- Add Modus CLI [#389](https://github.com/hypermodeinc/modus/pull/389) [#483](https://github.com/hypermodeinc/modus/pull/483) [#484](https://github.com/hypermodeinc/modus/pull/484) [#485](https://github.com/hypermodeinc/modus/pull/485)
 - Support user defined jwt auth and sdk functions [#405](https://github.com/hypermodeinc/modus/pull/405)
 - Migrate from Hypermode to Modus [#412](https://github.com/hypermodeinc/modus/pull/412)
 - Import WasmExtractor code [#415](https://github.com/hypermodeinc/modus/pull/415)

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -14,7 +14,7 @@ PACKAGE_ORG="@hypermode"
 PACKAGE_NAME="modus-cli"
 INSTALL_DIR="${MODUS_CLI:-"$HOME/.modus/cli"}"
 VERSION="latest"
-INSTALLER_VERSION="0.1.0"
+INSTALLER_VERSION="0.1.1"
 
 NODE_MIN=22
 NODE_PATH="$(which node)"
@@ -120,6 +120,7 @@ build_path_str() {
   if [[ $profile == *.fish ]]; then
     echo -e "set -gx MODUS_CLI \"$install_dir\"\nstring match -r \".modus\" \"\$PATH\" > /dev/null; or set -gx PATH \"\$MODUS_CLI/bin\" \$PATH"
   else
+    install_dir="${install_dir/#$HOME/\$HOME}"
     echo -e "\n# Modus CLI\nexport MODUS_CLI=\"$install_dir\"\nexport PATH=\"\$MODUS_CLI/bin:\$PATH\""
   fi
 }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@oclif/core": "^4",
         "chalk": "^5.3.0",
+        "chokidar": "^4.0.1",
         "gradient-string": "^3.0.0",
         "ora": "^8.1.0",
         "semver": "^7.6.3"
@@ -23,9 +24,6 @@
         "oclif": "^4",
         "ts-node": "^10",
         "typescript": "^5"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2457,6 +2455,21 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -3833,6 +3846,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/registry-auth-token": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,9 +17,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
-  "engines": {
-    "node": ">=22"
-  },
   "bin": {
     "modus": "./bin/modus.js"
   },
@@ -32,6 +29,7 @@
   "dependencies": {
     "@oclif/core": "^4",
     "chalk": "^5.3.0",
+    "chokidar": "^4.0.1",
     "gradient-string": "^3.0.0",
     "ora": "^8.1.0",
     "semver": "^7.6.3"

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -62,13 +62,13 @@ export default class BuildCommand extends Command {
       switch (app.sdk) {
         case SDK.AssemblyScript:
           if (!(await fs.exists(path.join(appPath, "node_modules")))) {
-            const results = await execFileWithExitCode("npm", ["install"], { cwd: appPath, env: process.env });
+            const results = await execFileWithExitCode("npm", ["install"], { cwd: appPath, env: process.env, shell: true });
             if (results.exitCode !== 0) {
               this.logError("Failed to install dependencies");
               return results;
             }
           }
-          return await execFileWithExitCode("npx", ["modus-as-build"], { cwd: appPath, env: process.env });
+          return await execFileWithExitCode("npx", ["modus-as-build"], { cwd: appPath, env: process.env, shell: true });
         case SDK.Go:
           const version = app.sdkVersion || (await vi.getLatestInstalledSdkVersion(app.sdk, true));
           if (!version) {

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -208,6 +208,7 @@ export default class CustomHelp extends Help {
     if (flags.length) {
       this.log(chalk.bold("Flags:"));
       for (const flag of Object.values(command.flags)) {
+        if (flag.hidden) continue;
         this.log("  " + chalk.bold.blueBright("--" + flag.name) + " ".repeat(margin - flag.name.length) + flag.description);
       }
       this.log();


### PR DESCRIPTION
- Fixes `--nologo` flags rendering on help menus
- Fixes spawn errors on Windows
- Fixes watching for rebuild in `modus dev` on Windows
- Terminates `modus dev` correctly when runtime exits
- Updates install script to not expand `$HOME` path
- Removes the Node 22 engine attribute from the CLI.  The CLI runs fine on older Node.  The CLI itself will report if Node needs to be updated for the AssemblyScript SDK.