### PR TITLE
Improve file watching and fix Windows issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Simplify and polish `modus new` experience [#494](https://github.com/hypermodeinc/modus/pull/494)
 - Move hyp settings for local model invocation to env variables [#495](https://github.com/hypermodeinc/modus/pull/495) [#504](https://github.com/hypermodeinc/modus/pull/504)
 - Change GraphQL SDK examples to use a generic public GraphQL API [#501](https://github.com/hypermodeinc/modus/pull/501)
+- Improve file watching and fix Windows issues [#505](https://github.com/hypermodeinc/modus/pull/505)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -13,6 +13,7 @@
         "chokidar": "^4.0.1",
         "gradient-string": "^3.0.0",
         "ora": "^8.1.0",
+        "picomatch": "^4.0.2",
         "semver": "^7.6.3"
       },
       "bin": {
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@oclif/test": "^4",
         "@types/node": "^22",
+        "@types/picomatch": "^3.0.1",
         "@types/semver": "^7.5.8",
         "oclif": "^4",
         "ts-node": "^10",
@@ -2812,6 +2814,13 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.1.tgz",
+      "integrity": "sha512-1MRgzpzY0hOp9pW/kLRxeQhUWwil6gnrUYd3oEpeYBqp/FexhaCPv3F8LsYr47gtUU45fO2cm1dbwkSrHEo8Uw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -4111,6 +4120,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
@@ -4439,12 +4460,12 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,11 +34,13 @@
     "chokidar": "^4.0.1",
     "gradient-string": "^3.0.0",
     "ora": "^8.1.0",
+    "picomatch": "^4.0.2",
     "semver": "^7.6.3"
   },
   "devDependencies": {
     "@oclif/test": "^4",
     "@types/node": "^22",
+    "@types/picomatch": "^3.0.1",
     "@types/semver": "^7.5.8",
     "oclif": "^4",
     "ts-node": "^10",

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -59,16 +59,21 @@ export default class BuildCommand extends Command {
     process.env.FORCE_COLOR = chalk.level.toString();
 
     const results = await withSpinner("Building " + app.name, async () => {
+      const execOpts = {
+        cwd: appPath,
+        env: process.env,
+        shell: true,
+      };
       switch (app.sdk) {
         case SDK.AssemblyScript:
           if (!(await fs.exists(path.join(appPath, "node_modules")))) {
-            const results = await execFileWithExitCode("npm", ["install"], { cwd: appPath, env: process.env, shell: true });
+            const results = await execFileWithExitCode("npm", ["install"], execOpts);
             if (results.exitCode !== 0) {
               this.logError("Failed to install dependencies");
               return results;
             }
           }
-          return await execFileWithExitCode("npx", ["modus-as-build"], { cwd: appPath, env: process.env, shell: true });
+          return await execFileWithExitCode("npx", ["modus-as-build"], execOpts);
         case SDK.Go:
           const version = app.sdkVersion || (await vi.getLatestInstalledSdkVersion(app.sdk, true));
           if (!version) {
@@ -81,7 +86,7 @@ export default class BuildCommand extends Command {
             this.logError("Modus Go Build tool is not installed");
             return;
           }
-          return await execFileWithExitCode(buildTool, ["."], { cwd: appPath, env: process.env });
+          return await execFileWithExitCode(buildTool, ["."], execOpts);
         default:
           this.logError("Unsupported SDK");
           this.exit(1);

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -52,10 +52,10 @@ export default class DevCommand extends Command {
       aliases: ["no-watch"],
       description: "Don't watch app code for changes",
     }),
-    freq: Flags.integer({
+    delay: Flags.integer({
       char: "f",
-      description: "Frequency to check for changes",
-      default: 3000,
+      description: "Delay (in milliseconds) between file change detection and rebuild",
+      default: 500,
     }),
   };
 
@@ -162,7 +162,6 @@ export default class DevCommand extends Command {
     runtime.on("close", (code) => this.exit(code || 1));
 
     if (!flags.nowatch) {
-      const delay = flags.freq;
       let lastModified = 0;
       let lastBuild = 0;
       let paused = true;
@@ -175,15 +174,15 @@ export default class DevCommand extends Command {
         if (lastBuild > lastModified) {
           return;
         }
-
         lastBuild = Date.now();
+
         try {
           this.log();
           this.log(chalk.magentaBright("Detected change. Rebuilding..."));
           this.log();
           await BuildCommand.run([appPath, "--no-logo"]);
         } catch {}
-      }, delay);
+      }, flags.delay);
 
       const globs = getGlobsToWatch(sdk);
 
@@ -211,7 +210,7 @@ export default class DevCommand extends Command {
           ignoreInitial: true,
           persistent: true,
         })
-        .on("all", async (event, path) => {
+        .on("all", () => {
           lastModified = Date.now();
           paused = false;
         });

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -85,9 +85,9 @@ export default class DevCommand extends Command {
       await withSpinner(chalk.dim("Downloading and installing " + sdkText), async (spinner) => {
         try {
           await installer.installSDK(sdk, sdkVersion);
-        } catch {
+        } catch (e) {
           spinner.fail(chalk.red(`Failed to download ${sdkText}`));
-          this.exit(1);
+          throw e;
         }
         spinner.succeed(chalk.dim(`Installed ${sdkText}`));
       });
@@ -101,9 +101,9 @@ export default class DevCommand extends Command {
           await withSpinner(chalk.dim("Downloading and installing " + runtimeText), async (spinner) => {
             try {
               await installer.installRuntime(runtimeVersion!);
-            } catch {
+            } catch (e) {
               spinner.fail(chalk.red("Failed to download " + runtimeText));
-              this.exit(1);
+              throw e;
             }
             spinner.succeed(chalk.dim("Installed " + runtimeText));
           });
@@ -119,9 +119,9 @@ export default class DevCommand extends Command {
         await withSpinner(chalk.dim("Downloading and installing " + runtimeText), async (spinner) => {
           try {
             await installer.installRuntime(version!);
-          } catch {
+          } catch (e) {
             spinner.fail(chalk.red("Failed to download " + runtimeText));
-            this.exit(1);
+            throw e;
           }
           spinner.succeed(chalk.dim("Installed " + runtimeText));
         });

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -100,9 +100,9 @@ export default class RuntimeInstallCommand extends Command {
       await withSpinner(chalk.dim("Downloading and installing " + runtimeText), async (spinner) => {
         try {
           await installer.installRuntime(version);
-        } catch {
+        } catch (e) {
           spinner.fail(chalk.red(`Failed to download ${runtimeText}`));
-          this.exit(1);
+          throw e;
         }
         spinner.succeed(chalk.dim(`Installed ${runtimeText}`));
       });

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -142,9 +142,9 @@ export default class SDKInstallCommand extends Command {
       await withSpinner(chalk.dim("Downloading and installing " + sdkText), async (spinner) => {
         try {
           await installer.installSDK(sdk, sdkVersion);
-        } catch {
+        } catch (e) {
           spinner.fail(chalk.red(`Failed to download ${sdkText}`));
-          this.exit(1);
+          throw e;
         }
         spinner.succeed(chalk.dim(`Installed ${sdkText}`));
       });
@@ -191,9 +191,9 @@ export default class SDKInstallCommand extends Command {
       await withSpinner(chalk.dim("Downloading and installing " + runtimeText), async (spinner) => {
         try {
           await installer.installRuntime(version);
-        } catch {
+        } catch (e) {
           spinner.fail(chalk.red(`Failed to download ${runtimeText}`));
-          this.exit(1);
+          throw e;
         }
         spinner.succeed(chalk.dim(`Installed ${runtimeText}`));
       });

--- a/cli/src/util/installer.ts
+++ b/cli/src/util/installer.ts
@@ -11,7 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import * as fs from "./fs.js";
 import * as vi from "./versioninfo.js";
-import { execFile } from "./cp.js";
+import { extract } from "./tar.js";
 import { downloadFile, isOnline } from "./index.js";
 import { GitHubOwner, GitHubRepo, SDK } from "../custom/globals.js";
 
@@ -57,6 +57,6 @@ export async function installRuntime(version: string) {
 
   const installDir = vi.getRuntimePath(version);
   await fs.mkdir(installDir, { recursive: true });
-  await execFile("tar", ["-xf", archivePath, "-C", installDir]);
+  await extract(archivePath, installDir);
   await fs.rm(archivePath);
 }

--- a/cli/src/util/tar.ts
+++ b/cli/src/util/tar.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { execFile } from "./cp.js";
+
+export async function extract(archivePath: string, installDir: string, ...args: string[]): Promise<void> {
+  let tarCmd = "tar";
+
+  if (os.platform() === "win32") {
+    // On Windows, make sure we're using the OS's tar command,
+    // to avoid issues with the tar command that comes with Git Bash.
+    tarCmd = path.join(process.env.SystemRoot!, "System32", "tar.exe");
+  }
+
+  await execFile(tarCmd, ["-xf", archivePath, "-C", installDir, ...args]);
+}

--- a/cspell.json
+++ b/cspell.json
@@ -128,6 +128,7 @@
     "PEMS",
     "pgconn",
     "pgxpool",
+    "picomatch",
     "picsum",
     "pjson",
     "pkgs",

--- a/runtime/graphql/engine/engine.go
+++ b/runtime/graphql/engine/engine.go
@@ -11,6 +11,7 @@ package engine
 
 import (
 	"fmt"
+	"os"
 	"sync"
 
 	"context"
@@ -82,7 +83,7 @@ func generateSchema(ctx context.Context, md *metadata.Metadata) (*gql.Schema, *d
 		if config.UseJsonLogging {
 			logger.Debug(ctx).Str("schema", generated.Schema).Msg("Generated schema")
 		} else {
-			fmt.Printf("\n%s\n", generated.Schema)
+			fmt.Fprintf(os.Stderr, "\n%s\n", generated.Schema)
 		}
 	}
 

--- a/runtime/httpserver/server.go
+++ b/runtime/httpserver/server.go
@@ -169,7 +169,7 @@ func GetMainHandler(options ...func(map[string]http.Handler)) http.Handler {
 		mux.ReplaceRoutes(routes)
 
 		if len(endpoints) > 0 && config.IsDevEnvironment() {
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
 
 			titleColor := color.New(color.FgHiGreen, color.Bold)
 			itemColor := color.New(color.FgHiBlue)
@@ -178,21 +178,21 @@ func GetMainHandler(options ...func(map[string]http.Handler)) http.Handler {
 
 			if len(endpoints) == 1 {
 				ep := endpoints[0]
-				titleColor.Println("Your local endpoint is ready!")
-				itemColor.Printf("• %s (%s): ", ep.apiType, ep.name)
-				urlColor.Println(ep.url)
+				titleColor.Fprintln(os.Stderr, "Your local endpoint is ready!")
+				itemColor.Fprintf(os.Stderr, "• %s (%s): ", ep.apiType, ep.name)
+				urlColor.Fprintln(os.Stderr, ep.url)
 			} else {
-				titleColor.Println("Your local endpoints are ready!")
+				titleColor.Fprintln(os.Stderr, "Your local endpoints are ready!")
 				for _, ep := range endpoints {
-					itemColor.Printf("• %s (%s): ", ep.apiType, ep.name)
-					urlColor.Println(ep.url)
+					itemColor.Fprintf(os.Stderr, "• %s (%s): ", ep.apiType, ep.name)
+					urlColor.Fprintln(os.Stderr, ep.url)
 				}
 			}
 
-			fmt.Println()
-			noticeColor.Println("Changes will automatically be applied when you save your files.")
-			noticeColor.Println("Press Ctrl+C at any time to stop the server.")
-			fmt.Println()
+			fmt.Fprintln(os.Stderr)
+			noticeColor.Fprintln(os.Stderr, "Changes will automatically be applied when you save your files.")
+			noticeColor.Fprintln(os.Stderr, "Press Ctrl+C at any time to stop the server.")
+			fmt.Fprintln(os.Stderr)
 		}
 
 		return nil

--- a/runtime/secrets/secrets.go
+++ b/runtime/secrets/secrets.go
@@ -100,9 +100,9 @@ func ApplyAuthToLocalHypermodeModelRequest(ctx context.Context, connection manif
 	warningColor := color.New(color.FgHiYellow, color.Bold)
 
 	if jwt == "" || orgId == "" {
-		fmt.Println()
-		warningColor.Println("Warning: Local authentication not found. Please login using `hyp login`")
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
+		warningColor.Fprintln(os.Stderr, "Warning: Local authentication not found. Please login using `hyp login`")
+		fmt.Fprintln(os.Stderr)
 		return errLocalAuthFailed
 	}
 
@@ -111,9 +111,9 @@ func ApplyAuthToLocalHypermodeModelRequest(ctx context.Context, connection manif
 		return err
 	}
 	if isExpired {
-		fmt.Println()
-		warningColor.Println("Warning: Local authentication expired. Please login using `hyp login`")
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
+		warningColor.Fprintln(os.Stderr, "Warning: Local authentication expired. Please login using `hyp login`")
+		fmt.Fprintln(os.Stderr)
 		return errLocalAuthFailed
 	}
 


### PR DESCRIPTION
- Fixes continuous rebuild when using `modus dev`, by using include/exclude globs that exclude generated files.
- Fixes runtime installation and `modus new` template extraction on Windows
- Improves the display output in `modus dev` by pausing the runtime child process `stderr` while building, so the runtime logs don't interleave with the cli text
- Ensures the runtime is always writing status messages to `stderr` to align with previous change
- Improves debuggability of hard errors in the CLI by throwing instead of just exiting
- Reduces the initial delay to detect changes so it feels more responsive
- A few other misc cleanup items