### PR TITLE
Fix timestamp parsing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Fix timestamp parsing bug [#527](https://github.com/hypermodeinc/modus/pull/527)
+
 ## 2024-10-29 - CLI Version 0.13.4
 
 - `modus build` should install SDK if not already installed [#524](https://github.com/hypermodeinc/modus/pull/524)

--- a/runtime/languages/assemblyscript/handler_dates.go
+++ b/runtime/languages/assemblyscript/handler_dates.go
@@ -12,7 +12,6 @@ package assemblyscript
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/hypermodeinc/modus/lib/metadata"
@@ -54,18 +53,9 @@ func (h *dateHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offs
 }
 
 func (h *dateHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, offset uint32, obj any) (utils.Cleaner, error) {
-	var tm time.Time
-	switch t := obj.(type) {
-	case time.Time:
-		tm = t.UTC()
-	case *time.Time:
-		tm = t.UTC()
-	case utils.JSONTime:
-		tm = time.Time(t).UTC()
-	case *utils.JSONTime:
-		tm = time.Time(*t).UTC()
-	default:
-		return nil, fmt.Errorf("incompatible type for Date object: %T", obj)
+	tm, err := utils.ConvertToTimestamp(obj)
+	if err != nil {
+		return nil, err
 	}
 
 	if ok := wa.Memory().WriteUint32Le(offset, uint32(tm.Year())); !ok {

--- a/runtime/languages/assemblyscript/tests/dates_test.go
+++ b/runtime/languages/assemblyscript/tests/dates_test.go
@@ -16,11 +16,19 @@ import (
 	"github.com/hypermodeinc/modus/runtime/utils"
 )
 
-var testTime, _ = time.Parse(time.RFC3339, "2024-12-31T23:59:59.999Z")
+var testTimeStr = "2024-12-31T23:59:59.999Z"
+var testTime, _ = time.Parse(time.RFC3339, testTimeStr)
 
 func TestDateInput(t *testing.T) {
 	fnName := "testDateInput"
 	if _, err := fixture.CallFunction(t, fnName, testTime); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDateStrInput(t *testing.T) {
+	fnName := "testDateInput"
+	if _, err := fixture.CallFunction(t, fnName, testTimeStr); err != nil {
 		t.Error(err)
 	}
 }

--- a/runtime/languages/golang/handler_time.go
+++ b/runtime/languages/golang/handler_time.go
@@ -12,7 +12,6 @@ package golang
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 	"unsafe"
 
@@ -52,12 +51,12 @@ func (h *timeHandler) Read(ctx context.Context, wa langsupport.WasmAdapter, offs
 }
 
 func (h *timeHandler) Write(ctx context.Context, wa langsupport.WasmAdapter, offset uint32, obj any) (utils.Cleaner, error) {
-	t, ok := obj.(time.Time)
-	if !ok {
-		return nil, fmt.Errorf("expected time.Time, got %T", obj)
+	tm, err := utils.ConvertToTimestamp(obj)
+	if err != nil {
+		return nil, err
 	}
 
-	wall, ext := getTimeVals(t)
+	wall, ext := getTimeVals(tm)
 
 	if !wa.Memory().WriteUint64Le(offset, wall) {
 		return nil, errors.New("failed to write time.Time.wall to WASM memory")
@@ -84,12 +83,12 @@ func (h *timeHandler) Decode(ctx context.Context, wa langsupport.WasmAdapter, va
 }
 
 func (h *timeHandler) Encode(ctx context.Context, wa langsupport.WasmAdapter, obj any) ([]uint64, utils.Cleaner, error) {
-	t, ok := obj.(time.Time)
-	if !ok {
-		return []uint64{0}, nil, fmt.Errorf("expected time.Time, got %T", obj)
+	tm, err := utils.ConvertToTimestamp(obj)
+	if err != nil {
+		return []uint64{0}, nil, err
 	}
 
-	wall, ext := getTimeVals(t)
+	wall, ext := getTimeVals(tm)
 
 	// skip loc - we only support UTC
 

--- a/runtime/languages/golang/tests/time_test.go
+++ b/runtime/languages/golang/tests/time_test.go
@@ -16,12 +16,20 @@ import (
 	"github.com/hypermodeinc/modus/runtime/utils"
 )
 
-var testTime, _ = time.Parse(time.RFC3339, "2024-12-31T23:59:59.999999999Z")
+var testTimeStr = "2024-12-31T23:59:59.999999999Z"
+var testTime, _ = time.Parse(time.RFC3339, testTimeStr)
 var testDuration = time.Duration(5 * time.Second)
 
 func TestTimeInput(t *testing.T) {
 	fnName := "testTimeInput"
 	if _, err := fixture.CallFunction(t, fnName, testTime); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTimeStrInput(t *testing.T) {
+	fnName := "testTimeInput"
+	if _, err := fixture.CallFunction(t, fnName, testTimeStr); err != nil {
 		t.Error(err)
 	}
 }
@@ -32,6 +40,16 @@ func TestTimePtrInput(t *testing.T) {
 		t.Error(err)
 	}
 	if _, err := fixture.CallFunction(t, fnName, &testTime); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTimeStrPtrInput(t *testing.T) {
+	fnName := "testTimePtrInput"
+	if _, err := fixture.CallFunction(t, fnName, testTimeStr); err != nil {
+		t.Error(err)
+	}
+	if _, err := fixture.CallFunction(t, fnName, &testTimeStr); err != nil {
 		t.Error(err)
 	}
 }

--- a/runtime/utils/time.go
+++ b/runtime/utils/time.go
@@ -52,13 +52,13 @@ func (t JSONTime) String() string {
 // If time is not included, it is assumed to be midnight.
 // Allow space or T as separator between date and time.
 var inputTimeFormats = []string{
-	"2006-01-02T15:04:05.999Z07:00",
+	"2006-01-02T15:04:05.999999999Z07:00",
 	"2006-01-02T15:04Z07:00",
-	"2006-01-02T15:04:05.999",
+	"2006-01-02T15:04:05.999999999",
 	"2006-01-02T15:04",
-	"2006-01-02 15:04:05.999Z07:00",
+	"2006-01-02 15:04:05.999999999Z07:00",
 	"2006-01-02 15:04Z07:00",
-	"2006-01-02 15:04:05.999",
+	"2006-01-02 15:04:05.999999999",
 	"2006-01-02 15:04",
 	"2006-01-02",
 }
@@ -83,4 +83,23 @@ func ParseTime(s string) (time.Time, error) {
 // GetTime returns the current time.
 func GetTime() time.Time {
 	return time.Now().UTC()
+}
+
+func ConvertToTimestamp(obj any) (time.Time, error) {
+	switch t := obj.(type) {
+	case time.Time:
+		return t.UTC(), nil
+	case *time.Time:
+		return t.UTC(), nil
+	case JSONTime:
+		return time.Time(t).UTC(), nil
+	case *JSONTime:
+		return time.Time(*t).UTC(), nil
+	case string:
+		return ParseTime(t)
+	case *string:
+		return ParseTime(*t)
+	default:
+		return time.Time{}, fmt.Errorf("incompatible type for timestamp: %T", obj)
+	}
 }


### PR DESCRIPTION
# Description
Fixes issue with parsing timestamp from string input

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
