### PR TITLE
Fix data race in logging adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Remove deprecated model fields [#488](https://github.com/hypermodeinc/modus/pull/488)
 - Improve dev first use log messages [#489](https://github.com/hypermodeinc/modus/pull/489)
 - Highlight endpoints when running in dev [#490](https://github.com/hypermodeinc/modus/pull/490)
+- Fix data race in logging adapter [#491](https://github.com/hypermodeinc/modus/pull/491)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/runtime/manifestdata/manifestdata.go
+++ b/runtime/manifestdata/manifestdata.go
@@ -45,6 +45,7 @@ func MonitorManifestFile(ctx context.Context) {
 
 		if err := loadManifest(ctx); err != nil {
 			logger.Err(ctx, err).Str("filename", file.Name).Msg("Failed to load manifest file.")
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
Integration tests started failing intermittently following #489

Found that we were missing a mutex on the logging adapters.  Also found I missed an `err` return in #489.

Fixed both.