### PR TITLE
Fix CLI errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 2024-10-25 - Version 0.13.0
+## 2024-01-28 - CLI Version 0.13.1
+
+- Fix issues with interactive CLI prompts [#517](https://github.com/hypermodeinc/modus/pull/517)
+
+## 2024-10-25 - Version 0.13.0 (all components)
 
 _NOTE: This is the first fully open-source release, using the name "Modus" for the framework.
 "Hypermode" still refers to the company and the commercial hosting platform - but not the framework.

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -217,7 +217,7 @@ export default class NewCommand extends Command {
 
       let updateSDK = false;
       if (!installedSdkVersion) {
-        const confirmed = inquirer.confirm({
+        const confirmed = await inquirer.confirm({
           message: `You do not have the ${sdkText} installed. Would you like to install it now?`,
           default: true,
         });

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -133,6 +133,8 @@ export default class NewCommand extends Command {
     } catch (err: any) {
       if (err.name === "ExitPromptError") {
         this.abort();
+      } else {
+        throw err;
       }
     }
   }

--- a/cli/src/commands/runtime/remove/index.ts
+++ b/cli/src/commands/runtime/remove/index.ts
@@ -40,19 +40,19 @@ export default class RuntimeRemoveCommand extends Command {
   static examples = ["modus runtime remove v0.0.0", "modus runtime remove all"];
 
   async run(): Promise<void> {
-    const { args, flags } = await this.parse(RuntimeRemoveCommand);
-    if (!args.version) {
-      this.logError(`No runtime version specified. Run ${chalk.whiteBright("modus runtime remove <version>")}, or ${chalk.whiteBright("modus runtime remove all")}`);
-      return;
-    }
+    try {
+      const { args, flags } = await this.parse(RuntimeRemoveCommand);
+      if (!args.version) {
+        this.logError(`No runtime version specified. Run ${chalk.whiteBright("modus runtime remove <version>")}, or ${chalk.whiteBright("modus runtime remove all")}`);
+        return;
+      }
 
-    if (args.version.toLowerCase() === "all") {
-      const versions = await vi.getInstalledRuntimeVersions();
-      if (versions.length === 0) {
-        this.log(chalk.yellow("No Modus runtimes are installed."));
-        this.exit(1);
-      } else if (!flags.force) {
-        try {
+      if (args.version.toLowerCase() === "all") {
+        const versions = await vi.getInstalledRuntimeVersions();
+        if (versions.length === 0) {
+          this.log(chalk.yellow("No Modus runtimes are installed."));
+          this.exit(1);
+        } else if (!flags.force) {
           const confirmed = await inquirer.confirm({
             message: "Are you sure you want to remove all Modus runtimes?",
             default: false,
@@ -60,27 +60,21 @@ export default class RuntimeRemoveCommand extends Command {
           if (!confirmed) {
             this.abort();
           }
-        } catch (err: any) {
-          if (err.name === "ExitPromptError") {
-            this.abort();
-          }
         }
-      }
 
-      for (const version of versions) {
-        await this.removeRuntime(version);
-      }
-    } else if (!args.version.startsWith("v")) {
-      this.logError("Version must start with 'v'.");
-      this.exit(1);
-    } else {
-      const runtimeText = `Modus Runtime ${args.version}`;
-      const isInstalled = await vi.runtimeVersionIsInstalled(args.version);
-      if (!isInstalled) {
-        this.log(chalk.yellow(runtimeText + "is not installed."));
+        for (const version of versions) {
+          await this.removeRuntime(version);
+        }
+      } else if (!args.version.startsWith("v")) {
+        this.logError("Version must start with 'v'.");
         this.exit(1);
-      } else if (!flags.force) {
-        try {
+      } else {
+        const runtimeText = `Modus Runtime ${args.version}`;
+        const isInstalled = await vi.runtimeVersionIsInstalled(args.version);
+        if (!isInstalled) {
+          this.log(chalk.yellow(runtimeText + "is not installed."));
+          this.exit(1);
+        } else if (!flags.force) {
           const confirmed = await inquirer.confirm({
             message: `Are you sure you want to remove ${runtimeText}?`,
             default: false,
@@ -88,14 +82,16 @@ export default class RuntimeRemoveCommand extends Command {
           if (!confirmed) {
             this.abort();
           }
-        } catch (err: any) {
-          if (err.name === "ExitPromptError") {
-            this.abort();
-          }
         }
-      }
 
-      await this.removeRuntime(args.version);
+        await this.removeRuntime(args.version);
+      }
+    } catch (err: any) {
+      if (err.name === "ExitPromptError") {
+        this.abort();
+      } else {
+        throw err;
+      }
     }
   }
 

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -72,7 +72,7 @@ export default class SDKRemoveCommand extends Command {
 
       if (!flags.force) {
         try {
-          const confirmed = inquirer.confirm({
+          const confirmed = await inquirer.confirm({
             message: "Are you sure you want to remove all Modus SDKs?",
             default: false,
           });
@@ -108,7 +108,7 @@ export default class SDKRemoveCommand extends Command {
           this.exit(1);
         } else if (!flags.force) {
           try {
-            const confirmed = inquirer.confirm({
+            const confirmed = await inquirer.confirm({
               message: `Are you sure you want to remove all Modus ${sdk} SDKs?`,
               default: false,
             });
@@ -136,7 +136,7 @@ export default class SDKRemoveCommand extends Command {
           this.exit(1);
         } else if (!flags.force) {
           try {
-            const confirmed = inquirer.confirm({
+            const confirmed = await inquirer.confirm({
               message: `Are you sure you want to remove ${sdkText}?`,
               default: false,
             });

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -50,28 +50,28 @@ export default class SDKRemoveCommand extends Command {
   static examples = ["modus sdk remove assemblyscript v0.0.0", "modus sdk remove all"];
 
   async run(): Promise<void> {
-    const { args, flags } = await this.parse(SDKRemoveCommand);
-    if (!args.version) {
-      this.logError(`No SDK specified! Run ${chalk.whiteBright("modus sdk remove <name> [version]")}, or ${chalk.whiteBright("modus sdk remove all")}`);
-      return;
-    }
+    try {
+      const { args, flags } = await this.parse(SDKRemoveCommand);
+      if (!args.version) {
+        this.logError(`No SDK specified! Run ${chalk.whiteBright("modus sdk remove <name> [version]")}, or ${chalk.whiteBright("modus sdk remove all")}`);
+        return;
+      }
 
-    if (args.name.toLowerCase() === "all") {
-      let found = false;
-      for (const sdk of Object.values(SDK)) {
-        const versions = await vi.getInstalledSdkVersions(sdk);
-        if (versions.length > 0) {
-          found = true;
-          break;
+      if (args.name.toLowerCase() === "all") {
+        let found = false;
+        for (const sdk of Object.values(SDK)) {
+          const versions = await vi.getInstalledSdkVersions(sdk);
+          if (versions.length > 0) {
+            found = true;
+            break;
+          }
         }
-      }
-      if (!found) {
-        this.log(chalk.yellow("No Modus SDKs are installed."));
-        this.exit(1);
-      }
+        if (!found) {
+          this.log(chalk.yellow("No Modus SDKs are installed."));
+          this.exit(1);
+        }
 
-      if (!flags.force) {
-        try {
+        if (!flags.force) {
           const confirmed = await inquirer.confirm({
             message: "Are you sure you want to remove all Modus SDKs?",
             default: false,
@@ -79,35 +79,29 @@ export default class SDKRemoveCommand extends Command {
           if (!confirmed) {
             this.abort();
           }
-        } catch (err: any) {
-          if (err.name === "ExitPromptError") {
-            this.abort();
+        }
+
+        for (const sdk of Object.values(SDK)) {
+          const versions = await vi.getInstalledSdkVersions(sdk);
+          for (const version of versions) {
+            await this.removeSDK(sdk, version);
           }
         }
-      }
 
-      for (const sdk of Object.values(SDK)) {
-        const versions = await vi.getInstalledSdkVersions(sdk);
-        for (const version of versions) {
-          await this.removeSDK(sdk, version);
+        if (flags.runtimes) {
+          const versions = await vi.getInstalledRuntimeVersions();
+          for (const version of versions) {
+            await this.removeRuntime(version);
+          }
         }
-      }
-
-      if (flags.runtimes) {
-        const versions = await vi.getInstalledRuntimeVersions();
-        for (const version of versions) {
-          await this.removeRuntime(version);
-        }
-      }
-    } else {
-      const sdk = parseSDK(args.name);
-      if (args.version.toLowerCase() === "all") {
-        const versions = await vi.getInstalledSdkVersions(sdk);
-        if (versions.length === 0) {
-          this.log(chalk.yellow(`No Modus ${sdk} SDKs are installed.`));
-          this.exit(1);
-        } else if (!flags.force) {
-          try {
+      } else {
+        const sdk = parseSDK(args.name);
+        if (args.version.toLowerCase() === "all") {
+          const versions = await vi.getInstalledSdkVersions(sdk);
+          if (versions.length === 0) {
+            this.log(chalk.yellow(`No Modus ${sdk} SDKs are installed.`));
+            this.exit(1);
+          } else if (!flags.force) {
             const confirmed = await inquirer.confirm({
               message: `Are you sure you want to remove all Modus ${sdk} SDKs?`,
               default: false,
@@ -115,27 +109,21 @@ export default class SDKRemoveCommand extends Command {
             if (!confirmed) {
               this.abort();
             }
-          } catch (err: any) {
-            if (err.name === "ExitPromptError") {
-              this.abort();
-            }
           }
-        }
 
-        for (const version of versions) {
-          await this.removeSDK(sdk, version);
-        }
-      } else if (!args.version.startsWith("v")) {
-        this.logError("Version must start with 'v'.");
-        this.exit(1);
-      } else {
-        const sdkText = `Modus ${sdk} SDK ${args.version}`;
-        const isInstalled = await vi.sdkVersionIsInstalled(sdk, args.version);
-        if (!isInstalled) {
-          this.log(chalk.yellow(sdkText + "is not installed."));
+          for (const version of versions) {
+            await this.removeSDK(sdk, version);
+          }
+        } else if (!args.version.startsWith("v")) {
+          this.logError("Version must start with 'v'.");
           this.exit(1);
-        } else if (!flags.force) {
-          try {
+        } else {
+          const sdkText = `Modus ${sdk} SDK ${args.version}`;
+          const isInstalled = await vi.sdkVersionIsInstalled(sdk, args.version);
+          if (!isInstalled) {
+            this.log(chalk.yellow(sdkText + "is not installed."));
+            this.exit(1);
+          } else if (!flags.force) {
             const confirmed = await inquirer.confirm({
               message: `Are you sure you want to remove ${sdkText}?`,
               default: false,
@@ -143,14 +131,16 @@ export default class SDKRemoveCommand extends Command {
             if (!confirmed) {
               this.abort();
             }
-          } catch (err: any) {
-            if (err.name === "ExitPromptError") {
-              this.abort();
-            }
           }
-        }
 
-        await this.removeSDK(sdk, args.version);
+          await this.removeSDK(sdk, args.version);
+        }
+      }
+    } catch (err: any) {
+      if (err.name === "ExitPromptError") {
+        this.abort();
+      } else {
+        throw err;
       }
     }
   }


### PR DESCRIPTION
Fix unhandled `ExitPromptError: User force closed the prompt with 0 null` errors from the CLI

- All prompts are async and should have `await` keywords used.  (root cause)
- Any CLI command that uses prompts should have a single try/catch for the CLI command that will handle the user aborting the prompt (ie., pressing `ctrl-c` instead of y or n).