### PR TITLE
Automatically generate and push release info to R2 bucket on every release

### DIFF
--- a/.github/workflows/ci-release-info-build.yaml
+++ b/.github/workflows/ci-release-info-build.yaml
@@ -1,0 +1,29 @@
+name: ci-release-info-build
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - 'tools/release-info/**'
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/release-info
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci-release-info-lint.yaml
+++ b/.github/workflows/ci-release-info-lint.yaml
@@ -1,0 +1,31 @@
+name: ci-release-info-lint
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - 'tools/release-info/**'
+jobs:
+  lint:
+    if: github.event_name == 'pull_request'
+    name: lint (tools/release-info)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/release-info
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+      - name: Install dependencies
+        run: npm ci
+      - name: Check formatting
+        run: npm run pretty:check
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -50,38 +50,4 @@ jobs:
   release-info:
     needs: release
     name: "Generate Release Info"
-    runs-on: warp-ubuntu-latest-x64-2x
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.ref_name }}"
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ">=22"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install Dependencies
-        working-directory: tools/release-info
-        run: npm ci
-      - name: Build
-        working-directory: tools/release-info
-        run: npm run build
-      - name: Run
-        working-directory: tools/release-info
-        run: node dist/index.js
-      - name: Push to R2 Bucket
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          version: "3.83.0"
-          workingDirectory: "tools/release-info"
-          preCommands: |
-            cat modus-latest.json
-            cat modus-preview.json
-            cat modus-all.json
-            cat modus-preview-all.json
-          command: |
-            r2 object put releases/modus-latest.json modus-latest.json
-            r2 object put releases/modus-preview.json modus-preview.json
-            r2 object put releases/modus-all.json modus-all.json
-            r2 object put releases/modus-preview-all.json modus-preview-all.json
+    uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -8,6 +8,7 @@ permissions:
   id-token: write
 jobs:
   release:
+    name: Release
     # note: must use GitHub-hosted runner for publishing to NPM with --provenance flag
     runs-on: ubuntu-latest
     steps:
@@ -46,3 +47,41 @@ jobs:
         with:
           prerelease: ${{ contains(steps.parse_cli_version.outputs.cli_version, '-') }}
           make_latest: false
+  release-info:
+    needs: release
+    name: "Generate Release Info"
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref_name }}"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        working-directory: tools/release-info
+        run: npm ci
+      - name: Build
+        working-directory: tools/release-info
+        run: npm run build
+      - name: Run
+        working-directory: tools/release-info
+        run: node dist/index.js
+      - name: Push to R2 Bucket
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          version: "3.83.0"
+          workingDirectory: "tools/release-info"
+          preCommands: |
+            cat modus-latest.json
+            cat modus-preview.json
+            cat modus-all.json
+            cat modus-preview-all.json
+          command: |
+            r2 object put releases/modus-latest.json modus-latest.json
+            r2 object put releases/modus-preview.json modus-preview.json
+            r2 object put releases/modus-all.json modus-all.json
+            r2 object put releases/modus-preview-all.json modus-preview-all.json

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -49,5 +49,5 @@ jobs:
           make_latest: false
   release-info:
     needs: release
-    name: "Generate Release Info"
+    name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -1,0 +1,43 @@
+name: "Generate Release Info"
+on:
+  workflow_dispatch:
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  release-info:
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref_name }}"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        working-directory: tools/release-info
+        run: npm ci
+      - name: Build
+        working-directory: tools/release-info
+        run: npm run build
+      - name: Run
+        working-directory: tools/release-info
+        run: node dist/index.js
+      - name: Push to R2 Bucket
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
+          version: "3.83.0"
+          workingDirectory: "tools/release-info"
+          preCommands: |
+            cat modus-latest.json
+            cat modus-preview.json
+            cat modus-all.json
+            cat modus-preview-all.json
+          command: |
+            r2 object put releases/modus-latest.json modus-latest.json
+            r2 object put releases/modus-preview.json modus-preview.json
+            r2 object put releases/modus-all.json modus-all.json
+            r2 object put releases/modus-preview-all.json modus-preview-all.json

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Push to R2 Bucket
         uses: cloudflare/wrangler-action@v3
         with:
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
           wranglerVersion: "3.83.0"
           workingDirectory: "tools/release-info"

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -38,7 +38,7 @@ jobs:
             cat modus-all.json
             cat modus-preview-all.json
           command: |
-            r2 object put releases/modus-latest.json -f modus-latest.json
-            r2 object put releases/modus-preview.json -f modus-preview.json
-            r2 object put releases/modus-all.json -f modus-all.json
-            r2 object put releases/modus-preview-all.json -f modus-preview-all.json
+            r2 object put releases/modus-latest.json -f modus-latest.json --content-type application/json
+            r2 object put releases/modus-preview.json -f modus-preview.json --content-type application/json
+            r2 object put releases/modus-all.json -f modus-all.json --content-type application/json
+            r2 object put releases/modus-preview-all.json -f modus-preview-all.json --content-type application/json

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -39,7 +39,6 @@ jobs:
             cat modus-all.json
             cat modus-preview-all.json
           command: |
-            whoami
             r2 object put releases/modus-latest.json -f modus-latest.json
             r2 object put releases/modus-preview.json -f modus-preview.json
             r2 object put releases/modus-all.json -f modus-all.json

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -38,6 +38,7 @@ jobs:
             cat modus-all.json
             cat modus-preview-all.json
           command: |
+            whoami
             r2 object put releases/modus-latest.json -f modus-latest.json
             r2 object put releases/modus-preview.json -f modus-preview.json
             r2 object put releases/modus-all.json -f modus-all.json

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -1,5 +1,6 @@
 name: "Generate Release Info"
 on:
+  push:
   workflow_dispatch:
   workflow_call:
 permissions:

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -1,4 +1,4 @@
-name: "Generate Release Info"
+name: Generate Release Info
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -1,6 +1,5 @@
 name: "Generate Release Info"
 on:
-  push:
   workflow_dispatch:
   workflow_call:
 permissions:

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -1,6 +1,5 @@
 name: "Generate Release Info"
 on:
-  push:
   workflow_dispatch:
   workflow_call:
 permissions:
@@ -30,7 +29,7 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
-          version: "3.83.0"
+          wranglerVersion: "3.83.0"
           workingDirectory: "tools/release-info"
           preCommands: |
             cat modus-latest.json
@@ -38,7 +37,7 @@ jobs:
             cat modus-all.json
             cat modus-preview-all.json
           command: |
-            r2 object put releases/modus-latest.json modus-latest.json
-            r2 object put releases/modus-preview.json modus-preview.json
-            r2 object put releases/modus-all.json modus-all.json
-            r2 object put releases/modus-preview-all.json modus-preview-all.json
+            r2 object put releases/modus-latest.json -f modus-latest.json
+            r2 object put releases/modus-preview.json -f modus-preview.json
+            r2 object put releases/modus-all.json -f modus-all.json
+            r2 object put releases/modus-preview-all.json -f modus-preview-all.json

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -37,5 +37,5 @@ jobs:
           MACOS_NOTARY_KEY: "${{ secrets.MACOS_NOTARY_KEY }}"
   release-info:
     needs: release
-    name: "Generate Release Info"
+    name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -7,6 +7,7 @@ permissions:
   contents: "write"
 jobs:
   release:
+    name: Release
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - name: "Validate version"
@@ -34,3 +35,41 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: "${{ secrets.MACOS_NOTARY_ISSUER_ID }}"
           MACOS_NOTARY_KEY_ID: "${{ secrets.MACOS_NOTARY_KEY_ID }}"
           MACOS_NOTARY_KEY: "${{ secrets.MACOS_NOTARY_KEY }}"
+  release-info:
+    needs: release
+    name: "Generate Release Info"
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref_name }}"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        working-directory: tools/release-info
+        run: npm ci
+      - name: Build
+        working-directory: tools/release-info
+        run: npm run build
+      - name: Run
+        working-directory: tools/release-info
+        run: node dist/index.js
+      - name: Push to R2 Bucket
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          version: "3.83.0"
+          workingDirectory: "tools/release-info"
+          preCommands: |
+            cat modus-latest.json
+            cat modus-preview.json
+            cat modus-all.json
+            cat modus-preview-all.json
+          command: |
+            r2 object put releases/modus-latest.json modus-latest.json
+            r2 object put releases/modus-preview.json modus-preview.json
+            r2 object put releases/modus-all.json modus-all.json
+            r2 object put releases/modus-preview-all.json modus-preview-all.json

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -38,38 +38,4 @@ jobs:
   release-info:
     needs: release
     name: "Generate Release Info"
-    runs-on: warp-ubuntu-latest-x64-2x
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.ref_name }}"
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ">=22"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install Dependencies
-        working-directory: tools/release-info
-        run: npm ci
-      - name: Build
-        working-directory: tools/release-info
-        run: npm run build
-      - name: Run
-        working-directory: tools/release-info
-        run: node dist/index.js
-      - name: Push to R2 Bucket
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          version: "3.83.0"
-          workingDirectory: "tools/release-info"
-          preCommands: |
-            cat modus-latest.json
-            cat modus-preview.json
-            cat modus-all.json
-            cat modus-preview-all.json
-          command: |
-            r2 object put releases/modus-latest.json modus-latest.json
-            r2 object put releases/modus-preview.json modus-preview.json
-            r2 object put releases/modus-all.json modus-all.json
-            r2 object put releases/modus-preview-all.json modus-preview-all.json
+    uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-sdk-as.yaml
+++ b/.github/workflows/release-sdk-as.yaml
@@ -50,38 +50,4 @@ jobs:
   release-info:
     needs: release
     name: "Generate Release Info"
-    runs-on: warp-ubuntu-latest-x64-2x
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.ref_name }}"
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ">=22"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install Dependencies
-        working-directory: tools/release-info
-        run: npm ci
-      - name: Build
-        working-directory: tools/release-info
-        run: npm run build
-      - name: Run
-        working-directory: tools/release-info
-        run: node dist/index.js
-      - name: Push to R2 Bucket
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          version: "3.83.0"
-          workingDirectory: "tools/release-info"
-          preCommands: |
-            cat modus-latest.json
-            cat modus-preview.json
-            cat modus-all.json
-            cat modus-preview-all.json
-          command: |
-            r2 object put releases/modus-latest.json modus-latest.json
-            r2 object put releases/modus-preview.json modus-preview.json
-            r2 object put releases/modus-all.json modus-all.json
-            r2 object put releases/modus-preview-all.json modus-preview-all.json
+    uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-sdk-as.yaml
+++ b/.github/workflows/release-sdk-as.yaml
@@ -8,6 +8,7 @@ permissions:
   id-token: write
 jobs:
   release:
+    name: Release
     # note: must use GitHub-hosted runner for publishing to NPM with --provenance flag
     runs-on: ubuntu-latest
     steps:
@@ -46,3 +47,41 @@ jobs:
             sdk/assemblyscript/templates_assemblyscript_${{ steps.parse_sdk_version.outputs.sdk_version }}.tar.gz
           prerelease: ${{ contains(steps.parse_sdk_version.outputs.sdk_version, '-') }}
           make_latest: false
+  release-info:
+    needs: release
+    name: "Generate Release Info"
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref_name }}"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        working-directory: tools/release-info
+        run: npm ci
+      - name: Build
+        working-directory: tools/release-info
+        run: npm run build
+      - name: Run
+        working-directory: tools/release-info
+        run: node dist/index.js
+      - name: Push to R2 Bucket
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          version: "3.83.0"
+          workingDirectory: "tools/release-info"
+          preCommands: |
+            cat modus-latest.json
+            cat modus-preview.json
+            cat modus-all.json
+            cat modus-preview-all.json
+          command: |
+            r2 object put releases/modus-latest.json modus-latest.json
+            r2 object put releases/modus-preview.json modus-preview.json
+            r2 object put releases/modus-all.json modus-all.json
+            r2 object put releases/modus-preview-all.json modus-preview-all.json

--- a/.github/workflows/release-sdk-as.yaml
+++ b/.github/workflows/release-sdk-as.yaml
@@ -49,5 +49,5 @@ jobs:
           make_latest: false
   release-info:
     needs: release
-    name: "Generate Release Info"
+    name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -38,5 +38,5 @@ jobs:
           make_latest: false
   release-info:
     needs: release
-    name: "Generate Release Info"
+    name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -39,38 +39,4 @@ jobs:
   release-info:
     needs: release
     name: "Generate Release Info"
-    runs-on: warp-ubuntu-latest-x64-2x
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.ref_name }}"
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ">=22"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install Dependencies
-        working-directory: tools/release-info
-        run: npm ci
-      - name: Build
-        working-directory: tools/release-info
-        run: npm run build
-      - name: Run
-        working-directory: tools/release-info
-        run: node dist/index.js
-      - name: Push to R2 Bucket
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          version: "3.83.0"
-          workingDirectory: "tools/release-info"
-          preCommands: |
-            cat modus-latest.json
-            cat modus-preview.json
-            cat modus-all.json
-            cat modus-preview-all.json
-          command: |
-            r2 object put releases/modus-latest.json modus-latest.json
-            r2 object put releases/modus-preview.json modus-preview.json
-            r2 object put releases/modus-all.json modus-all.json
-            r2 object put releases/modus-preview-all.json modus-preview-all.json
+    uses: ./.github/workflows/release-info.yaml

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -7,6 +7,7 @@ permissions:
   contents: "write"
 jobs:
   release:
+    name: Release
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
       - name: "Validate version"
@@ -35,3 +36,41 @@ jobs:
             sdk/go/templates_go_${{ steps.parse_sdk_version.outputs.sdk_version }}.tar.gz
           prerelease: ${{ contains(steps.parse_sdk_version.outputs.sdk_version, '-') }}
           make_latest: false
+  release-info:
+    needs: release
+    name: "Generate Release Info"
+    runs-on: warp-ubuntu-latest-x64-2x
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.ref_name }}"
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ">=22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install Dependencies
+        working-directory: tools/release-info
+        run: npm ci
+      - name: Build
+        working-directory: tools/release-info
+        run: npm run build
+      - name: Run
+        working-directory: tools/release-info
+        run: node dist/index.js
+      - name: Push to R2 Bucket
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          version: "3.83.0"
+          workingDirectory: "tools/release-info"
+          preCommands: |
+            cat modus-latest.json
+            cat modus-preview.json
+            cat modus-all.json
+            cat modus-preview-all.json
+          command: |
+            r2 object put releases/modus-latest.json modus-latest.json
+            r2 object put releases/modus-preview.json modus-preview.json
+            r2 object put releases/modus-all.json modus-all.json
+            r2 object put releases/modus-preview-all.json modus-preview-all.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## UNRELEASED
 
+- Automatically generate and push releases info to R2 bucket on every release [#526](https://github.com/hypermodeinc/modus/pull/526)
 - Consistent help + print enum options + validate SDK prereq [#542](https://github.com/hypermodeinc/modus/pull/542)
   - Consistent padding in the help section 
   - `modus new`: Enum options need to print possible options

--- a/tools/release-info/.gitignore
+++ b/tools/release-info/.gitignore
@@ -1,0 +1,2 @@
+dist/
+modus-*.json

--- a/tools/release-info/.prettierrc
+++ b/tools/release-info/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "printWidth": 1024
+}

--- a/tools/release-info/constants.ts
+++ b/tools/release-info/constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const GitHubOwner = "hypermodeinc";
+export const GitHubRepo = "modus";
+export const GitHubRuntimeTagPrefix = "runtime/";
+export const GitHubCliTagPrefix = "cli/";
+
+export function GetSdkTagPrefix(sdk: SDK): string {
+  return `sdk/${sdk.toLowerCase()}/`;
+}
+
+export enum SDK {
+  AssemblyScript = "AssemblyScript",
+  Go = "Go",
+}

--- a/tools/release-info/eslint.config.js
+++ b/tools/release-info/eslint.config.js
@@ -1,0 +1,6 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended);

--- a/tools/release-info/index.ts
+++ b/tools/release-info/index.ts
@@ -14,43 +14,43 @@ import {
   getAllSdkVersions,
   getAllRuntimeVersions,
   getAllCliVersions,
-} from "./versioninfo.js";
-import { SDK } from "./constants.js";
-import { writeFileSync } from "fs";
+} from "./versioninfo.js"
+import { SDK } from "./constants.js"
+import { writeFile } from "fs/promises"
 
 async function buildModusLatestJSON(
   filename: string,
-  includePrerelease: boolean,
+  includePrerelease: boolean
 ) {
-  const as = await getLatestSdkVersion(SDK.AssemblyScript, includePrerelease);
-  const go = await getLatestSdkVersion(SDK.Go, includePrerelease);
-  const cli = await getLatestCliVersion(includePrerelease);
-  const runtime = await getLatestRuntimeVersion(includePrerelease);
+  const as = await getLatestSdkVersion(SDK.AssemblyScript, includePrerelease)
+  const go = await getLatestSdkVersion(SDK.Go, includePrerelease)
+  const cli = await getLatestCliVersion(includePrerelease)
+  const runtime = await getLatestRuntimeVersion(includePrerelease)
   const info = {
     "sdk/assemblyscript": as,
     "sdk/go": go,
     cli: cli,
     runtime: runtime,
-  };
+  }
 
-  writeFileSync(filename, JSON.stringify(info, null, 2));
+  await writeFile(filename, JSON.stringify(info, null, 2))
 }
 
 async function buildModusAllJSON(filename: string, includePrerelease: boolean) {
-  const as = await getAllSdkVersions(SDK.AssemblyScript, includePrerelease);
-  const go = await getAllSdkVersions(SDK.Go, includePrerelease);
-  const cli = await getAllCliVersions(includePrerelease);
-  const runtime = await getAllRuntimeVersions(includePrerelease);
+  const as = await getAllSdkVersions(SDK.AssemblyScript, includePrerelease)
+  const go = await getAllSdkVersions(SDK.Go, includePrerelease)
+  const cli = await getAllCliVersions(includePrerelease)
+  const runtime = await getAllRuntimeVersions(includePrerelease)
   const info = {
     "sdk/assemblyscript": as,
     "sdk/go": go,
     cli: cli,
     runtime: runtime,
-  };
-  writeFileSync(filename, JSON.stringify(info, null, 2));
+  }
+  await writeFile(filename, JSON.stringify(info, null, 2))
 }
 
-await buildModusLatestJSON("modus-latest.json", false);
-await buildModusLatestJSON("modus-preview.json", true);
-await buildModusAllJSON("modus-all.json", false);
-await buildModusAllJSON("modus-preview-all.json", true);
+await buildModusLatestJSON("modus-latest.json", false)
+await buildModusLatestJSON("modus-preview.json", true)
+await buildModusAllJSON("modus-all.json", false)
+await buildModusAllJSON("modus-preview-all.json", true)

--- a/tools/release-info/index.ts
+++ b/tools/release-info/index.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  getLatestSdkVersion,
+  getLatestRuntimeVersion,
+  getLatestCliVersion,
+  getAllSdkVersions,
+  getAllRuntimeVersions,
+  getAllCliVersions,
+} from "./versioninfo.js";
+import { SDK } from "./constants.js";
+import { writeFileSync } from "fs";
+
+async function buildModusLatestJSON(
+  filename: string,
+  includePrerelease: boolean,
+) {
+  const as = await getLatestSdkVersion(SDK.AssemblyScript, includePrerelease);
+  const go = await getLatestSdkVersion(SDK.Go, includePrerelease);
+  const cli = await getLatestCliVersion(includePrerelease);
+  const runtime = await getLatestRuntimeVersion(includePrerelease);
+  const info = {
+    "sdk/assemblyscript": as,
+    "sdk/go": go,
+    cli: cli,
+    runtime: runtime,
+  };
+
+  writeFileSync(filename, JSON.stringify(info, null, 2));
+}
+
+async function buildModusAllJSON(filename: string, includePrerelease: boolean) {
+  const as = await getAllSdkVersions(SDK.AssemblyScript, includePrerelease);
+  const go = await getAllSdkVersions(SDK.Go, includePrerelease);
+  const cli = await getAllCliVersions(includePrerelease);
+  const runtime = await getAllRuntimeVersions(includePrerelease);
+  const info = {
+    "sdk/assemblyscript": as,
+    "sdk/go": go,
+    cli: cli,
+    runtime: runtime,
+  };
+  writeFileSync(filename, JSON.stringify(info, null, 2));
+}
+
+await buildModusLatestJSON("modus-latest.json", false);
+await buildModusLatestJSON("modus-preview.json", true);
+await buildModusAllJSON("modus-all.json", false);
+await buildModusAllJSON("modus-preview-all.json", true);

--- a/tools/release-info/index.ts
+++ b/tools/release-info/index.ts
@@ -7,50 +7,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  getLatestSdkVersion,
-  getLatestRuntimeVersion,
-  getLatestCliVersion,
-  getAllSdkVersions,
-  getAllRuntimeVersions,
-  getAllCliVersions,
-} from "./versioninfo.js"
-import { SDK } from "./constants.js"
-import { writeFile } from "fs/promises"
+import { getLatestSdkVersion, getLatestRuntimeVersion, getLatestCliVersion, getAllSdkVersions, getAllRuntimeVersions, getAllCliVersions } from "./versioninfo.js";
+import { SDK } from "./constants.js";
+import { writeFile } from "fs/promises";
 
-async function buildModusLatestJSON(
-  filename: string,
-  includePrerelease: boolean
-) {
-  const as = await getLatestSdkVersion(SDK.AssemblyScript, includePrerelease)
-  const go = await getLatestSdkVersion(SDK.Go, includePrerelease)
-  const cli = await getLatestCliVersion(includePrerelease)
-  const runtime = await getLatestRuntimeVersion(includePrerelease)
+async function buildModusLatestJSON(filename: string, includePrerelease: boolean) {
+  const as = await getLatestSdkVersion(SDK.AssemblyScript, includePrerelease);
+  const go = await getLatestSdkVersion(SDK.Go, includePrerelease);
+  const cli = await getLatestCliVersion(includePrerelease);
+  const runtime = await getLatestRuntimeVersion(includePrerelease);
   const info = {
     "sdk/assemblyscript": as,
     "sdk/go": go,
     cli: cli,
     runtime: runtime,
-  }
+  };
 
-  await writeFile(filename, JSON.stringify(info, null, 2))
+  await writeFile(filename, JSON.stringify(info, null, 2));
 }
 
 async function buildModusAllJSON(filename: string, includePrerelease: boolean) {
-  const as = await getAllSdkVersions(SDK.AssemblyScript, includePrerelease)
-  const go = await getAllSdkVersions(SDK.Go, includePrerelease)
-  const cli = await getAllCliVersions(includePrerelease)
-  const runtime = await getAllRuntimeVersions(includePrerelease)
+  const as = await getAllSdkVersions(SDK.AssemblyScript, includePrerelease);
+  const go = await getAllSdkVersions(SDK.Go, includePrerelease);
+  const cli = await getAllCliVersions(includePrerelease);
+  const runtime = await getAllRuntimeVersions(includePrerelease);
   const info = {
     "sdk/assemblyscript": as,
     "sdk/go": go,
     cli: cli,
     runtime: runtime,
-  }
-  await writeFile(filename, JSON.stringify(info, null, 2))
+  };
+  await writeFile(filename, JSON.stringify(info, null, 2));
 }
 
-await buildModusLatestJSON("modus-latest.json", false)
-await buildModusLatestJSON("modus-preview.json", true)
-await buildModusAllJSON("modus-all.json", false)
-await buildModusAllJSON("modus-preview-all.json", true)
+await buildModusLatestJSON("modus-latest.json", false);
+await buildModusLatestJSON("modus-preview.json", true);
+await buildModusAllJSON("modus-all.json", false);
+await buildModusAllJSON("modus-preview-all.json", true);

--- a/tools/release-info/package-lock.json
+++ b/tools/release-info/package-lock.json
@@ -11,9 +11,277 @@
         "semver": "^7.6.3"
       },
       "devDependencies": {
+        "@eslint/js": "^9.14.0",
+        "@types/eslint__js": "^8.42.3",
         "@types/node": "^22.8.6",
-        "@types/semver": "^7.5.8"
+        "@types/semver": "^7.5.8",
+        "eslint": "^9.14.0",
+        "typescript": "^5.6.3",
+        "typescript-eslint": "^8.12.2"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+      "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
+      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.0.tgz",
+      "integrity": "sha512-xnRgu9DxZbkWak/te3fcytNyp8MTbuiZIaueg2rgEvBuN55n04nwLYLU9TX/VVlusc9L2ZNXi99nUFNkHXtr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint__js": {
+      "version": "8.42.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
+      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.8.6",
@@ -32,6 +300,1150 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.2.tgz",
+      "integrity": "sha512-gQxbxM8mcxBwaEmWdtLCIGLfixBMHhQjBqR8sVWNTPpcj45WlYL2IObS/DNMLH1DBP0n8qz+aiiLTGfopPEebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/type-utils": "8.12.2",
+        "@typescript-eslint/utils": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.2.tgz",
+      "integrity": "sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.2.tgz",
+      "integrity": "sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.2.tgz",
+      "integrity": "sha512-bwuU4TAogPI+1q/IJSKuD4shBLc/d2vGcRT588q+jzayQyjVK2X6v/fbR4InY2U2sgf8MEvVCqEWUzYzgBNcGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.12.2",
+        "@typescript-eslint/utils": "8.12.2",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.2.tgz",
+      "integrity": "sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.2.tgz",
+      "integrity": "sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.2.tgz",
+      "integrity": "sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.12.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.2.tgz",
+      "integrity": "sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+      "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.7.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.14.0",
+        "@eslint/plugin-kit": "^0.2.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.0",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -44,12 +1456,194 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.0.tgz",
+      "integrity": "sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.12.2.tgz",
+      "integrity": "sha512-UbuVUWSrHVR03q9CWx+JDHeO6B/Hr9p4U5lRH++5tq/EbFq1faYZe50ZSBePptgfIKLEti0aPQ3hFgnPVcd8ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.12.2",
+        "@typescript-eslint/parser": "8.12.2",
+        "@typescript-eslint/utils": "8.12.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/tools/release-info/package-lock.json
+++ b/tools/release-info/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "@hypermode/release-info",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@hypermode/release-info",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "devDependencies": {
+        "@types/semver": "^7.5.8"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/tools/release-info/package-lock.json
+++ b/tools/release-info/package-lock.json
@@ -11,7 +11,18 @@
         "semver": "^7.6.3"
       },
       "devDependencies": {
+        "@types/node": "^22.8.6",
         "@types/semver": "^7.5.8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
+      "integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/semver": {
@@ -32,6 +43,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/tools/release-info/package-lock.json
+++ b/tools/release-info/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^22.8.6",
         "@types/semver": "^7.5.8",
         "eslint": "^9.14.0",
+        "prettier": "3.3.3",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.12.2"
       }
@@ -1366,6 +1367,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/tools/release-info/package.json
+++ b/tools/release-info/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^22.8.6",
     "@types/semver": "^7.5.8",
     "eslint": "^9.14.0",
+    "prettier": "3.3.3",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.12.2"
   }

--- a/tools/release-info/package.json
+++ b/tools/release-info/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@hypermode/release-info",
+  "version": "",
+  "description": "Generates release information for the Modus CLI",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "rm -rf dist && tsc -b",
+    "watch": "rm -rf dist && tsc -b -w"
+  },
+  "repository": "github:hypermodeinc/modus",
+  "author": "Hypermode Inc.",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/hypermodeinc/modus/issues"
+  },
+  "homepage": "https://github.com/hypermodeinc/modus",
+  "dependencies": {
+    "semver": "^7.6.3"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.5.8"
+  }
+}

--- a/tools/release-info/package.json
+++ b/tools/release-info/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && tsc -b",
-    "watch": "rm -rf dist && tsc -b -w"
+    "watch": "rm -rf dist && tsc -b -w",
+    "lint": "eslint ."
   },
   "repository": "github:hypermodeinc/modus",
   "author": "Hypermode Inc.",
@@ -20,7 +21,12 @@
     "semver": "^7.6.3"
   },
   "devDependencies": {
+    "@eslint/js": "^9.14.0",
+    "@types/eslint__js": "^8.42.3",
     "@types/node": "^22.8.6",
-    "@types/semver": "^7.5.8"
+    "@types/semver": "^7.5.8",
+    "eslint": "^9.14.0",
+    "typescript": "^5.6.3",
+    "typescript-eslint": "^8.12.2"
   }
 }

--- a/tools/release-info/package.json
+++ b/tools/release-info/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "rm -rf dist && tsc -b",
     "watch": "rm -rf dist && tsc -b -w",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "pretty": "prettier --write .",
+    "pretty:check": "prettier --check ."
   },
   "repository": "github:hypermodeinc/modus",
   "author": "Hypermode Inc.",

--- a/tools/release-info/package.json
+++ b/tools/release-info/package.json
@@ -20,6 +20,7 @@
     "semver": "^7.6.3"
   },
   "devDependencies": {
+    "@types/node": "^22.8.6",
     "@types/semver": "^7.5.8"
   }
 }

--- a/tools/release-info/tsconfig.json
+++ b/tools/release-info/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "NodeNext",
+    "outDir": "dist",
+    "strict": true,
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "sourceMap": true
+  },
+  "include": ["./*"],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -29,53 +29,21 @@ export function isPrerelease(version: string): boolean {
   return !!semver.prerelease(version);
 }
 
-export async function getLatestSdkVersion(
-  sdk: globals.SDK,
-  includePrerelease: boolean,
-): Promise<string | undefined> {
-  return await getLatestVersion(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GetSdkTagPrefix(sdk),
-    includePrerelease,
-  );
+export async function getLatestSdkVersion(sdk: globals.SDK, includePrerelease: boolean): Promise<string | undefined> {
+  return await getLatestVersion(globals.GitHubOwner, globals.GitHubRepo, globals.GetSdkTagPrefix(sdk), includePrerelease);
 }
 
-export async function getLatestRuntimeVersion(
-  includePrerelease: boolean,
-): Promise<string | undefined> {
-  return await getLatestVersion(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GitHubRuntimeTagPrefix,
-    includePrerelease,
-  );
+export async function getLatestRuntimeVersion(includePrerelease: boolean): Promise<string | undefined> {
+  return await getLatestVersion(globals.GitHubOwner, globals.GitHubRepo, globals.GitHubRuntimeTagPrefix, includePrerelease);
 }
 
-export async function getLatestCliVersion(
-  includePrerelease: boolean,
-): Promise<string | undefined> {
-  return await getLatestVersion(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GitHubCliTagPrefix,
-    includePrerelease,
-  );
+export async function getLatestCliVersion(includePrerelease: boolean): Promise<string | undefined> {
+  return await getLatestVersion(globals.GitHubOwner, globals.GitHubRepo, globals.GitHubCliTagPrefix, includePrerelease);
 }
 
-async function getLatestVersion(
-  owner: string,
-  repo: string,
-  prefix: string,
-  includePrerelease: boolean,
-): Promise<string | undefined> {
+async function getLatestVersion(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string | undefined> {
   try {
-    let tag = await findLatestReleaseTag(
-      owner,
-      repo,
-      prefix,
-      includePrerelease,
-    );
+    let tag = await findLatestReleaseTag(owner, repo, prefix, includePrerelease);
     if (!tag && !includePrerelease) {
       // If no stable release was found, look for a prerelease
       tag = await findLatestReleaseTag(owner, repo, prefix, true);
@@ -88,46 +56,19 @@ async function getLatestVersion(
   }
 }
 
-export async function getAllSdkVersions(
-  sdk: globals.SDK,
-  includePrerelease: boolean,
-): Promise<string[]> {
-  return await getAllVersions(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GetSdkTagPrefix(sdk),
-    includePrerelease,
-  );
+export async function getAllSdkVersions(sdk: globals.SDK, includePrerelease: boolean): Promise<string[]> {
+  return await getAllVersions(globals.GitHubOwner, globals.GitHubRepo, globals.GetSdkTagPrefix(sdk), includePrerelease);
 }
 
-export async function getAllCliVersions(
-  includePrerelease: boolean,
-): Promise<string[]> {
-  return await getAllVersions(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GitHubCliTagPrefix,
-    includePrerelease,
-  );
+export async function getAllCliVersions(includePrerelease: boolean): Promise<string[]> {
+  return await getAllVersions(globals.GitHubOwner, globals.GitHubRepo, globals.GitHubCliTagPrefix, includePrerelease);
 }
 
-export async function getAllRuntimeVersions(
-  includePrerelease: boolean,
-): Promise<string[]> {
-  return await getAllVersions(
-    globals.GitHubOwner,
-    globals.GitHubRepo,
-    globals.GitHubRuntimeTagPrefix,
-    includePrerelease,
-  );
+export async function getAllRuntimeVersions(includePrerelease: boolean): Promise<string[]> {
+  return await getAllVersions(globals.GitHubOwner, globals.GitHubRepo, globals.GitHubRuntimeTagPrefix, includePrerelease);
 }
 
-async function getAllVersions(
-  owner: string,
-  repo: string,
-  prefix: string,
-  includePrerelease: boolean,
-): Promise<string[]> {
+async function getAllVersions(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string[]> {
   try {
     let tags = await getAllReleaseTags(owner, repo, prefix, includePrerelease);
     if (tags.length === 0 && !includePrerelease) {
@@ -151,18 +92,10 @@ async function getAllVersions(
 
 const headers = getGitHubApiHeaders();
 
-async function findLatestReleaseTag(
-  owner: string,
-  repo: string,
-  prefix: string,
-  includePrerelease: boolean,
-): Promise<string | undefined> {
+async function findLatestReleaseTag(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string | undefined> {
   let page = 1;
   while (true) {
-    const response = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/releases?page=${page}`,
-      { headers },
-    );
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases?page=${page}`, { headers });
 
     if (!response.ok) {
       throw new Error(`Error fetching releases: ${response.statusText}`);
@@ -189,20 +122,12 @@ async function findLatestReleaseTag(
   }
 }
 
-async function getAllReleaseTags(
-  owner: string,
-  repo: string,
-  prefix: string,
-  includePrerelease: boolean,
-): Promise<string[]> {
+async function getAllReleaseTags(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string[]> {
   const results: string[] = [];
 
   let page = 1;
   while (true) {
-    const response = await fetch(
-      `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100&page=${page}`,
-      { headers },
-    );
+    const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases?per_page=100&page=${page}`, { headers });
 
     if (!response.ok) {
       throw new Error(`Error fetching releases: ${response.statusText}`);

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import semver from "semver";
+import * as globals from "./constants.js";
+
+function getGitHubApiHeaders() {
+  const headers = new Headers({
+    Accept: "application/vnd.github.v3+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "Modus CLI",
+  });
+  if (process.env.GITHUB_TOKEN) {
+    headers.append("Authorization", `Bearer ${process.env.GITHUB_TOKEN}`);
+  }
+  return headers;
+}
+
+export function isPrerelease(version: string): boolean {
+  if (version.startsWith("v")) {
+    version = version.slice(1);
+  }
+  return !!semver.prerelease(version);
+}
+
+export async function getLatestSdkVersion(
+  sdk: globals.SDK,
+  includePrerelease: boolean,
+): Promise<string | undefined> {
+  return await getLatestVersion(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GetSdkTagPrefix(sdk),
+    includePrerelease,
+  );
+}
+
+export async function getLatestRuntimeVersion(
+  includePrerelease: boolean,
+): Promise<string | undefined> {
+  return await getLatestVersion(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GitHubRuntimeTagPrefix,
+    includePrerelease,
+  );
+}
+
+export async function getLatestCliVersion(
+  includePrerelease: boolean,
+): Promise<string | undefined> {
+  return await getLatestVersion(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GitHubCliTagPrefix,
+    includePrerelease,
+  );
+}
+
+async function getLatestVersion(
+  owner: string,
+  repo: string,
+  prefix: string,
+  includePrerelease: boolean,
+): Promise<string | undefined> {
+  try {
+    let tag = await findLatestReleaseTag(
+      owner,
+      repo,
+      prefix,
+      includePrerelease,
+    );
+    if (!tag && !includePrerelease) {
+      // If no stable release was found, look for a prerelease
+      tag = await findLatestReleaseTag(owner, repo, prefix, true);
+    }
+    if (tag) {
+      return tag.slice(prefix.length);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export async function getAllSdkVersions(
+  sdk: globals.SDK,
+  includePrerelease: boolean,
+): Promise<string[]> {
+  return await getAllVersions(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GetSdkTagPrefix(sdk),
+    includePrerelease,
+  );
+}
+
+export async function getAllCliVersions(
+  includePrerelease: boolean,
+): Promise<string[]> {
+  return await getAllVersions(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GitHubCliTagPrefix,
+    includePrerelease,
+  );
+}
+
+export async function getAllRuntimeVersions(
+  includePrerelease: boolean,
+): Promise<string[]> {
+  return await getAllVersions(
+    globals.GitHubOwner,
+    globals.GitHubRepo,
+    globals.GitHubRuntimeTagPrefix,
+    includePrerelease,
+  );
+}
+
+async function getAllVersions(
+  owner: string,
+  repo: string,
+  prefix: string,
+  includePrerelease: boolean,
+): Promise<string[]> {
+  try {
+    let tags = await getAllReleaseTags(owner, repo, prefix, includePrerelease);
+    if (tags.length === 0 && !includePrerelease) {
+      // If no stable release was found, look for prereleases
+      tags = await getAllReleaseTags(owner, repo, prefix, true);
+    }
+    let versions = tags.map((tag) => {
+      let version = tag.slice(prefix.length);
+      if (version.startsWith("v")) {
+        version = version.slice(1);
+      }
+      return version;
+    });
+    versions = semver.rsort(versions);
+    return versions.map((v) => "v" + v);
+  } catch (e) {
+    console.error(e);
+    return [];
+  }
+}
+
+const headers = getGitHubApiHeaders();
+
+async function findLatestReleaseTag(
+  owner: string,
+  repo: string,
+  prefix: string,
+  includePrerelease: boolean,
+): Promise<string | undefined> {
+  let page = 1;
+  while (true) {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases?page=${page}`,
+      { headers },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Error fetching releases: ${response.statusText}`);
+    }
+
+    const releases = await response.json();
+    if (releases.length === 0) {
+      return;
+    }
+
+    for (const release of releases) {
+      if (!includePrerelease && release.prerelease) {
+        continue;
+      }
+
+      if (prefix && !release.tag_name.startsWith(prefix)) {
+        continue;
+      }
+
+      return release.tag_name;
+    }
+
+    page++;
+  }
+}
+
+async function getAllReleaseTags(
+  owner: string,
+  repo: string,
+  prefix: string,
+  includePrerelease: boolean,
+): Promise<string[]> {
+  const results: string[] = [];
+
+  let page = 1;
+  while (true) {
+    const response = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100&page=${page}`,
+      { headers },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Error fetching releases: ${response.statusText}`);
+    }
+
+    const releases = await response.json();
+    if (releases.length === 0) {
+      return results;
+    }
+
+    for (const release of releases) {
+      if (!includePrerelease && release.prerelease) {
+        continue;
+      }
+
+      if (prefix && !release.tag_name.startsWith(prefix)) {
+        continue;
+      }
+
+      results.push(release.tag_name);
+    }
+
+    page++;
+  }
+}

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -10,18 +10,6 @@
 import semver from "semver";
 import * as globals from "./constants.js";
 
-function getGitHubApiHeaders() {
-  const headers = new Headers({
-    Accept: "application/vnd.github.v3+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Modus CLI",
-  });
-  if (process.env.GITHUB_TOKEN) {
-    headers.append("Authorization", `Bearer ${process.env.GITHUB_TOKEN}`);
-  }
-  return headers;
-}
-
 export function isPrerelease(version: string): boolean {
   if (version.startsWith("v")) {
     version = version.slice(1);
@@ -90,7 +78,11 @@ async function getAllVersions(owner: string, repo: string, prefix: string, inclu
   }
 }
 
-const headers = getGitHubApiHeaders();
+const headers = {
+  Accept: "application/vnd.github.v3+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "Modus CLI",
+};
 
 async function findLatestReleaseTag(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string | undefined> {
   let page = 1;


### PR DESCRIPTION
# Description
- Made a new script (`/tools/release-info`) to generate `modus-all.json`, `modus-preview.json`, `modus-preview-all.json`, and `modus-preview.json`,
- Copied most of the code from `/cli/src/util/versioninfo.ts`, most of which should be removed in #545
- Created `release-info`, which is a standalone workflow that can be invoked both manually (`workflow_dispatch`) and from another workflow (`workflow_call`), which in our case is `release-cli`, `release-runtime`, `release-sdk-as`, and `release-sdk-go`,
- This workflow simply compiles and runs the script, and pushes the four JSON files to our releases R2 bucket

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
