### PR TITLE
Remove deprecated model fields from manifest schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Update SDK releases [#480](https://github.com/hypermodeinc/modus/pull/480)
 - Add metadata shared library [#482](https://github.com/hypermodeinc/modus/pull/482)
 - Add `.gitignore` files to default templates [#486](https://github.com/hypermodeinc/modus/pull/486)
+- Remove deprecated model fields [#488](https://github.com/hypermodeinc/modus/pull/488)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/lib/manifest/modus_schema.json
+++ b/lib/manifest/modus_schema.json
@@ -69,13 +69,6 @@
                 "required": ["sourceModel", "provider", "connection"],
                 "additionalProperties": false,
                 "properties": {
-                  "task": {
-                    "type": "string",
-                    "deprecated": true,
-                    "minLength": 1,
-                    "enum": ["classification", "embedding", "generation"],
-                    "description": "Training intent of the model, such as 'classification' or 'embedding'.\n\nThis field is deprecated and no longer used.  It will be removed in a future version of the schema."
-                  },
                   "sourceModel": {
                     "type": "string",
                     "minLength": 1,
@@ -92,11 +85,6 @@
                     "type": "string",
                     "const": "hypermode",
                     "description": "Connection for the model.  Either 'hypermode', or the name of an external connection as defined in the 'connections' section."
-                  },
-                  "dedicated": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether to have the model be dedicated to the project, or shared."
                   }
                 }
               },
@@ -105,13 +93,6 @@
                 "required": ["connection"],
                 "additionalProperties": false,
                 "properties": {
-                  "task": {
-                    "type": "string",
-                    "deprecated": true,
-                    "minLength": 1,
-                    "enum": ["classification", "embedding", "generation"],
-                    "description": "Training intent of model, such as 'classification' or 'embedding'.\n\nThis field is deprecated and no longer used.  It will be removed in a future version of the schema."
-                  },
                   "sourceModel": {
                     "type": "string",
                     "minLength": 1,

--- a/lib/manifest/test/manifest_test.go
+++ b/lib/manifest/test/manifest_test.go
@@ -50,12 +50,6 @@ func TestReadManifest(t *testing.T) {
 				SourceModel: "source-model-3",
 				Connection:  "my-model-connection",
 			},
-			"model-4": {
-				Name:        "model-4",
-				SourceModel: "example/source-model-4",
-				Provider:    "hugging-face",
-				Connection:  "hypermode",
-			},
 		},
 		Connections: map[string]manifest.ConnectionInfo{
 			"my-model-connection": manifest.HTTPConnectionInfo{

--- a/lib/manifest/test/valid_modus.json
+++ b/lib/manifest/test/valid_modus.json
@@ -22,12 +22,6 @@
     "model-3": {
       "sourceModel": "source-model-3",
       "connection": "my-model-connection"
-    },
-    "model-4": {
-      "sourceModel": "example/source-model-4",
-      "provider": "hugging-face",
-      "connection": "hypermode",
-      "dedicated": true
     }
   },
   "connections": {


### PR DESCRIPTION
The `modus.json` schema had some fields that are no longer used.  Removing.