### PR TITLE
centralize systemVersions

### DIFF
--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import * as vi from "../../util/versioninfo.js";
 import { SDK } from "../../custom/globals.js";
 import { getHeader } from "../../custom/header.js";
-import { execFileWithExitCode } from "../../util/cp.js";
+import { getGoVersion, getNPMVersion, getTinyGoVersion } from "../../util/systemVersions.js";
 
 export default class InfoCommand extends Command {
   static args = {};
@@ -45,9 +45,9 @@ export default class InfoCommand extends Command {
       "Operating System": `${os.type()} ${os.release()}`,
       "Platform Architecture": process.arch,
       "Node.js Version": process.version,
-      "NPM Version": await this.getNPMVersion(),
-      "Go Version": await this.getGoVersion(),
-      "TinyGo Version": await this.getTinyGoVersion(),
+      "NPM Version": await getNPMVersion() || "Not installed",
+      "Go Version": await getGoVersion() || "Not installed",
+      "TinyGo Version": await getTinyGoVersion() || "Not installed",
     };
   }
 
@@ -98,28 +98,5 @@ export default class InfoCommand extends Command {
     }
 
     this.log();
-  }
-
-  async getNPMVersion(): Promise<string> {
-    const { stdout } = await execFileWithExitCode("npm", ["--version"], { shell: true });
-    return stdout.trim();
-  }
-
-  async getGoVersion(): Promise<string> {
-    try {
-      const { stdout } = await execFileWithExitCode("go", ["version"], { shell: true });
-      return stdout.trim().split(" ")[2];
-    } catch (error) {
-      return "Not installed";
-    }
-  }
-
-  async getTinyGoVersion(): Promise<string> {
-    try {
-      const { stdout } = await execFileWithExitCode("tinygo", ["version"], { shell: true });
-      return stdout.trim().split(" ")[2];
-    } catch (error) {
-      return "Not installed";
-    }
   }
 }

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -23,6 +23,7 @@ import { extract } from "../../util/tar.js";
 import SDKInstallCommand from "../sdk/install/index.js";
 import { getHeader } from "../../custom/header.js";
 import * as inquirer from "@inquirer/prompts";
+import { getGoVersion, getTinyGoVersion } from "../../util/systemVersions.js";
 
 const MODUS_DEFAULT_TEMPLATE_NAME = "default";
 
@@ -102,12 +103,14 @@ export default class NewCommand extends Command {
       }
 
       const defaultAppName = getDefaultAppNameBySdk(sdk);
-      const name =
+      let name =
         flags.name ||
         (await inquirer.input({
           message: "Pick a name for your app:",
           default: defaultAppName,
         }));
+
+      name = toValidAppName(name);
 
       const dir = flags.dir || "." + path.sep + name;
 
@@ -315,33 +318,6 @@ export default class NewCommand extends Command {
     this.log(chalk.dim("Aborted"));
     this.exit(1);
   }
-}
-
-async function getGoVersion(): Promise<string | undefined> {
-  try {
-    const result = await execFile("go", ["version"], {
-      shell: true,
-      cwd: ModusHomeDir,
-      env: process.env,
-    });
-    const parts = result.stdout.split(" ");
-    const str = parts.length > 2 ? parts[2] : undefined;
-    if (str?.startsWith("go")) {
-      return str.slice(2);
-    }
-  } catch {}
-}
-
-async function getTinyGoVersion(): Promise<string | undefined> {
-  try {
-    const result = await execFile("tinygo", ["version"], {
-      shell: true,
-      cwd: ModusHomeDir,
-      env: process.env,
-    });
-    const parts = result.stdout.split(" ");
-    return parts.length > 2 ? parts[2] : undefined;
-  } catch {}
 }
 
 function toValidAppName(input: string): string {

--- a/cli/src/util/systemVersions.ts
+++ b/cli/src/util/systemVersions.ts
@@ -1,13 +1,24 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { execFile } from "./cp.js";
 import { ModusHomeDir } from "../custom/globals.js";
 
+const EXEC_OPTIONS = {
+  shell: true,
+  cwd: ModusHomeDir,
+  env: process.env,
+};
+
 export async function getGoVersion(): Promise<string | undefined> {
   try {
-    const result = await execFile("go", ["version"], {
-      shell: true,
-      cwd: ModusHomeDir,
-      env: process.env,
-    });
+    const result = await execFile("go", ["version"], EXEC_OPTIONS);
     const parts = result.stdout.split(" ");
     const str = parts.length > 2 ? parts[2] : undefined;
     if (str?.startsWith("go")) {
@@ -18,11 +29,7 @@ export async function getGoVersion(): Promise<string | undefined> {
 
 export async function getTinyGoVersion(): Promise<string | undefined> {
   try {
-    const result = await execFile("tinygo", ["version"], {
-      shell: true,
-      cwd: ModusHomeDir,
-      env: process.env,
-    });
+    const result = await execFile("tinygo", ["version"], EXEC_OPTIONS);
     const parts = result.stdout.split(" ");
     return parts.length > 2 ? parts[2] : undefined;
   } catch {}
@@ -30,7 +37,7 @@ export async function getTinyGoVersion(): Promise<string | undefined> {
 
 export async function getNPMVersion(): Promise<string | undefined> {
   try {
-    const result = await execFile("npm", ["--version"], { shell: true });
+    const result = await execFile("npm", ["--version"], EXEC_OPTIONS);
     const parts = result.stdout.split(" ");
     return parts.length > 0 ? parts[0].trim() : undefined;
   } catch {}

--- a/cli/src/util/systemVersions.ts
+++ b/cli/src/util/systemVersions.ts
@@ -1,0 +1,37 @@
+import { execFile } from "./cp.js";
+import { ModusHomeDir } from "../custom/globals.js";
+
+export async function getGoVersion(): Promise<string | undefined> {
+  try {
+    const result = await execFile("go", ["version"], {
+      shell: true,
+      cwd: ModusHomeDir,
+      env: process.env,
+    });
+    const parts = result.stdout.split(" ");
+    const str = parts.length > 2 ? parts[2] : undefined;
+    if (str?.startsWith("go")) {
+      return str.slice(2);
+    }
+  } catch {}
+}
+
+export async function getTinyGoVersion(): Promise<string | undefined> {
+  try {
+    const result = await execFile("tinygo", ["version"], {
+      shell: true,
+      cwd: ModusHomeDir,
+      env: process.env,
+    });
+    const parts = result.stdout.split(" ");
+    return parts.length > 2 ? parts[2] : undefined;
+  } catch {}
+}
+
+export async function getNPMVersion(): Promise<string | undefined> {
+  try {
+    const result = await execFile("npm", ["--version"], { shell: true });
+    const parts = result.stdout.split(" ");
+    return parts.length > 0 ? parts[0].trim() : undefined;
+  } catch {}
+}


### PR DESCRIPTION
# Description
- centralize the util to get go/tinygo versions
- fix a bug where invalid chars in app name is not removed or hyphenated.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
