### PR TITLE
Improve dev first use log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Update SDK releases [#480](https://github.com/hypermodeinc/modus/pull/480)
 - Add metadata shared library [#482](https://github.com/hypermodeinc/modus/pull/482)
 - Add `.gitignore` files to default templates [#486](https://github.com/hypermodeinc/modus/pull/486)
+- Improve dev first use log messages [#489](https://github.com/hypermodeinc/modus/pull/489)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -178,7 +178,6 @@ export default class DevCommand extends Command {
       // NOTE: The built-in fs.watch or fsPromises.watch is insufficient for our needs.
       // Instead, we use chokidar for consistent behavior in cross-platform file watching.
       const ignoredPaths = [path.join(appPath, "build") + path.sep, path.join(appPath, "node_modules") + path.sep];
-      this.log(chalk.dim("Ignoring paths:"), ignoredPaths);
       chokidar
         .watch(appPath, {
           ignored: (filePath, stats) => (stats?.isFile() || true) && ignoredPaths.some((p) => path.normalize(filePath).startsWith(p)),

--- a/runtime/db/db.go
+++ b/runtime/db/db.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/hypermodeinc/modus/lib/manifest"
+	"github.com/hypermodeinc/modus/runtime/config"
 	"github.com/hypermodeinc/modus/runtime/logger"
 	"github.com/hypermodeinc/modus/runtime/metrics"
 	"github.com/hypermodeinc/modus/runtime/plugins"
@@ -243,7 +244,9 @@ func logDbWarningOrError(ctx context.Context, err error, msg string) {
 	if _, ok := err.(*pgconn.ConnectError); ok {
 		logger.Warn(ctx).Err(err).Msgf("Database connection error. %s", msg)
 	} else if errors.Is(err, errDbNotConfigured) {
-		logger.Warn(ctx).Msgf("Database has not been configured. %s", msg)
+		if !config.IsDevEnvironment() {
+			logger.Warn(ctx).Msgf("Database has not been configured. %s", msg)
+		}
 	} else {
 		logger.Err(ctx, err).Msg(msg)
 	}
@@ -663,7 +666,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 func Initialize(ctx context.Context) {
 	// this will initialize the pool and start the worker
 	_, err := globalRuntimePostgresWriter.GetPool(ctx)
-	if err != nil {
+	if err != nil && !config.IsDevEnvironment() {
 		logger.Warn(ctx).Err(err).Msg("Metadata database is not available.")
 	}
 	go globalRuntimePostgresWriter.worker(ctx)

--- a/runtime/manifestdata/manifestdata.go
+++ b/runtime/manifestdata/manifestdata.go
@@ -38,21 +38,16 @@ func SetManifest(m *manifest.Manifest) {
 
 func MonitorManifestFile(ctx context.Context) {
 	loadFile := func(file storage.FileInfo) error {
+		logger.Info(ctx).Str("filename", file.Name).Msg("Loading manifest file.")
 		if file.Name != manifestFileName {
 			return nil
 		}
-		err := loadManifest(ctx)
-		if err == nil {
-			logger.Info(ctx).
-				Str("filename", file.Name).
-				Msg("Loaded manifest file.")
-		} else {
-			logger.Err(ctx, err).
-				Str("filename", file.Name).
-				Msg("Failed to load manifest file.")
+
+		if err := loadManifest(ctx); err != nil {
+			logger.Err(ctx, err).Str("filename", file.Name).Msg("Failed to load manifest file.")
 		}
 
-		return err
+		return nil
 	}
 
 	// NOTE: Removing the manifest file entirely is not currently supported.


### PR DESCRIPTION
# Description
To improve the first use of launching `modus dev` I've done the following:
- In dev, hide the warnings about the DB not being configured.  The DB isn't required for most operations, and we'll soon have an alternative.
- Fix the sort order of messages logged when reading the manifest.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
