### PR TITLE
Skip confirmation if all required params are provided

### DIFF
--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -253,7 +253,7 @@ export default class NewCommand extends Command {
         }
       } else if (latestVersion !== installedSdkVersion) {
         const confirmed = await inquirer.confirm({
-          message: `You have ${installedSdkVersion} of the ${sdkText}. The latest is ${latestVersion}. Would you like to update?`,
+          message: `You have ${installedSdkVersion} of the ${sdkText}.\n  The latest is ${latestVersion}. Would you like to update?`,
           default: true,
         });
         if (confirmed) {

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -53,6 +53,7 @@ export default class NewCommand extends Command {
       description: "App directory",
     }),
     "no-git": Flags.boolean({
+      aliases: ["nogit"],
       default: false,
       description: "Do not initialize a git repository",
     }),
@@ -65,7 +66,7 @@ export default class NewCommand extends Command {
     //   description: "Template to use",
     // }),
     "no-prompt": Flags.boolean({
-      char: "f",
+      aliases: ["noprompt"],
       default: false,
       description: "Initialize without prompting",
     }),
@@ -143,7 +144,7 @@ export default class NewCommand extends Command {
       }
 
       const allRequiredFlagsProvided = flags.sdk && flags.name && flags.dir;
-      if (!flags['no-prompt'] && !allRequiredFlagsProvided) {
+      if (!flags["no-prompt"] && !allRequiredFlagsProvided) {
         const confirmed = await inquirer.confirm({ message: "Continue?", default: true });
         if (!confirmed) {
           this.abort();


### PR DESCRIPTION
# Description

- `--force` -> `--no-prompt`
- Check for non TTY terminal. In that case, require all options to be passed as flags.
- If all required flags are provided, do not prompt for confirmation

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [ ] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
