### PR TITLE
Fix issue with git info capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-10-30 - AssemblyScript SDK 0.13.2
+
+- Fix issue with git info capture [#536](https://github.com/hypermodeinc/modus/pull/536)
+
 ## 2024-10-30 - Runtime Version 0.13.1
 
 - Add env file callback support for auth key reloading [#520](https://github.com/hypermodeinc/modus/pull/520)

--- a/sdk/assemblyscript/src/transform/src/metadata.ts
+++ b/sdk/assemblyscript/src/transform/src/metadata.ts
@@ -180,22 +180,30 @@ function isGitRepo(): boolean {
   }
 }
 
-function getGitRepo(): string {
-  let url = execSync("git remote get-url origin").toString().trim();
+function getGitRepo(): string | undefined {
+  try {
+    let url = execSync("git remote get-url origin").toString().trim();
 
-  // Convert ssh to https
-  if (url.startsWith("git@")) {
-    url = url.replace(":", "/").replace("git@", "https://");
+    // Convert ssh to https
+    if (url.startsWith("git@")) {
+      url = url.replace(":", "/").replace("git@", "https://");
+    }
+
+    // Remove the .git suffix
+    if (url.endsWith(".git")) {
+      url = url.slice(0, -4);
+    }
+
+    return url;
+  } catch {
+    return undefined;
   }
-
-  // Remove the .git suffix
-  if (url.endsWith(".git")) {
-    url = url.slice(0, -4);
-  }
-
-  return url;
 }
 
-function getGitCommit(): string {
-  return execSync("git rev-parse HEAD").toString().trim();
+function getGitCommit(): string | undefined {
+  try {
+    return execSync("git rev-parse HEAD").toString().trim();
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
# Description
When building a project that was in a git repository but had not yet been pushed to a remote, the git remote/commit capture was failing in the AssemblyScript transform.  Fixed.

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
