### PR TITLE
`modus new`: Fix issues with Go/TinyGo version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
+## 2024-10-30 - CLI 0.13.6
+
+- `modus new`: Initialize git repo on interactive flow [#538](https://github.com/hypermodeinc/modus/pull/538)
+- `modus new`: Skip confirmation if all required params are provided [#539](https://github.com/hypermodeinc/modus/pull/539)
+- `modus new`: Fix issues with Go/TinyGo version detection [#540](https://github.com/hypermodeinc/modus/pull/540)
+
 ## 2024-10-30 - AssemblyScript SDK 0.13.3
 
 - Actually fix issue with git info capture [#537](https://github.com/hypermodeinc/modus/pull/537)
-- `modus new`: Initialize git repo on interactive flow: [#538](https://github.com/hypermodeinc/modus/pull/538)
 
 ## 2024-10-30 - AssemblyScript SDK 0.13.2
 

--- a/cli/src/util/systemVersions.ts
+++ b/cli/src/util/systemVersions.ts
@@ -21,7 +21,10 @@ export async function getGoVersion(): Promise<string | undefined> {
     const parts = result.stdout.split(" ");
     const str = parts.length > 2 ? parts[2] : undefined;
     if (str?.startsWith("go")) {
-      return str.slice(2);
+      const ver = str.slice(2);
+
+      // if version is two parts, add a .0 to make it semver compatible
+      return ver.split(".").length === 2 ? ver + ".0" : ver;
     }
   } catch {}
 }
@@ -30,7 +33,11 @@ export async function getTinyGoVersion(): Promise<string | undefined> {
   try {
     const result = await execFile("tinygo", ["version"], EXEC_OPTIONS);
     const parts = result.stdout.split(" ");
-    return parts.length > 2 ? parts[2] : undefined;
+    const ver = parts.length > 2 ? parts[2] : undefined;
+    if (!ver) return undefined;
+
+    // if version is two parts, add a .0 to make it semver compatible
+    return ver.split(".").length === 2 ? ver + ".0" : ver;
   } catch {}
 }
 


### PR DESCRIPTION
If the system had a two-part version of Go (or TinyGo) such as `1.19`, `modus new` would give a message such as `TypeError: Invalid Version: 1.19` - because it's not semver compatible.

This is the fix.