### PR TITLE
Fix Go not found on first install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
-## 2024-01-28 - CLI Version 0.13.2
+## 2024-10-29 - CLI Version 0.13.3
 
-- Fix CLI hang on Linux [#522](https://github.com/hypermodeinc/modus/pull/522)
+- Fix Go not found on first install [#522](https://github.com/hypermodeinc/modus/pull/522)
 
-## 2024-01-28 - CLI Version 0.13.1
+## 2024-10-28 - CLI Version 0.13.2
+
+- Fix CLI hang on Linux [#521](https://github.com/hypermodeinc/modus/pull/521)
+
+## 2024-10-28 - CLI Version 0.13.1
 
 - Fix issues with interactive CLI prompts [#517](https://github.com/hypermodeinc/modus/pull/517)
 

--- a/cli/src/util/systemVersions.ts
+++ b/cli/src/util/systemVersions.ts
@@ -7,12 +7,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import process from "node:process";
 import { execFile } from "./cp.js";
-import { ModusHomeDir } from "../custom/globals.js";
 
 const EXEC_OPTIONS = {
   shell: true,
-  cwd: ModusHomeDir,
   env: process.env,
 };
 


### PR DESCRIPTION
When the Modus CLI has never been installed, the `~/.modus` directory does not exist.  If you do `modus new` and pick Go, then it wasn't finding Go or TinyGo because the current working directory didn't exist.


Also cleaned up the changelog