### PR TITLE
CLI Polish Round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Move hyp settings for local model invocation to env variables [#495](https://github.com/hypermodeinc/modus/pull/495) [#504](https://github.com/hypermodeinc/modus/pull/504)
 - Change GraphQL SDK examples to use a generic public GraphQL API [#501](https://github.com/hypermodeinc/modus/pull/501)
 - Improve file watching and fix Windows issues [#505](https://github.com/hypermodeinc/modus/pull/505)
+- Improve help messages and show SDK version in `modus new` [#506](https://github.com/hypermodeinc/modus/pull/506)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Move hyp settings for local model invocation to env variables [#495](https://github.com/hypermodeinc/modus/pull/495) [#504](https://github.com/hypermodeinc/modus/pull/504)
 - Change GraphQL SDK examples to use a generic public GraphQL API [#501](https://github.com/hypermodeinc/modus/pull/501)
 - Improve file watching and fix Windows issues [#505](https://github.com/hypermodeinc/modus/pull/505)
-- Improve help messages and show SDK version in `modus new` [#506](https://github.com/hypermodeinc/modus/pull/506)
+- Improve help messages, add `modus info` and show SDK version in `modus new` [#506](https://github.com/hypermodeinc/modus/pull/506)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,12 @@
       "runtime": {
         "description": "Modus Runtime Management"
       }
-    }
+    },
+    "additionalHelpFlags": [
+      "-h"
+    ],
+    "additionalVersionFlags": [
+      "-v"
+    ]
   }
 }

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -29,6 +29,11 @@ export default class BuildCommand extends Command {
   };
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -35,6 +35,11 @@ export default class DevCommand extends Command {
   };
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -1,12 +1,3 @@
-/*
- * Copyright 2024 Hypermode Inc.
- * Licensed under the terms of the Apache License, Version 2.0
- * See the LICENSE file that accompanied this code for further details.
- *
- * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import os from "node:os";
@@ -110,13 +101,13 @@ export default class InfoCommand extends Command {
   }
 
   async getNPMVersion(): Promise<string> {
-    const { stdout } = await execFileWithExitCode("npm", ["--version"]);
+    const { stdout } = await execFileWithExitCode("npm", ["--version"], { shell: true });
     return stdout.trim();
   }
 
   async getGoVersion(): Promise<string> {
     try {
-      const { stdout } = await execFileWithExitCode("go", ["version"]);
+      const { stdout } = await execFileWithExitCode("go", ["version"], { shell: true });
       return stdout.trim().split(" ")[2];
     } catch (error) {
       return "Not installed";
@@ -125,7 +116,7 @@ export default class InfoCommand extends Command {
 
   async getTinyGoVersion(): Promise<string> {
     try {
-      const { stdout } = await execFileWithExitCode("tinygo", ["version"]);
+      const { stdout } = await execFileWithExitCode("tinygo", ["version"], { shell: true });
       return stdout.trim().split(" ")[2];
     } catch (error) {
       return "Not installed";

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command, Flags } from "@oclif/core";
+import chalk from "chalk";
+import os from "node:os";
+import * as vi from "../../util/versioninfo.js";
+import { SDK } from "../../custom/globals.js";
+import { getHeader } from "../../custom/header.js";
+import { execFileWithExitCode } from "../../util/cp.js";
+
+export default class InfoCommand extends Command {
+  static args = {};
+
+  static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
+    nologo: Flags.boolean({
+      aliases: ["no-logo"],
+      hidden: true,
+    }),
+  };
+
+  static description = "Show Modus info";
+
+  static examples = ["modus info"];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(InfoCommand);
+
+    if (!flags.nologo) {
+      this.log(getHeader(this.config.version));
+    }
+
+    const info = await this.logInfo();
+    this.displayInfo(info);
+  }
+
+  async logInfo(): Promise<Record<string, string | string[]>> {
+    await this.logRuntimeVersions();
+    await this.logSDKVersions();
+
+    return {
+      "Modus Installation Path": this.config.root,
+      "Operating System": `${os.type()} ${os.release()}`,
+      "Platform Architecture": process.arch,
+      "Node.js Version": process.version,
+      "NPM Version": await this.getNPMVersion(),
+      "Go Version": await this.getGoVersion(),
+      "TinyGo Version": await this.getTinyGoVersion(),
+    };
+  }
+
+  displayInfo(info: Record<string, string | string[]>): void {
+    for (const [key, value] of Object.entries(info)) {
+      if (Array.isArray(value)) {
+        this.log(`${chalk.bold(key)}:`);
+        value.forEach((v) => this.log(`  ${v}`));
+      } else if (value) {
+        this.log(`${chalk.bold(key)}: ${value}`);
+      }
+    }
+  }
+
+  async logRuntimeVersions() {
+    const versions = await vi.getInstalledRuntimeVersions();
+    if (versions.length > 0) {
+      this.log(chalk.bold.cyan("Installed Runtimes:"));
+      for (const version of versions) {
+        this.log(`• Modus Runtime ${version}`);
+      }
+    } else {
+      this.log(chalk.yellow("No Modus runtimes installed"));
+    }
+
+    this.log();
+  }
+
+  async logSDKVersions() {
+    let found = false;
+    for (const sdk of Object.values(SDK)) {
+      const versions = await vi.getInstalledSdkVersions(sdk);
+      if (versions.length === 0) {
+        continue;
+      }
+      if (!found) {
+        this.log(chalk.bold.cyan("Installed SDKs:"));
+        found = true;
+      }
+
+      for (const version of versions) {
+        this.log(`• Modus ${sdk} SDK ${version}`);
+      }
+    }
+
+    if (!found) {
+      this.log(chalk.yellow("No Modus SDKs installed"));
+    }
+
+    this.log();
+  }
+
+  async getNPMVersion(): Promise<string> {
+    const { stdout } = await execFileWithExitCode("npm", ["--version"]);
+    return stdout.trim();
+  }
+
+  async getGoVersion(): Promise<string> {
+    try {
+      const { stdout } = await execFileWithExitCode("go", ["version"]);
+      return stdout.trim().split(" ")[2];
+    } catch (error) {
+      return "Not installed";
+    }
+  }
+
+  async getTinyGoVersion(): Promise<string> {
+    try {
+      const { stdout } = await execFileWithExitCode("tinygo", ["version"]);
+      return stdout.trim().split(" ")[2];
+    } catch (error) {
+      return "Not installed";
+    }
+  }
+}

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -34,8 +34,8 @@ export default class NewCommand extends Command {
   static flags = {
     help: Flags.help({
       char: "h",
-      helpLabel: '-h, --help',
-      description: "Show help message"
+      helpLabel: "-h, --help",
+      description: "Show help message",
     }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
@@ -110,6 +110,14 @@ export default class NewCommand extends Command {
 
     const dir = flags.dir || "." + path.sep + name;
 
+    if (!flags.force && (await fs.exists(dir))) {
+      const confirmed = await inquirer.confirm({ message: `Directory ${dir} already exists. Do you want to overwrite it?`, default: false });
+      if (!confirmed) {
+        this.log(chalk.dim("Aborted"));
+        this.exit(1);
+      }
+    }
+
     if (!flags.force) {
       const confirmed = await inquirer.confirm({ message: "Continue?", default: true });
       if (!confirmed) {
@@ -123,14 +131,6 @@ export default class NewCommand extends Command {
   }
 
   private async createApp(name: string, dir: string, sdk: SDK, template: string, force: boolean, prerelease: boolean) {
-    if (!force && (await fs.exists(dir))) {
-      const confirmed = await inquirer.confirm({ message: "Attempting to overwrite a folder that already exists.\nAre you sure you want to continue?", default: false });
-      if (!confirmed) {
-        this.log(chalk.dim("Aborted"));
-        this.exit(1);
-      }
-    }
-
     // Validate SDK-specific prerequisites
     const sdkText = `Modus ${sdk} SDK`;
     switch (sdk) {

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -84,14 +84,19 @@ export default class NewCommand extends Command {
     if (flags.sdk) {
       sdk = parseSDK(flags.sdk);
     } else {
+      const latestGoVersion = await vi.getLatestInstalledSdkVersion(SDK.Go, flags.prerelease);
+      const lastestAsVersion = await vi.getLatestInstalledSdkVersion(SDK.AssemblyScript, flags.prerelease);
+
       const sdkInput = await inquirer.select({
         message: "Select a SDK",
         default: SDK.Go,
         choices: [
           {
+            name: `${SDK.Go} (${latestGoVersion})`,
             value: SDK.Go,
           },
           {
+            name: `${SDK.AssemblyScript} (${lastestAsVersion})`,
             value: SDK.AssemblyScript,
           },
         ],

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -32,6 +32,11 @@ export default class NewCommand extends Command {
   static examples = ["modus new", "modus new --name my-app", "modus new --name my-app --sdk go --dir ./my-app --force"];
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: '-h, --help',
+      description: "Show help message"
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -85,19 +85,14 @@ export default class NewCommand extends Command {
       if (flags.sdk) {
         sdk = parseSDK(flags.sdk);
       } else {
-        const latestGoVersion = await vi.getLatestInstalledSdkVersion(SDK.Go, flags.prerelease);
-        const lastestAsVersion = await vi.getLatestInstalledSdkVersion(SDK.AssemblyScript, flags.prerelease);
-
         const sdkInput = await inquirer.select({
           message: "Select a SDK",
           default: SDK.Go,
           choices: [
             {
-              name: `${SDK.Go} (${latestGoVersion})`,
               value: SDK.Go,
             },
             {
-              name: `${SDK.AssemblyScript} (${lastestAsVersion})`,
               value: SDK.AssemblyScript,
             },
           ],

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -27,6 +27,11 @@ export default class RuntimeInstallCommand extends Command {
   static examples = ["modus runtime install", "modus runtime install v1.2.3", "modus runtime install --prerelease"];
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: '-h, --help',
+      description: "Show help message"
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -17,6 +17,11 @@ export default class RuntimeListCommand extends Command {
   static description = "List installed Modus runtimes";
   static examples = ["modus runtime list"];
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/runtime/remove/index.ts
+++ b/cli/src/commands/runtime/remove/index.ts
@@ -24,6 +24,11 @@ export default class RuntimeRemoveCommand extends Command {
   };
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     force: Flags.boolean({
       char: "f",
       default: false,

--- a/cli/src/commands/runtime/remove/index.ts
+++ b/cli/src/commands/runtime/remove/index.ts
@@ -52,13 +52,18 @@ export default class RuntimeRemoveCommand extends Command {
         this.log(chalk.yellow("No Modus runtimes are installed."));
         this.exit(1);
       } else if (!flags.force) {
-        const confirmed = await inquirer.confirm({
-          message: "Are you sure you want to remove all Modus runtimes?",
-          default: false,
-        });
-        if (!confirmed) {
-          this.log(chalk.dim("Aborted"));
-          this.exit(1);
+        try {
+          const confirmed = await inquirer.confirm({
+            message: "Are you sure you want to remove all Modus runtimes?",
+            default: false,
+          });
+          if (!confirmed) {
+            this.abort();
+          }
+        } catch (err: any) {
+          if (err.name === "ExitPromptError") {
+            this.abort();
+          }
         }
       }
 
@@ -75,13 +80,18 @@ export default class RuntimeRemoveCommand extends Command {
         this.log(chalk.yellow(runtimeText + "is not installed."));
         this.exit(1);
       } else if (!flags.force) {
-        const confirmed = await inquirer.confirm({
-          message: `Are you sure you want to remove ${runtimeText}?`,
-          default: false,
-        });
-        if (!confirmed) {
-          this.log(chalk.dim("Aborted"));
-          this.exit(1);
+        try {
+          const confirmed = await inquirer.confirm({
+            message: `Are you sure you want to remove ${runtimeText}?`,
+            default: false,
+          });
+          if (!confirmed) {
+            this.abort();
+          }
+        } catch (err: any) {
+          if (err.name === "ExitPromptError") {
+            this.abort();
+          }
         }
       }
 
@@ -105,5 +115,10 @@ export default class RuntimeRemoveCommand extends Command {
 
   private logError(message: string) {
     this.log(chalk.red(" ERROR ") + chalk.dim(": " + message));
+  }
+
+  private abort() {
+    this.log(chalk.dim("Aborted"));
+    this.exit(1);
   }
 }

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -34,6 +34,11 @@ export default class SDKInstallCommand extends Command {
   static examples = ["modus sdk install assemblyscript", "modus sdk install assemblyscript v1.2.3", "modus sdk install", "modus sdk install --prerelease"];
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -18,6 +18,11 @@ export default class SDKListCommand extends Command {
   static description = "List installed Modus SDKs";
   static examples = ["modus sdk list"];
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     nologo: Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -71,13 +71,18 @@ export default class SDKRemoveCommand extends Command {
       }
 
       if (!flags.force) {
-        const confirmed = inquirer.confirm({
-          message: "Are you sure you want to remove all Modus SDKs?",
-          default: false,
-        });
-        if (!confirmed) {
-          this.log(chalk.dim("Aborted"));
-          this.exit(1);
+        try {
+          const confirmed = inquirer.confirm({
+            message: "Are you sure you want to remove all Modus SDKs?",
+            default: false,
+          });
+          if (!confirmed) {
+            this.abort();
+          }
+        } catch (err: any) {
+          if (err.name === "ExitPromptError") {
+            this.abort();
+          }
         }
       }
 
@@ -102,13 +107,18 @@ export default class SDKRemoveCommand extends Command {
           this.log(chalk.yellow(`No Modus ${sdk} SDKs are installed.`));
           this.exit(1);
         } else if (!flags.force) {
-          const confirmed = inquirer.confirm({
-            message: `Are you sure you want to remove all Modus ${sdk} SDKs?`,
-            default: false,
-          });
-          if (!confirmed) {
-            this.log(chalk.dim("Aborted"));
-            this.exit(1);
+          try {
+            const confirmed = inquirer.confirm({
+              message: `Are you sure you want to remove all Modus ${sdk} SDKs?`,
+              default: false,
+            });
+            if (!confirmed) {
+              this.abort();
+            }
+          } catch (err: any) {
+            if (err.name === "ExitPromptError") {
+              this.abort();
+            }
           }
         }
 
@@ -125,13 +135,18 @@ export default class SDKRemoveCommand extends Command {
           this.log(chalk.yellow(sdkText + "is not installed."));
           this.exit(1);
         } else if (!flags.force) {
-          const confirmed = inquirer.confirm({
-            message: `Are you sure you want to remove ${sdkText}?`,
-            default: false,
-          });
-          if (!confirmed) {
-            this.log(chalk.dim("Aborted"));
-            this.exit(1);
+          try {
+            const confirmed = inquirer.confirm({
+              message: `Are you sure you want to remove ${sdkText}?`,
+              default: false,
+            });
+            if (!confirmed) {
+              this.abort();
+            }
+          } catch (err: any) {
+            if (err.name === "ExitPromptError") {
+              this.abort();
+            }
           }
         }
 
@@ -170,5 +185,10 @@ export default class SDKRemoveCommand extends Command {
 
   private logError(message: string) {
     this.log(chalk.red(" ERROR ") + chalk.dim(": " + message));
+  }
+
+  private abort() {
+    this.log(chalk.dim("Aborted"));
+    this.exit(1);
   }
 }

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -29,6 +29,11 @@ export default class SDKRemoveCommand extends Command {
   };
 
   static flags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
     runtimes: Flags.boolean({
       char: "r",
       default: false,

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -75,6 +75,18 @@ export default class CustomHelp extends Help {
     return out.trim();
   }
 
+  formatFlags(topics: Interfaces.Topic[]): string {
+    let out = "";
+    if (topics.find((v) => !v.hidden)) out += chalk.bold("Flags:") + "\n";
+    else return out;
+
+    for (const topic of topics) {
+      if (topic.hidden) continue;
+      out += "  " + chalk.bold.blue(topic.name) + " ".repeat(Math.max(1, this.pre_pad + this.post_pad - topic.name.length)) + topic.description + "\n";
+    }
+    return out.trim();
+  }
+
   formatFooter(): string {
     let out = "";
     const links = [
@@ -141,6 +153,19 @@ export default class CustomHelp extends Help {
       this.log(this.formatTopics(rootTopics));
       this.log();
     }
+
+    const globalFlagTopics: Interfaces.Topic[] = [
+      {
+        name: "--help",
+        description: "Show help message",
+      },
+      {
+        name: "--version",
+        description: "Show Modus version",
+      },
+    ];
+    this.log(this.formatFlags(globalFlagTopics));
+    this.log();
 
     this.log(this.formatFooter());
   }

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -92,7 +92,7 @@ export default class CustomHelp extends Help {
     const links = [
       { name: "Docs", url: "https://docs.hypermode.com/modus" },
       { name: "GitHub", url: "https://github.com/hypermodeinc/modus" },
-      { name: "Discord", url: "https://discord.hypermode.com" },
+      { name: "Discord", url: "https://discord.hypermode.com (#modus)" },
     ];
 
     for (const link of links) {

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -82,7 +82,9 @@ export default class CustomHelp extends Help {
 
     for (const topic of topics) {
       if (topic.hidden) continue;
-      out += "  " + chalk.bold.blue(topic.name) + " ".repeat(Math.max(1, this.pre_pad + this.post_pad - topic.name.length)) + topic.description + "\n";
+
+      const fullName = topic.shortName ? `${topic.shortName}, ${topic.name}` : topic.name;
+      out += "  " + chalk.bold.blue(fullName) + " ".repeat(Math.max(1, this.pre_pad + this.post_pad - fullName.length)) + topic.description + "\n";
     }
     return out.trim();
   }
@@ -158,10 +160,12 @@ export default class CustomHelp extends Help {
       {
         name: "--help",
         description: "Show help message",
+        shortName: "-h",
       },
       {
         name: "--version",
         description: "Show Modus version",
+        shortName: "-v",
       },
     ];
     this.log(this.formatFlags(globalFlagTopics));

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -216,7 +216,7 @@ export default class CustomHelp extends Help {
     if (command.description) this.log(chalk.hex("#A585FF")(command.description));
 
     const argsStr = args.length > 0 ? " " + args.map((a) => `<${a}>`).join(" ") : "";
-    const flagsStr = flags.length > 0 ? " [...flags]" : "";
+    const flagsStr = flags.length > 0 ? " [flags]" : "";
     this.log(`${chalk.bold("Usage:")} modus ${name}${chalk.blueBright(argsStr + flagsStr)}\n`);
 
     if (args.length) {
@@ -241,7 +241,9 @@ export default class CustomHelp extends Help {
       this.log(chalk.bold("Flags:"));
       for (const flag of Object.values(command.flags)) {
         if (flag.hidden) continue;
-        this.log("  " + chalk.bold.blueBright("--" + flag.name) + " ".repeat(margin - flag.name.length) + flag.description);
+
+        const flagOptions = flag.char ? `-${flag.char}, --${flag.name}` : `--${flag.name}`;
+        this.log("  " + chalk.bold.blueBright(flagOptions) + " ".repeat(margin + 2 - flagOptions.length) + flag.description);
       }
       this.log();
     }


### PR DESCRIPTION
# Description

- [HYP-2433](https://linear.app/hypermode/issue/HYP-2433/)[: modus should list global flags](https://github.com/hypermodeinc/modus/commit/42504facd15f0d30ff29ec456e6c6674a603955f)
- [HYP-2478](https://linear.app/hypermode/issue/HYP-2478/) [+](https://github.com/hypermodeinc/modus/pull/506/commits/9823d52d3e20dd8261451929017e8ca90fe709d4) [HYP-2468](https://linear.app/hypermode/issue/HYP-2468/)[: List flags for commands and enable -h](https://github.com/hypermodeinc/modus/pull/506/commits/9823d52d3e20dd8261451929017e8ca90fe709d4)
- [HYP-2447](https://linear.app/hypermode/issue/HYP-2447/)[: modus new should warn writing into existing folder earlier](https://github.com/hypermodeinc/modus/pull/506/commits/506744e0c540885fc95f56ad15a2f360116dd9ad)
- [HYP-2479](https://linear.app/hypermode/issue/HYP-2479/)[: modus new: List Go/AS SDK version in the selector](https://github.com/hypermodeinc/modus/pull/506/commits/8fc800bbfffb20381bc99e80246ef06c41f3f5e2)
- [HYP-2436](https://linear.app/hypermode/issue/HYP-2436/)[: Add simple info command or flag to modus CLI](https://github.com/hypermodeinc/modus/pull/506/commits/bd9a793b06ce3787d6779538eb3a9d038b6c5af5)
- [HYP-2482](https://linear.app/hypermode/issue/HYP-2482/)[: add error catching for all interactive prompt](https://github.com/hypermodeinc/modus/pull/506/commits/d06068285556fd186cd1ca51e66fad81fb4636d7)
- [HYP-2486](https://linear.app/hypermode/issue/HYP-2486/)[: enable -h and -v for global commands and print them for glo](https://github.com/hypermodeinc/modus/pull/506/commits/399b5ee9d62c6a037122e228536d0efc650f4e4a)

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
