### PR TITLE
Fix CLI hang on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-01-28 - CLI Version 0.13.2
+
+- Fix CLI hang on Linux [#522](https://github.com/hypermodeinc/modus/pull/522)
+
 ## 2024-01-28 - CLI Version 0.13.1
 
 - Fix issues with interactive CLI prompts [#517](https://github.com/hypermodeinc/modus/pull/517)

--- a/cli/bin/modus.js
+++ b/cli/bin/modus.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings=ExperimentalWarning
+#!/usr/bin/env node
 import { execute } from "@oclif/core";
 
 await execute({ dir: import.meta.url });

--- a/cli/src/util/index.ts
+++ b/cli/src/util/index.ts
@@ -8,7 +8,7 @@
  */
 
 import chalk from "chalk";
-import ora, { Ora } from "ora";
+import { oraPromise, Ora } from "ora";
 
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -17,16 +17,10 @@ import { createWriteStream } from "node:fs";
 import * as fs from "./fs.js";
 
 export async function withSpinner<T>(text: string, fn: (spinner: Ora) => Promise<T>): Promise<T> {
-  const spinner = ora({
+  return await oraPromise(fn, {
     color: "white",
     text: text,
-  }).start();
-
-  try {
-    return await fn(spinner);
-  } finally {
-    spinner.stop();
-  }
+  });
 }
 
 export async function downloadFile(url: string, dest: string): Promise<boolean> {

--- a/cli/src/util/index.ts
+++ b/cli/src/util/index.ts
@@ -10,30 +10,11 @@
 import chalk from "chalk";
 import ora, { Ora } from "ora";
 
-import os from "node:os";
 import path from "node:path";
-import readline from "node:readline";
-import { isatty } from "node:tty";
 import { Readable } from "node:stream";
 import { finished } from "node:stream/promises";
-import { spawnSync } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import * as fs from "./fs.js";
-
-// Expand ~ to the user's home directory
-export function expandHomeDir(filePath: string): string {
-  if (filePath.startsWith("~")) {
-    return path.normalize(path.join(os.homedir(), filePath.slice(1)));
-  }
-
-  return path.normalize(filePath);
-}
-
-export function isRunnable(cmd: string): boolean {
-  const shell = spawnSync(cmd);
-  if (!shell) return false;
-  return true;
-}
 
 export async function withSpinner<T>(text: string, fn: (spinner: Ora) => Promise<T>): Promise<T> {
   const spinner = ora({


### PR DESCRIPTION
Fixed issues with CLI hanging on Linux.

The main culprit was the shebang in `cli/bin/modus.js`

```sh
#!/usr/bin/env node --no-warnings=ExperimentalWarning
```

There were two possible fixes:

```sh
#!/usr/bin/env node
```

or

```sh
#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
```

The change implemented in #517 removed the need to pass the `--no-warnings` flag, so we'll simplify with the first one.  (FYI, this was all about getting clean output if the user pressed `ctrl-c` while a prompt was open.)

Also removed some unused code, and improved the spinner wrapper.