### PR TITLE
Use conventions to support GraphQL mutations and adjust query names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ In previous releases, the name "Hypermode" was used for all three._
 - Fix runtime shutdown issues with `modus dev` [#508](https://github.com/hypermodeinc/modus/pull/508)
 - Monitored manifest and env files for changes [#509](https://github.com/hypermodeinc/modus/pull/509)
 - Log bad GraphQL requests in dev [#510](https://github.com/hypermodeinc/modus/pull/510)
-- Add jwks endpoint key support to auth [#511](https://github.com/hypermodeinc/modus/pull/511)
+- Add JWKS endpoint key support to auth [#511](https://github.com/hypermodeinc/modus/pull/511)
+- Use conventions to support GraphQL mutations and adjust query names [#513](https://github.com/hypermodeinc/modus/pull/513)
 
 ## 2024-10-02 - Version 0.12.7
 

--- a/cspell.json
+++ b/cspell.json
@@ -88,6 +88,7 @@
     "jsonlogs",
     "jsonparser",
     "jsonschema",
+    "JWKS",
     "langsupport",
     "ldflags",
     "legacymodels",

--- a/runtime/graphql/datasource/configuration.go
+++ b/runtime/graphql/datasource/configuration.go
@@ -14,6 +14,7 @@ import (
 )
 
 type HypDSConfig struct {
-	WasmHost wasmhost.WasmHost
-	MapTypes []string
+	WasmHost          wasmhost.WasmHost
+	FieldsToFunctions map[string]string
+	MapTypes          []string
 }

--- a/runtime/graphql/datasource/source.go
+++ b/runtime/graphql/datasource/source.go
@@ -28,8 +28,9 @@ import (
 const DataSourceName = "ModusDataSource"
 
 type callInfo struct {
-	Function   fieldInfo      `json:"fn"`
-	Parameters map[string]any `json:"data"`
+	FieldInfo    fieldInfo      `json:"field"`
+	FunctionName string         `json:"function"`
+	Parameters   map[string]any `json:"data"`
 }
 
 type ModusDataSource struct {
@@ -65,7 +66,7 @@ func (*ModusDataSource) LoadWithFiles(ctx context.Context, input []byte, files [
 func (ds *ModusDataSource) callFunction(ctx context.Context, callInfo *callInfo) (any, []resolve.GraphQLError, error) {
 
 	// Get the function info
-	fnInfo, err := ds.WasmHost.GetFunctionInfo(callInfo.Function.Name)
+	fnInfo, err := ds.WasmHost.GetFunctionInfo(callInfo.FunctionName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,7 +80,7 @@ func (ds *ModusDataSource) callFunction(ctx context.Context, callInfo *callInfo)
 
 	// Store the execution info into the function output map.
 	outputMap := ctx.Value(utils.FunctionOutputContextKey).(map[string]wasmhost.ExecutionInfo)
-	outputMap[callInfo.Function.AliasOrName()] = execInfo
+	outputMap[callInfo.FieldInfo.AliasOrName()] = execInfo
 
 	// Transform messages (and error lines in the output buffers) to GraphQL errors.
 	messages := append(execInfo.Messages(), utils.TransformConsoleOutput(execInfo.Buffers())...)
@@ -107,7 +108,7 @@ func (ds *ModusDataSource) callFunction(ctx context.Context, callInfo *callInfo)
 
 func writeGraphQLResponse(ctx context.Context, out *bytes.Buffer, result any, gqlErrors []resolve.GraphQLError, fnErr error, ci *callInfo) error {
 
-	fieldName := ci.Function.AliasOrName()
+	fieldName := ci.FieldInfo.AliasOrName()
 
 	// Include the function error
 	if fnErr != nil {
@@ -139,7 +140,7 @@ func writeGraphQLResponse(ctx context.Context, out *bytes.Buffer, result any, gq
 				msg := fmt.Sprintf("Function completed successfully, but the result contains a %v value that cannot be serialized to JSON.", err.Value)
 				logger.Warn(ctx).
 					Bool("user_visible", true).
-					Str("function", ci.Function.Name).
+					Str("function", ci.FunctionName).
 					Str("result", fmt.Sprintf("%+v", result)).
 					Msg(msg)
 				fmt.Fprintf(out, `{"errors":[{"message":"%s","path":["%s"],"extensions":{"level":"error"}}]}`, msg, fieldName)
@@ -149,7 +150,7 @@ func writeGraphQLResponse(ctx context.Context, out *bytes.Buffer, result any, gq
 		}
 
 		// Transform the data
-		if r, err := transformValue(jsonResult, &ci.Function); err != nil {
+		if r, err := transformValue(jsonResult, &ci.FieldInfo); err != nil {
 			return err
 		} else {
 			jsonData = r
@@ -395,7 +396,7 @@ func transformErrors(messages []utils.LogMessage, ci *callInfo) []resolve.GraphQ
 		if msg.IsError() {
 			errors = append(errors, resolve.GraphQLError{
 				Message: msg.Message,
-				Path:    []any{ci.Function.AliasOrName()},
+				Path:    []any{ci.FieldInfo.AliasOrName()},
 				Extensions: map[string]interface{}{
 					"level": msg.Level,
 				},

--- a/runtime/graphql/engine/engine.go
+++ b/runtime/graphql/engine/engine.go
@@ -94,8 +94,9 @@ func generateSchema(ctx context.Context, md *metadata.Metadata) (*gql.Schema, *d
 	}
 
 	cfg := &datasource.HypDSConfig{
-		WasmHost: wasmhost.GetWasmHost(ctx),
-		MapTypes: generated.MapTypes,
+		WasmHost:          wasmhost.GetWasmHost(ctx),
+		FieldsToFunctions: generated.FieldsToFunctions,
+		MapTypes:          generated.MapTypes,
 	}
 
 	return schema, cfg, nil

--- a/runtime/graphql/engine/engine.go
+++ b/runtime/graphql/engine/engine.go
@@ -106,24 +106,25 @@ func getDatasourceConfig(ctx context.Context, schema *gql.Schema, cfg *datasourc
 	defer span.Finish()
 
 	queryTypeName := schema.QueryTypeName()
-	queryFieldNames := getAllQueryFields(ctx, schema)
+	queryFieldNames := getTypeFields(ctx, schema, queryTypeName)
+
+	mutationTypeName := schema.MutationTypeName()
+	mutationFieldNames := getTypeFields(ctx, schema, mutationTypeName)
+
 	rootNodes := []plan.TypeField{
 		{
 			TypeName:   queryTypeName,
 			FieldNames: queryFieldNames,
 		},
+		{
+			TypeName:   mutationTypeName,
+			FieldNames: mutationFieldNames,
+		},
 	}
 
-	var childNodes []plan.TypeField
-	for _, f := range queryFieldNames {
-		fields := schema.GetAllNestedFieldChildrenFromTypeField(queryTypeName, f, gql.NewSkipReservedNamesFunc())
-		for _, field := range fields {
-			childNodes = append(childNodes, plan.TypeField{
-				TypeName:   field.TypeName,
-				FieldNames: field.FieldNames,
-			})
-		}
-	}
+	childNodes := []plan.TypeField{}
+	childNodes = append(childNodes, getChildNodes(queryFieldNames, schema, queryTypeName)...)
+	childNodes = append(childNodes, getChildNodes(mutationFieldNames, schema, mutationTypeName)...)
 
 	return plan.NewDataSourceConfiguration(
 		datasource.DataSourceName,
@@ -131,6 +132,24 @@ func getDatasourceConfig(ctx context.Context, schema *gql.Schema, cfg *datasourc
 		&plan.DataSourceMetadata{RootNodes: rootNodes, ChildNodes: childNodes},
 		*cfg,
 	)
+}
+
+func getChildNodes(fieldNames []string, schema *gql.Schema, typeName string) []plan.TypeField {
+	var foundFields = make(map[string]bool)
+	var childNodes []plan.TypeField
+	for _, fieldName := range fieldNames {
+		fields := schema.GetAllNestedFieldChildrenFromTypeField(typeName, fieldName, gql.NewSkipReservedNamesFunc())
+		for _, field := range fields {
+			if !foundFields[field.TypeName] {
+				foundFields[field.TypeName] = true
+				childNodes = append(childNodes, plan.TypeField{
+					TypeName:   field.TypeName,
+					FieldNames: field.FieldNames,
+				})
+			}
+		}
+	}
+	return childNodes
 }
 
 func makeEngine(ctx context.Context, schema *gql.Schema, datasourceConfig plan.DataSourceConfiguration[datasource.HypDSConfig]) (*engine.ExecutionEngine, error) {
@@ -150,17 +169,14 @@ func makeEngine(ctx context.Context, schema *gql.Schema, datasourceConfig plan.D
 	return engine.NewExecutionEngine(ctx, adapter, engineConfig, resolverOptions)
 }
 
-func getAllQueryFields(ctx context.Context, s *gql.Schema) []string {
+func getTypeFields(ctx context.Context, s *gql.Schema, typeName string) []string {
 	span, _ := utils.NewSentrySpanForCurrentFunc(ctx)
 	defer span.Finish()
 
 	doc := s.Document()
-	queryTypeName := s.QueryTypeName()
-
 	fields := make([]string, 0)
 	for _, objectType := range doc.ObjectTypeDefinitions {
-		typeName := doc.Input.ByteSliceString(objectType.Name)
-		if typeName == queryTypeName {
+		if doc.Input.ByteSliceString(objectType.Name) == typeName {
 			for _, fieldRef := range objectType.FieldsDefinition.Refs {
 				field := doc.FieldDefinitions[fieldRef]
 				fieldName := doc.Input.ByteSliceString(field.Name)

--- a/runtime/graphql/graphql.go
+++ b/runtime/graphql/graphql.go
@@ -100,14 +100,14 @@ func handleGraphQLRequest(w http.ResponseWriter, r *http.Request) {
 		options = append(options, eng.WithRequestTraceOptions(traceOpts))
 	}
 
-	// Execute the GraphQL query
+	// Execute the GraphQL operation
 	resultWriter := gql.NewEngineResultWriter()
 	if err := engine.Execute(ctx, &gqlRequest, &resultWriter, options...); err != nil {
 
 		if report, ok := err.(operationreport.Report); ok {
 			if len(report.InternalErrors) > 0 {
 				// Log internal errors, but don't return them to the client
-				msg := "Failed to execute GraphQL query."
+				msg := "Failed to execute GraphQL operation."
 				logger.Err(ctx, err).Msg(msg)
 				http.Error(w, msg, http.StatusInternalServerError)
 				return
@@ -124,10 +124,10 @@ func handleGraphQLRequest(w http.ResponseWriter, r *http.Request) {
 				// cleanup empty arrays from error message before logging
 				errMsg := strings.Replace(err.Error(), ", locations: []", "", 1)
 				errMsg = strings.Replace(errMsg, ", path: []", "", 1)
-				logger.Warn(ctx).Str("error", errMsg).Msg("Failed to execute GraphQL query.")
+				logger.Warn(ctx).Str("error", errMsg).Msg("Failed to execute GraphQL operation.")
 			}
 		} else {
-			msg := "Failed to execute GraphQL query."
+			msg := "Failed to execute GraphQL operation."
 			logger.Err(ctx, err).Msg(msg)
 			http.Error(w, fmt.Sprintf("%s\n%v", msg, err), http.StatusInternalServerError)
 		}

--- a/runtime/graphql/schemagen/conventions.go
+++ b/runtime/graphql/schemagen/conventions.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package schemagen
+
+import "strings"
+
+// prefixes that are used to identify query fields, and will be trimmed from the field name
+var queryTrimPrefixes = []string{"get", "list"}
+
+// prefixes that are used to identify mutation fields
+var mutationPrefixes = []string{
+	"mutate",
+	"post", "patch", "put", "delete",
+	"add", "update", "insert", "upsert",
+	"create", "edit", "save", "remove", "alter", "modify",
+}
+
+func isMutation(fnName string) bool {
+	prefix := getPrefix(fnName, mutationPrefixes)
+	if prefix == "" {
+		return false
+	}
+
+	// embedders are not mutations
+	embedders := getEmbedderFields()
+	return !embedders[fnName]
+}
+
+func getFieldName(fnName string) string {
+	prefix := getPrefix(fnName, queryTrimPrefixes)
+	fieldName := strings.TrimPrefix(fnName, prefix)
+	return strings.ToLower(fieldName[:1]) + fieldName[1:]
+}
+
+func getPrefix(fnName string, prefixes []string) string {
+	for _, prefix := range prefixes {
+		// check for exact match
+		fnNameLowered := strings.ToLower(fnName)
+		if fnNameLowered == prefix {
+			return prefix
+		}
+
+		// check for a prefix, but only if the prefix is NOT followed by a lowercase letter
+		// for example, we want to match "addPost" but not "additionalPosts"
+		prefixLen := len(prefix)
+		if len(fnName) > prefixLen && strings.HasPrefix(fnNameLowered, prefix) {
+			c := fnName[prefixLen]
+			if c < 'a' || c > 'z' {
+				return prefix
+			}
+		}
+	}
+
+	return ""
+}

--- a/runtime/graphql/schemagen/filters.go
+++ b/runtime/graphql/schemagen/filters.go
@@ -12,14 +12,18 @@ package schemagen
 import "github.com/hypermodeinc/modus/runtime/manifestdata"
 
 func getFieldFilter() func(*FieldDefinition) bool {
-	embedders := make(map[string]bool)
-	for _, collection := range manifestdata.GetManifest().Collections {
-		for _, searchMethod := range collection.SearchMethods {
-			embedders[searchMethod.Embedder] = true
-		}
-	}
-
+	embedders := getEmbedderFields()
 	return func(f *FieldDefinition) bool {
 		return !embedders[f.Name]
 	}
+}
+
+func getEmbedderFields() map[string]bool {
+	embedders := make(map[string]bool)
+	for _, collection := range manifestdata.GetManifest().Collections {
+		for _, searchMethod := range collection.SearchMethods {
+			embedders[getFieldName(searchMethod.Embedder)] = true
+		}
+	}
+	return embedders
 }

--- a/runtime/graphql/schemagen/filters.go
+++ b/runtime/graphql/schemagen/filters.go
@@ -11,7 +11,7 @@ package schemagen
 
 import "github.com/hypermodeinc/modus/runtime/manifestdata"
 
-func getFnFilter() func(*FunctionSignature) bool {
+func getFieldFilter() func(*FieldDefinition) bool {
 	embedders := make(map[string]bool)
 	for _, collection := range manifestdata.GetManifest().Collections {
 		for _, searchMethod := range collection.SearchMethods {
@@ -19,7 +19,7 @@ func getFnFilter() func(*FunctionSignature) bool {
 		}
 	}
 
-	return func(f *FunctionSignature) bool {
+	return func(f *FieldDefinition) bool {
 		return !embedders[f.Name]
 	}
 }

--- a/runtime/graphql/schemagen/schemagen_as_test.go
+++ b/runtime/graphql/schemagen/schemagen_as_test.go
@@ -86,7 +86,7 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 	md.FnExports.AddFunction("getPerson").
 		WithResult("assembly/test/Person")
 
-	md.FnExports.AddFunction("getPeople").
+	md.FnExports.AddFunction("listPeople").
 		WithResult("~lib/array/Array<assembly/test/Person>")
 
 	md.FnExports.AddFunction("addPerson").
@@ -177,13 +177,11 @@ func Test_GetGraphQLSchema_AssemblyScript(t *testing.T) {
 # Modus GraphQL Schema (auto-generated)
 
 type Query {
-  add(a: Int!, b: Int!): Int!
-  addPerson(person: PersonInput!): Void
   currentTime: Timestamp!
   doNothing: Void
-  getPeople: [Person!]!
-  getPerson: Person!
-  getProductMap: [StringProductPair!]!
+  people: [Person!]!
+  person: Person!
+  productMap: [StringProductPair!]!
   sayHello(name: String!): String!
   testDefaultArrayParams(a: [Int!]!, b: [Int!]! = [], c: [Int!]! = [1,2,3], d: [Int!], e: [Int!] = null, f: [Int!] = [], g: [Int!] = [1,2,3]): Void
   testDefaultIntParams(a: Int!, b: Int! = 0, c: Int! = 1): Void
@@ -193,6 +191,11 @@ type Query {
   testObj3(obj: Obj3Input!): Void
   testObj4(obj: Obj4Input!): Void
   transform(items: [StringStringPairInput!]!): [StringStringPair!]!
+}
+
+type Mutation {
+  add(a: Int!, b: Int!): Int!
+  addPerson(person: PersonInput!): Void
 }
 
 scalar Timestamp

--- a/runtime/graphql/schemagen/schemagen_go_test.go
+++ b/runtime/graphql/schemagen/schemagen_go_test.go
@@ -85,7 +85,7 @@ func Test_GetGraphQLSchema_Go(t *testing.T) {
 	md.FnExports.AddFunction("getPerson").
 		WithResult("testdata.Person")
 
-	md.FnExports.AddFunction("getPeople").
+	md.FnExports.AddFunction("listPeople").
 		WithResult("[]testdata.Person")
 
 	md.FnExports.AddFunction("addPerson").
@@ -205,13 +205,11 @@ func Test_GetGraphQLSchema_Go(t *testing.T) {
 # Modus GraphQL Schema (auto-generated)
 
 type Query {
-  add(a: Int!, b: Int!): Int!
-  addPerson(person: PersonInput!): Void
   currentTime: Timestamp!
   doNothing: Void
-  getPeople: [Person!]
-  getPerson: Person!
-  getProductMap: [StringProductPair!]
+  people: [Person!]
+  person: Person!
+  productMap: [StringProductPair!]
   sayHello(name: String!): String!
   testDefaultArrayParams(a: [Int!], b: [Int!] = [], c: [Int!] = [1,2,3], d: [Int!], e: [Int!] = null, f: [Int!] = [], g: [Int!] = [1,2,3]): Void
   testDefaultIntParams(a: Int!, b: Int! = 0, c: Int! = 1): Void
@@ -224,6 +222,11 @@ type Query {
   testObj6: [Obj6!]
   testPointers(a: Int, b: [Int], c: [Int!], d: [PersonInput], e: [PersonInput!]): Person
   transform(items: [StringStringPairInput!]): [StringStringPair!]
+}
+
+type Mutation {
+  add(a: Int!, b: Int!): Int!
+  addPerson(person: PersonInput!): Void
 }
 
 scalar Timestamp

--- a/runtime/integration_tests/postgresql_integration_test.go
+++ b/runtime/integration_tests/postgresql_integration_test.go
@@ -154,7 +154,7 @@ func TestPostgresqlNoConnection(t *testing.T) {
 	// wait here to make sure the plugin is loaded
 	time.Sleep(waitRefreshPluginInterval)
 
-	query := "{ getAllPeople { id name age } }"
+	query := "{ allPeople { id name age } }"
 	response, err := runGraphqlQuery(graphQLRequest{Query: query})
 	assert.Nil(t, response)
 	assert.NotNil(t, err)
@@ -185,7 +185,7 @@ func TestPostgresqlNoHost(t *testing.T) {
 	time.Sleep(waitRefreshPluginInterval)
 
 	// when host name does not exist
-	query := "{ getAllPeople { id name age } }"
+	query := "{ allPeople { id name age } }"
 	response, err := runGraphqlQuery(graphQLRequest{Query: query})
 	assert.Nil(t, response)
 	assert.NotNil(t, err)
@@ -216,7 +216,7 @@ func TestPostgresqlNoPostgresqlHost(t *testing.T) {
 	time.Sleep(waitRefreshPluginInterval)
 
 	// when host name has the wrong host type
-	query := "{ getAllPeople { id name age } }"
+	query := "{ allPeople { id name age } }"
 	response, err := runGraphqlQuery(graphQLRequest{Query: query})
 	assert.Nil(t, response)
 	assert.NotNil(t, err)
@@ -247,7 +247,7 @@ func TestPostgresqlWrongConnString(t *testing.T) {
 	time.Sleep(waitRefreshPluginInterval)
 
 	// when connection string is wrong
-	query := "{ getAllPeople { id name age } }"
+	query := "{ allPeople { id name age } }"
 	response, err := runGraphqlQuery(graphQLRequest{Query: query})
 	assert.Nil(t, response)
 	assert.NotNil(t, err)
@@ -277,7 +277,7 @@ func TestPostgresqlNoConnString(t *testing.T) {
 	time.Sleep(waitRefreshPluginInterval)
 
 	// when host name has no connection string
-	query := "{ getAllPeople { id name age } }"
+	query := "{ allPeople { id name age } }"
 	response, err := runGraphqlQuery(graphQLRequest{Query: query})
 	assert.Nil(t, response)
 	assert.NotNil(t, err)
@@ -400,7 +400,7 @@ func (ps *postgresqlSuite) TearDownSuite() {
 
 func (ps *postgresqlSuite) TestPostgresqlBasicOps() {
 	query := `
-query AddPerson {
+mutation AddPerson {
     addPerson(name: "test", age: 21) {
         id
         name
@@ -414,7 +414,7 @@ query AddPerson {
 func (ps *postgresqlSuite) TestPostgresqlWrongTypeInsert() {
 	// try inserting data with wrong type, column: age
 	query := `
-query AddPerson {
+mutation AddPerson {
     addPerson(name: "test", age: "abc") {
         id
         name


### PR DESCRIPTION
Implements naming conventions for functions that alter how they are represented in the generated GraphQL API:

```go
var queryTrimPrefixes = []string{"get", "list"}
var mutationPrefixes = []string{
	"mutate",
	"post", "patch", "put", "delete",
	"add", "update", "insert", "upsert",
	"create", "edit", "save", "remove", "alter", "modify",
}
```

- If a function name starts with a mutation prefix, then it's a mutation, not a query.
- If a function name starts with a query trim prefix, then it's a query and the prefix will be trimmed away.
- Otherwise, it's a query.

For example, consider functions named `getCustomers`, searchInventory`, and `updateProduct`.  They now will get GraphQL schema of:

```graphql
type Query {
    customers(...)
    searchInventory(...)
}

type Mutation {
    updateProduct(...)
}
```
