### PR TITLE
Fix CLI warnings about Go/TinyGo installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Update SDK releases [#480](https://github.com/hypermodeinc/modus/pull/480)
 - Add metadata shared library [#482](https://github.com/hypermodeinc/modus/pull/482)
 - Add `.gitignore` files to default templates [#486](https://github.com/hypermodeinc/modus/pull/486)
+- Fix CLI warnings about Go/TinyGo installation [#487](https://github.com/hypermodeinc/modus/pull/487)
 
 ## 2024-10-02 - Version 0.12.7
 


### PR DESCRIPTION
# Description
Fixed and improved CLI errors when Go or TinyGo is not installed or outdated.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
