### PR TITLE
HYP-2508: Use adj-noun for default app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add env file callback support for auth key reloading [#520](https://github.com/hypermodeinc/modus/pull/520)
 - Fix timestamp parsing bug [#527](https://github.com/hypermodeinc/modus/pull/527)
+- Use `<adj>-<noun>` for default app name. [#528](https://github.com/hypermodeinc/modus/pull/528)
 
 ## 2024-10-29 - CLI Version 0.13.4
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -24,6 +24,7 @@ import SDKInstallCommand from "../sdk/install/index.js";
 import { getHeader } from "../../custom/header.js";
 import * as inquirer from "@inquirer/prompts";
 import { getGoVersion, getTinyGoVersion } from "../../util/systemVersions.js";
+import { generateAppName } from "../../util/appname.js";
 
 const MODUS_DEFAULT_TEMPLATE_NAME = "default";
 
@@ -102,7 +103,7 @@ export default class NewCommand extends Command {
         sdk = parseSDK(sdkInput);
       }
 
-      const defaultAppName = getDefaultAppNameBySdk(sdk);
+      const defaultAppName = generateAppName();
       let name =
         flags.name ||
         (await inquirer.input({
@@ -307,19 +308,4 @@ function toValidAppName(input: string): string {
     .replace(/\s+/g, "-") // Replace spaces (or multiple spaces) with a single hyphen
     .replace(/-+/g, "-") // Replace multiple consecutive hyphens with a single hyphen
     .replace(/^-|-$/g, ""); // Remove leading or trailing hyphens
-}
-
-const MODUS_NEW_DEFAULT_APP_NAME = "modus-app";
-const MODUS_NEW_GO_APP_NAME = "modus-go-app";
-const MODUS_NEW_AS_APP_NAME = "modus-as-app";
-
-function getDefaultAppNameBySdk(sdk: SDK) {
-  switch (sdk) {
-    case SDK.AssemblyScript:
-      return MODUS_NEW_AS_APP_NAME;
-    case SDK.Go:
-      return MODUS_NEW_GO_APP_NAME;
-    default:
-      return MODUS_NEW_DEFAULT_APP_NAME;
-  }
 }

--- a/cli/src/util/appname.ts
+++ b/cli/src/util/appname.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const ADJS = ["stealth", "covert", "master", "rogue", "steady", "secret", "bold", "infinite", "true", "ops"];
+const NOUNS = ["tactic", "script", "sequence", "nexus", "blueprint", "protocol", "strategy", "path", "circuit", "code"];
+
+export function generateAppName(): string {
+  const randomAdjective = getRandomItem(ADJS);
+  const randomNoun = getRandomItem(NOUNS);
+
+  return `${randomAdjective}-${randomNoun}`;
+}
+
+function getRandomItem<T>(list: T[]): T {
+  return list[Math.floor(Math.random() * list.length)];
+}


### PR DESCRIPTION
# Description

Use `adj-noun` for default app name.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
