### PR TITLE
Add env file to default project templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Add env file callback support for auth key reloading [#520](https://github.com/hypermodeinc/modus/pull/520)
 - Fix timestamp parsing bug [#527](https://github.com/hypermodeinc/modus/pull/527)
-- Use `<adj>-<noun>` for default app name. [#528](https://github.com/hypermodeinc/modus/pull/528)
+- Use `<adj>-<noun>` for default app name [#528](https://github.com/hypermodeinc/modus/pull/528)
+- Add env file to default project templates [#530](https://github.com/hypermodeinc/modus/pull/530)
 
 ## 2024-10-29 - CLI Version 0.13.4
 

--- a/sdk/assemblyscript/templates/default/.env.dev.local
+++ b/sdk/assemblyscript/templates/default/.env.dev.local
@@ -1,0 +1,19 @@
+# Modus understands .env files and will load them automatically
+# To add a secret for local development, first add a secret placeholder as
+# a template in a connection within modus.json, for example:
+#
+#   "connections": {
+#     "my-api": {
+#       "type": "http",
+#       "baseUrl": "https://api.example.com/",
+#       "headers": {
+#         "Authorization": "Bearer {{AUTH_TOKEN}}"
+#       }
+#     }
+#   }
+#
+# Then add the secret to this file (.env.dev.local), using a corresponding
+# environment name such as the following:
+#
+# MODUS_MY_API_AUTH_TOKEN="secretValue"
+#

--- a/sdk/go/templates/default/.env.dev.local
+++ b/sdk/go/templates/default/.env.dev.local
@@ -1,0 +1,19 @@
+# Modus understands .env files and will load them automatically
+# To add a secret for local development, first add a secret placeholder as
+# a template in a connection within modus.json, for example:
+#
+#   "connections": {
+#     "my-api": {
+#       "type": "http",
+#       "baseUrl": "https://api.example.com/",
+#       "headers": {
+#         "Authorization": "Bearer {{AUTH_TOKEN}}"
+#       }
+#     }
+#   }
+#
+# Then add the secret to this file (.env.dev.local), using a corresponding
+# environment name such as the following:
+#
+# MODUS_MY_API_AUTH_TOKEN="secretValue"
+#


### PR DESCRIPTION
This puts a `.env.dev.local` file in each default project template, so that there's a starting point for local secrets when using `modus dev`