### PR TITLE
`modus build` should install SDK if not already installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-10-29 - CLI Version 0.13.4
+
+- `modus build` should install SDK if not already installed [#524](https://github.com/hypermodeinc/modus/pull/524)
+
 ## 2024-10-29 - CLI Version 0.13.3
 
 - Fix Go not found on first install [#522](https://github.com/hypermodeinc/modus/pull/522)

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -18,6 +18,7 @@ import { getHeader } from "../../custom/header.js";
 import { getAppInfo } from "../../util/appinfo.js";
 import { withSpinner } from "../../util/index.js";
 import { execFileWithExitCode } from "../../util/cp.js";
+import SDKInstallCommand from "../sdk/install/index.js";
 
 export default class BuildCommand extends Command {
   static args = {
@@ -62,6 +63,10 @@ export default class BuildCommand extends Command {
 
     // pass chalk level to child processes so they can colorize output
     process.env.FORCE_COLOR = chalk.level.toString();
+
+    if (!(await vi.sdkVersionIsInstalled(app.sdk, app.sdkVersion))) {
+      await SDKInstallCommand.run([app.sdk, app.sdkVersion, "--no-logo"]);
+    }
 
     const results = await withSpinner("Building " + app.name, async () => {
       const execOpts = {

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -24,7 +24,6 @@ import SDKInstallCommand from "../sdk/install/index.js";
 import { getHeader } from "../../custom/header.js";
 import * as inquirer from "@inquirer/prompts";
 import { getGoVersion, getTinyGoVersion } from "../../util/systemVersions.js";
-import { installBuildTools } from "../../util/installer.js";
 
 const MODUS_DEFAULT_TEMPLATE_NAME = "default";
 
@@ -256,9 +255,6 @@ export default class NewCommand extends Command {
       this.logError(`Could not find any templates for ${sdkText} ${sdkVersion}`);
       this.exit(1);
     }
-
-    // Install build tools if needed
-    await installBuildTools(sdk, sdkVersion);
 
     // Create the app
     this.log(chalk.dim(`Using ${sdkText} ${sdkVersion}`));

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -151,6 +151,9 @@ export default class SDKInstallCommand extends Command {
           spinner.fail(chalk.red(`Failed to download ${sdkText}`));
           throw e;
         }
+
+        await installer.installBuildTools(sdk, sdkVersion);
+
         spinner.succeed(chalk.dim(`Installed ${sdkText}`));
       });
     }

--- a/cli/src/util/index.ts
+++ b/cli/src/util/index.ts
@@ -8,7 +8,7 @@
  */
 
 import chalk from "chalk";
-import { oraPromise, Ora } from "ora";
+import ora, { Ora } from "ora";
 
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -17,10 +17,18 @@ import { createWriteStream } from "node:fs";
 import * as fs from "./fs.js";
 
 export async function withSpinner<T>(text: string, fn: (spinner: Ora) => Promise<T>): Promise<T> {
-  return await oraPromise(fn, {
+  // NOTE: Ora comes with "oraPromise", but it doesn't clear the original text on completion.
+  // Thus, we use this custom async function to ensure the spinner is applied correctly.
+  const spinner = ora({
     color: "white",
     text: text,
-  });
+  }).start();
+
+  try {
+    return await fn(spinner);
+  } finally {
+    spinner.stop();
+  }
 }
 
 export async function downloadFile(url: string, dest: string): Promise<boolean> {

--- a/cli/src/util/installer.ts
+++ b/cli/src/util/installer.ts
@@ -13,7 +13,7 @@ import * as fs from "./fs.js";
 import * as vi from "./versioninfo.js";
 import { extract } from "./tar.js";
 import { execFile } from "./cp.js";
-import { downloadFile, isOnline, withSpinner } from "./index.js";
+import { downloadFile, isOnline } from "./index.js";
 import { GitHubOwner, GitHubRepo, SDK } from "../custom/globals.js";
 
 export async function installSDK(sdk: SDK, version: string) {
@@ -84,13 +84,11 @@ async function installGoBuildTools(sdkVersion: string) {
   }
 
   const module = `github.com/${GitHubOwner}/${GitHubRepo}/sdk/go/tools/modus-go-build@${sdkVersion}`;
-  await withSpinner("Downloading the Modus Go build tool.", async () => {
-    await execFile("go", ["install", module], {
-      shell: true,
-      env: {
-        ...process.env,
-        GOBIN: sdkPath,
-      },
-    });
+  await execFile("go", ["install", module], {
+    shell: true,
+    env: {
+      ...process.env,
+      GOBIN: sdkPath,
+    },
   });
 }

--- a/cli/src/util/installer.ts
+++ b/cli/src/util/installer.ts
@@ -12,7 +12,8 @@ import path from "node:path";
 import * as fs from "./fs.js";
 import * as vi from "./versioninfo.js";
 import { extract } from "./tar.js";
-import { downloadFile, isOnline } from "./index.js";
+import { execFile } from "./cp.js";
+import { downloadFile, isOnline, withSpinner } from "./index.js";
 import { GitHubOwner, GitHubRepo, SDK } from "../custom/globals.js";
 
 export async function installSDK(sdk: SDK, version: string) {
@@ -59,4 +60,37 @@ export async function installRuntime(version: string) {
   await fs.mkdir(installDir, { recursive: true });
   await extract(archivePath, installDir);
   await fs.rm(archivePath);
+}
+
+export async function installBuildTools(sdk: SDK, sdkVersion: string) {
+  switch (sdk) {
+    case SDK.Go:
+      await installGoBuildTools(sdkVersion);
+      break;
+  }
+}
+
+async function installGoBuildTools(sdkVersion: string) {
+  const sdkPath = vi.getSdkPath(SDK.Go, sdkVersion);
+
+  const ext = os.platform() === "win32" ? ".exe" : "";
+  const buildTool = path.join(sdkPath, "modus-go-build" + ext);
+  if (await fs.exists(buildTool)) {
+    return;
+  }
+
+  if (!(await isOnline())) {
+    throw new Error("Could not find the Modus Go build tool. Please try again when you are online.");
+  }
+
+  const module = `github.com/${GitHubOwner}/${GitHubRepo}/sdk/go/tools/modus-go-build@${sdkVersion}`;
+  await withSpinner("Downloading the Modus Go build tool.", async () => {
+    await execFile("go", ["install", module], {
+      shell: true,
+      env: {
+        ...process.env,
+        GOBIN: sdkPath,
+      },
+    });
+  });
 }


### PR DESCRIPTION
- The "build tools" are part of the SDK, and should be installed when the SDK is installed.
- If `modus build` is run, and the SDK is not installed, then the SDK should be downloaded and installed before attempting to invoke the build tools.
- Minor update to the spinner text output.