### PR TITLE
Fix runtime shutdown issues with `modus dev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Change GraphQL SDK examples to use a generic public GraphQL API [#501](https://github.com/hypermodeinc/modus/pull/501)
 - Improve file watching and fix Windows issues [#505](https://github.com/hypermodeinc/modus/pull/505)
 - Improve help messages, add `modus info` and show SDK version in `modus new` [#506](https://github.com/hypermodeinc/modus/pull/506)
+- Fix runtime shutdown issues with `modus dev` [#508](https://github.com/hypermodeinc/modus/pull/508)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -34,7 +34,7 @@ export default class BuildCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -56,7 +56,7 @@ export default class BuildCommand extends Command {
 
     const app = await getAppInfo(appPath);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -35,7 +35,7 @@ export default class BuildCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
   };

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -40,7 +40,7 @@ export default class DevCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -51,14 +51,17 @@ export default class DevCommand extends Command {
     prerelease: Flags.boolean({
       char: "p",
       aliases: ["pre"],
-      description: "Use a prerelease version of the Modus runtime.  Not needed if specifying a runtime version.",
+      description: "Use a prerelease version of the Modus runtime. Not needed if specifying a runtime version.",
     }),
-    nowatch: Flags.boolean({
-      aliases: ["no-watch"],
+    "no-build": Flags.boolean({
+      aliases: ["nobuild"],
+      description: "Don't build the app before running (implies --no-watch)",
+    }),
+    "no-watch": Flags.boolean({
+      aliases: ["nowatch"],
       description: "Don't watch app code for changes",
     }),
     delay: Flags.integer({
-      char: "f",
       description: "Delay (in milliseconds) between file change detection and rebuild",
       default: 500,
     }),
@@ -81,7 +84,7 @@ export default class DevCommand extends Command {
     const app = await getAppInfo(appPath);
     const { sdk, sdkVersion } = app;
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 
@@ -148,7 +151,9 @@ export default class DevCommand extends Command {
     const ext = os.platform() === "win32" ? ".exe" : "";
     const runtimePath = path.join(vi.getRuntimePath(runtimeVersion), "modus_runtime" + ext);
 
-    await BuildCommand.run([appPath, "--no-logo"]);
+    if (!flags["no-build"]) {
+      await BuildCommand.run([appPath, "--no-logo"]);
+    }
 
     const hypSettings = await readHypermodeSettings();
 
@@ -167,7 +172,7 @@ export default class DevCommand extends Command {
     child.stderr.pipe(process.stderr);
     child.on("close", (code) => this.exit(code || 1));
 
-    if (!flags.nowatch) {
+    if (!flags["no-watch"] && !flags["no-build"]) {
       let lastModified = 0;
       let lastBuild = 0;
       let paused = true;

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -41,7 +41,7 @@ export default class DevCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
     runtime: Flags.string({

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -15,7 +15,7 @@ export default class InfoCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -28,7 +28,7 @@ export default class InfoCommand extends Command {
   async run(): Promise<void> {
     const { flags } = await this.parse(InfoCommand);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 
@@ -45,9 +45,9 @@ export default class InfoCommand extends Command {
       "Operating System": `${os.type()} ${os.release()}`,
       "Platform Architecture": process.arch,
       "Node.js Version": process.version,
-      "NPM Version": await getNPMVersion() || "Not installed",
-      "Go Version": await getGoVersion() || "Not installed",
-      "TinyGo Version": await getTinyGoVersion() || "Not installed",
+      "NPM Version": (await getNPMVersion()) || "Not installed",
+      "Go Version": (await getGoVersion()) || "Not installed",
+      "TinyGo Version": (await getTinyGoVersion()) || "Not installed",
     };
   }
 

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -16,7 +16,7 @@ export default class InfoCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
   };

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -39,7 +39,7 @@ export default class NewCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
     name: Flags.string({

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -38,7 +38,7 @@ export default class NewCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -76,7 +76,7 @@ export default class NewCommand extends Command {
     try {
       const { flags } = await this.parse(NewCommand);
 
-      if (!flags.nologo) {
+      if (!flags["no-logo"]) {
         this.log(getHeader(this.config.version));
       }
 

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -29,10 +29,10 @@ export default class RuntimeInstallCommand extends Command {
   static flags = {
     help: Flags.help({
       char: "h",
-      helpLabel: '-h, --help',
-      description: "Show help message"
+      helpLabel: "-h, --help",
+      description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -52,7 +52,7 @@ export default class RuntimeInstallCommand extends Command {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(RuntimeInstallCommand);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -33,7 +33,7 @@ export default class RuntimeInstallCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
     force: Flags.boolean({

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -23,7 +23,7 @@ export default class RuntimeListCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
   };

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -22,7 +22,7 @@ export default class RuntimeListCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -31,7 +31,7 @@ export default class RuntimeListCommand extends Command {
   async run(): Promise<void> {
     const { flags } = await this.parse(RuntimeListCommand);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -40,7 +40,7 @@ export default class SDKInstallCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
     force: Flags.boolean({

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -39,7 +39,7 @@ export default class SDKInstallCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -59,7 +59,7 @@ export default class SDKInstallCommand extends Command {
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SDKInstallCommand);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -24,7 +24,7 @@ export default class SDKListCommand extends Command {
       description: "Show help message",
     }),
     "no-logo": Flags.boolean({
-      aliases: ["no-logo"],
+      aliases: ["nologo"],
       hidden: true,
     }),
   };

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -23,7 +23,7 @@ export default class SDKListCommand extends Command {
       helpLabel: "-h, --help",
       description: "Show help message",
     }),
-    nologo: Flags.boolean({
+    "no-logo": Flags.boolean({
       aliases: ["no-logo"],
       hidden: true,
     }),
@@ -32,7 +32,7 @@ export default class SDKListCommand extends Command {
   async run(): Promise<void> {
     const { flags } = await this.parse(SDKListCommand);
 
-    if (!flags.nologo) {
+    if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
     }
 

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -75,19 +75,19 @@ export default class CustomHelp extends Help {
     return out.trim();
   }
 
-  formatFlags(topics: Interfaces.Topic[]): string {
-    let out = "";
-    if (topics.find((v) => !v.hidden)) out += chalk.bold("Flags:") + "\n";
-    else return out;
+  // formatFlags(topics: Interfaces.Topic[]): string {
+  //   let out = "";
+  //   if (topics.find((v) => !v.hidden)) out += chalk.bold("Flags:") + "\n";
+  //   else return out;
 
-    for (const topic of topics) {
-      if (topic.hidden) continue;
+  //   for (const topic of topics) {
+  //     if (topic.hidden) continue;
 
-      const fullName = topic.shortName ? `${topic.shortName}, ${topic.name}` : topic.name;
-      out += "  " + chalk.bold.blue(fullName) + " ".repeat(Math.max(1, this.pre_pad + this.post_pad - fullName.length)) + topic.description + "\n";
-    }
-    return out.trim();
-  }
+  //     const fullName = topic.shortName ? `${topic.shortName}, ${topic.name}` : topic.name;
+  //     out += "  " + chalk.bold.blue(fullName) + " ".repeat(Math.max(1, this.pre_pad + this.post_pad - fullName.length)) + topic.description + "\n";
+  //   }
+  //   return out.trim();
+  // }
 
   formatFooter(): string {
     let out = "";
@@ -156,20 +156,20 @@ export default class CustomHelp extends Help {
       this.log();
     }
 
-    const globalFlagTopics: Interfaces.Topic[] = [
-      {
-        name: "--help",
-        description: "Show help message",
-        shortName: "-h",
-      },
-      {
-        name: "--version",
-        description: "Show Modus version",
-        shortName: "-v",
-      },
-    ];
-    this.log(this.formatFlags(globalFlagTopics));
-    this.log();
+    // const globalFlagTopics: Interfaces.Topic[] = [
+    //   {
+    //     name: "--help",
+    //     description: "Show help message",
+    //     shortName: "-h",
+    //   },
+    //   {
+    //     name: "--version",
+    //     description: "Show Modus version",
+    //     shortName: "-v",
+    //   },
+    // ];
+    // this.log(this.formatFlags(globalFlagTopics));
+    // this.log();
 
     this.log(this.formatFooter());
   }

--- a/cspell.json
+++ b/cspell.json
@@ -112,6 +112,7 @@
     "mydgraph",
     "nanos",
     "Nanotime",
+    "nobuild",
     "noescape",
     "nolint",
     "nologo",

--- a/runtime/app/app.go
+++ b/runtime/app/app.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package app
+
+import (
+	"sync"
+	"time"
+)
+
+// ShutdownTimeout is the time to wait for the server to shutdown gracefully.
+const ShutdownTimeout = 5 * time.Second
+
+var mu = &sync.RWMutex{}
+var shuttingDown = false
+
+func IsShuttingDown() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return shuttingDown
+}
+
+func SetShuttingDown() {
+	mu.Lock()
+	defer mu.Unlock()
+	shuttingDown = true
+}

--- a/runtime/functions/events.go
+++ b/runtime/functions/events.go
@@ -12,6 +12,8 @@ package functions
 import (
 	"context"
 	"sync"
+
+	"github.com/hypermodeinc/modus/runtime/app"
 )
 
 type FunctionsLoadedCallback = func(ctx context.Context)
@@ -26,6 +28,9 @@ func RegisterFunctionsLoadedCallback(callback FunctionsLoadedCallback) {
 }
 
 func triggerFunctionsLoaded(ctx context.Context) {
+	if ctx.Err() != nil || app.IsShuttingDown() {
+		return
+	}
 	eventsMutex.RLock()
 	defer eventsMutex.RUnlock()
 	for _, callback := range functionsLoadedCallbacks {

--- a/runtime/manifestdata/events.go
+++ b/runtime/manifestdata/events.go
@@ -12,6 +12,8 @@ package manifestdata
 import (
 	"context"
 	"sync"
+
+	"github.com/hypermodeinc/modus/runtime/app"
 )
 
 type ManifestLoadedCallback = func(ctx context.Context) error
@@ -26,6 +28,10 @@ func RegisterManifestLoadedCallback(callback ManifestLoadedCallback) {
 }
 
 func triggerManifestLoaded(ctx context.Context) error {
+	if ctx.Err() != nil || app.IsShuttingDown() {
+		return nil
+	}
+
 	eventsMutex.RLock()
 	defer eventsMutex.RUnlock()
 

--- a/runtime/pluginmanager/events.go
+++ b/runtime/pluginmanager/events.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/hypermodeinc/modus/lib/metadata"
+	"github.com/hypermodeinc/modus/runtime/app"
 )
 
 type PluginLoadedCallback = func(ctx context.Context, md *metadata.Metadata) error
@@ -28,6 +29,10 @@ func RegisterPluginLoadedCallback(callback PluginLoadedCallback) {
 }
 
 func triggerPluginLoaded(ctx context.Context, md *metadata.Metadata) error {
+	if ctx.Err() != nil || app.IsShuttingDown() {
+		return nil
+	}
+
 	eventsMutex.RLock()
 	defer eventsMutex.RUnlock()
 	for _, callback := range pluginLoadedCallbacks {


### PR DESCRIPTION
- Captures `SIGINT` and `SIGTERM` signals from the CLI and forwards them to the runtime for graceful exit
- Improves the runtime's event handling when shutting down, so we don't see extraneous/conflicting log messages
- Updates some of the CLI flags
