### PR TITLE
modus new: Initialize git repo on interactive flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2024-10-30 - AssemblyScript SDK 0.13.3
 
 - Actually fix issue with git info capture [#537](https://github.com/hypermodeinc/modus/pull/537)
+- `modus new`: Initialize git repo on interactive flow: [#538](https://github.com/hypermodeinc/modus/pull/538)
 
 ## 2024-10-30 - AssemblyScript SDK 0.13.2
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -294,6 +294,8 @@ export default class NewCommand extends Command {
 
       if (createGitRepo) {
         await execFile("git", ["init"], execOpts);
+        await execFile("git", ["add", "."], execOpts);
+        await execFile("git", ["commit", "-m", "'Initial Commit'"], execOpts);
       }
     });
 

--- a/cli/src/util/cp.ts
+++ b/cli/src/util/cp.ts
@@ -17,7 +17,7 @@ const execFile = util.promisify(cp.execFile);
 export { execFile };
 
 /**
- * Promisified version of `child_process.execSync`.
+ * Promisified version of `child_process.exec`.
  */
 const exec = util.promisify(cp.exec);
 export { exec };

--- a/cli/src/util/cp.ts
+++ b/cli/src/util/cp.ts
@@ -17,6 +17,12 @@ const execFile = util.promisify(cp.execFile);
 export { execFile };
 
 /**
+ * Promisified version of `child_process.execSync`.
+ */
+const exec = util.promisify(cp.exec);
+export { exec };
+
+/**
  * Promisified version of `child_process.execFile`, but returns the exit code instead of throwing an error.
  */
 export async function execFileWithExitCode(file: string, args?: string[], options?: cp.ExecFileOptions): Promise<{ stdout: string; stderr: string; exitCode: number }> {


### PR DESCRIPTION
# Description

Initialize a git repo for new projects

- Add a flag `--no-git` for skipping initializing a git repo
- Prompt user to create a new git repo
- When `git` is not found, skip this option
- When project is already in a git repo, skip this option

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
