### PR TITLE
Log bad GraphQL requests in dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ In previous releases, the name "Hypermode" was used for all three._
 - Improve help messages, add `modus info` and show SDK version in `modus new` [#506](https://github.com/hypermodeinc/modus/pull/506)
 - Fix runtime shutdown issues with `modus dev` [#508](https://github.com/hypermodeinc/modus/pull/508)
 - Monitored manifest and env files for changes [#509](https://github.com/hypermodeinc/modus/pull/509)
+- Log bad GraphQL requests in dev [#510](https://github.com/hypermodeinc/modus/pull/510)
 
 ## 2024-10-02 - Version 0.12.7
 


### PR DESCRIPTION
# Description
In dev, especially with `modus dev`, we now log invalid GraphQL requests.
We still avoid logging them in non-dev environments, to prevent a bad actor from spamming the logs.

Includes some minor code cleanup.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
