### PR TITLE
CLI refactor + consistent help + print enum options + validate SDK prereq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## UNRELEASED
+
+- Consistent padding in the help section
+- `modus new`: Enum options need to print possible options
+- Validate SDK prereq immediately after choosing SDK
+
 ## 2024-10-30 - CLI 0.13.6
 
 - `modus new`: Initialize git repo on interactive flow [#538](https://github.com/hypermodeinc/modus/pull/538)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## UNRELEASED
 
-- Consistent padding in the help section [#542](https://github.com/hypermodeinc/modus/pull/542)
-- `modus new`: Enum options need to print possible options [#542](https://github.com/hypermodeinc/modus/pull/542)
-- Validate SDK prereq immediately after choosing SDK [#542](https://github.com/hypermodeinc/modus/pull/542)
+- Consistent help + print enum options + validate SDK prereq [#542](https://github.com/hypermodeinc/modus/pull/542)
+  - Consistent padding in the help section 
+  - `modus new`: Enum options need to print possible options
+  - Validate SDK prereq immediately after choosing SDK
 - For CLI to track non-prereleases, pull from releases json to remove rate limiting issues from github releases [#543](https://github.com/hypermodeinc/modus/pull/543)
 
 ## 2024-10-30 - CLI 0.13.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Consistent padding in the help section 
   - `modus new`: Enum options need to print possible options
   - Validate SDK prereq immediately after choosing SDK
+  - `modus sdk remove`: Use select prompt to allow selection
 - For CLI to track non-prereleases, pull from releases json to remove rate limiting issues from github releases [#543](https://github.com/hypermodeinc/modus/pull/543)
 
 ## 2024-10-30 - CLI 0.13.6

--- a/cli/src/baseCommand.ts
+++ b/cli/src/baseCommand.ts
@@ -6,6 +6,7 @@ export abstract class BaseCommand extends Command {
       char: "h",
       helpLabel: "-h, --help",
       description: "Show help message",
+      helpGroup: "Global",
     }),
     "no-logo": Flags.boolean({
       aliases: ["nologo"],

--- a/cli/src/commands/baseCommand.ts
+++ b/cli/src/commands/baseCommand.ts
@@ -1,0 +1,15 @@
+import { Command, Flags } from "@oclif/core";
+
+export abstract class BaseCommand extends Command {
+  static baseFlags = {
+    help: Flags.help({
+      char: "h",
+      helpLabel: "-h, --help",
+      description: "Show help message",
+    }),
+    "no-logo": Flags.boolean({
+      aliases: ["nologo"],
+      hidden: true,
+    }),
+  };
+}

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -19,7 +19,7 @@ import { getAppInfo } from "../../util/appinfo.js";
 import { withSpinner } from "../../util/index.js";
 import { execFileWithExitCode } from "../../util/cp.js";
 import SDKInstallCommand from "../sdk/install/index.js";
-import { BaseCommand } from "../baseCommand.js";
+import { BaseCommand } from "../../baseCommand.js";
 
 export default class BuildCommand extends BaseCommand {
   static args = {

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -19,8 +19,9 @@ import { getAppInfo } from "../../util/appinfo.js";
 import { withSpinner } from "../../util/index.js";
 import { execFileWithExitCode } from "../../util/cp.js";
 import SDKInstallCommand from "../sdk/install/index.js";
+import { BaseCommand } from "../baseCommand.js";
 
-export default class BuildCommand extends Command {
+export default class BuildCommand extends BaseCommand {
   static args = {
     path: Args.directory({
       description: "Path to app directory",
@@ -29,17 +30,7 @@ export default class BuildCommand extends Command {
     }),
   };
 
-  static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
-  };
+  static flags = {};
 
   static description = "Build a Modus app";
 

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -25,11 +25,12 @@ import { getAppInfo } from "../../util/appinfo.js";
 import { isOnline, withSpinner } from "../../util/index.js";
 import { readHypermodeSettings } from "../../util/hypermode.js";
 import BuildCommand from "../build/index.js";
+import { BaseCommand } from "../baseCommand.js";
 
 const MANIFEST_FILE = "modus.json";
 const ENV_FILES = [".env", ".env.local", ".env.development", ".env.dev", ".env.development.local", ".env.dev.local"];
 
-export default class DevCommand extends Command {
+export default class DevCommand extends BaseCommand {
   static args = {
     path: Args.directory({
       description: "Path to app directory",
@@ -39,15 +40,6 @@ export default class DevCommand extends Command {
   };
 
   static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
     runtime: Flags.string({
       char: "r",
       description: "Modus runtime version to use. If not provided, the latest runtime compatible with the app will be used.",

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -25,7 +25,7 @@ import { getAppInfo } from "../../util/appinfo.js";
 import { isOnline, withSpinner } from "../../util/index.js";
 import { readHypermodeSettings } from "../../util/hypermode.js";
 import BuildCommand from "../build/index.js";
-import { BaseCommand } from "../baseCommand.js";
+import { BaseCommand } from "../../baseCommand.js";
 
 const MANIFEST_FILE = "modus.json";
 const ENV_FILES = [".env", ".env.local", ".env.development", ".env.dev", ".env.development.local", ".env.dev.local"];

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -5,7 +5,7 @@ import * as vi from "../../util/versioninfo.js";
 import { SDK } from "../../custom/globals.js";
 import { getHeader } from "../../custom/header.js";
 import { getGoVersion, getNPMVersion, getTinyGoVersion } from "../../util/systemVersions.js";
-import { BaseCommand } from "../baseCommand.js";
+import { BaseCommand } from "../../baseCommand.js";
 
 export default class InfoCommand extends BaseCommand {
   static args = {};

--- a/cli/src/commands/info/index.ts
+++ b/cli/src/commands/info/index.ts
@@ -5,21 +5,12 @@ import * as vi from "../../util/versioninfo.js";
 import { SDK } from "../../custom/globals.js";
 import { getHeader } from "../../custom/header.js";
 import { getGoVersion, getNPMVersion, getTinyGoVersion } from "../../util/systemVersions.js";
+import { BaseCommand } from "../baseCommand.js";
 
-export default class InfoCommand extends Command {
+export default class InfoCommand extends BaseCommand {
   static args = {};
 
-  static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
-  };
+  static flags = {};
 
   static description = "Show Modus info";
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 import chalk from "chalk";
 import semver from "semver";
 import os from "node:os";
@@ -52,6 +52,7 @@ export default class NewCommand extends BaseCommand {
     sdk: Flags.string({
       char: "s",
       description: "SDK to use",
+      options: ["go", "assemblyscript"],
     }),
     // template: Flags.string({
     //   char: "t",

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -52,7 +52,7 @@ export default class NewCommand extends BaseCommand {
     sdk: Flags.string({
       char: "s",
       description: "SDK to use",
-      options: ["go", "assemblyscript"],
+      options: ["go", "golang", "assemblyscript", "as"],
     }),
     // template: Flags.string({
     //   char: "t",
@@ -219,7 +219,7 @@ export default class NewCommand extends BaseCommand {
         this.log(`${chalk.dim("$")} tinygo version`);
         this.log();
 
-        this.exit(0);
+        this.exit(1);
     }
   }
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -107,6 +107,8 @@ export default class NewCommand extends BaseCommand {
         sdk = parseSDK(sdkInput);
       }
 
+      await this.validateSdkPrereq(sdk);
+
       const defaultAppName = generateAppName();
       let name =
         flags.name ||
@@ -155,8 +157,7 @@ export default class NewCommand extends BaseCommand {
     }
   }
 
-  private async createApp(name: string, dir: string, sdk: SDK, template: string, force: boolean, prerelease: boolean, createGitRepo: boolean) {
-    // Validate SDK-specific prerequisites
+  private async validateSdkPrereq(sdk: string) {
     const sdkText = `Modus ${sdk} SDK`;
     switch (sdk) {
       case SDK.AssemblyScript:
@@ -218,8 +219,12 @@ export default class NewCommand extends BaseCommand {
         this.log(`${chalk.dim("$")} tinygo version`);
         this.log();
 
-        this.exit(1);
+        this.exit(0);
     }
+  }
+
+  private async createApp(name: string, dir: string, sdk: SDK, template: string, force: boolean, prerelease: boolean, createGitRepo: boolean) {
+    const sdkText = `Modus ${sdk} SDK`;
 
     // Verify and/or install the Modus SDK
     let installedSdkVersion = await vi.getLatestInstalledSdkVersion(sdk, prerelease);

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -25,24 +25,16 @@ import { getHeader } from "../../custom/header.js";
 import * as inquirer from "@inquirer/prompts";
 import { getGoVersion, getTinyGoVersion } from "../../util/systemVersions.js";
 import { generateAppName } from "../../util/appname.js";
+import { BaseCommand } from "../baseCommand.js";
 
 const MODUS_DEFAULT_TEMPLATE_NAME = "default";
 
-export default class NewCommand extends Command {
+export default class NewCommand extends BaseCommand {
   static description = "Create a new Modus app";
 
   static examples = ["modus new", "modus new --name my-app", "modus new --name my-app --sdk go --dir ./my-app --no-prompt"];
 
   static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
     name: Flags.string({
       char: "n",
       description: "App name",

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -25,7 +25,7 @@ import { getHeader } from "../../custom/header.js";
 import * as inquirer from "@inquirer/prompts";
 import { getGoVersion, getTinyGoVersion } from "../../util/systemVersions.js";
 import { generateAppName } from "../../util/appname.js";
-import { BaseCommand } from "../baseCommand.js";
+import { BaseCommand } from "../../baseCommand.js";
 
 const MODUS_DEFAULT_TEMPLATE_NAME = "default";
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -144,7 +144,7 @@ export default class NewCommand extends BaseCommand {
       }
 
       this.log();
-      await this.createApp(name, dir, sdk, MODUS_DEFAULT_TEMPLATE_NAME, flags.force, flags.prerelease, createGitRepo);
+      await this.createApp(name, dir, sdk, MODUS_DEFAULT_TEMPLATE_NAME, flags["no-prompt"], flags.prerelease, createGitRepo);
     } catch (err: any) {
       if (err.name === "ExitPromptError") {
         this.abort();

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -14,8 +14,9 @@ import * as vi from "../../../util/versioninfo.js";
 import * as installer from "../../../util/installer.js";
 import { isOnline, withSpinner } from "../../../util/index.js";
 import { getHeader } from "../../../custom/header.js";
+import { BaseCommand } from "../../baseCommand.js";
 
-export default class RuntimeInstallCommand extends Command {
+export default class RuntimeInstallCommand extends BaseCommand {
   static args = {
     version: Args.string({
       description: "Runtime version to install",
@@ -27,15 +28,6 @@ export default class RuntimeInstallCommand extends Command {
   static examples = ["modus runtime install", "modus runtime install v1.2.3", "modus runtime install --prerelease"];
 
   static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
     force: Flags.boolean({
       char: "f",
       default: false,

--- a/cli/src/commands/runtime/install/index.ts
+++ b/cli/src/commands/runtime/install/index.ts
@@ -14,7 +14,7 @@ import * as vi from "../../../util/versioninfo.js";
 import * as installer from "../../../util/installer.js";
 import { isOnline, withSpinner } from "../../../util/index.js";
 import { getHeader } from "../../../custom/header.js";
-import { BaseCommand } from "../../baseCommand.js";
+import { BaseCommand } from "../../../baseCommand.js";
 
 export default class RuntimeInstallCommand extends BaseCommand {
   static args = {

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -11,22 +11,13 @@ import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";
+import { BaseCommand } from "../../baseCommand.js";
 
-export default class RuntimeListCommand extends Command {
+export default class RuntimeListCommand extends BaseCommand {
   static args = {};
   static description = "List installed Modus runtimes";
   static examples = ["modus runtime list"];
-  static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
-  };
+  static flags = {};
 
   async run(): Promise<void> {
     const { flags } = await this.parse(RuntimeListCommand);

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -11,7 +11,7 @@ import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";
-import { BaseCommand } from "../../baseCommand.js";
+import { BaseCommand } from "../../../baseCommand.js";
 
 export default class RuntimeListCommand extends BaseCommand {
   static args = {};

--- a/cli/src/commands/runtime/list/index.ts
+++ b/cli/src/commands/runtime/list/index.ts
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";

--- a/cli/src/commands/runtime/remove/index.ts
+++ b/cli/src/commands/runtime/remove/index.ts
@@ -23,18 +23,7 @@ export default class RuntimeRemoveCommand extends Command {
     }),
   };
 
-  static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    force: Flags.boolean({
-      char: "f",
-      default: false,
-      description: "Remove without prompting",
-    }),
-  };
+  static flags = {};
 
   static description = "Remove a Modus runtime";
   static examples = ["modus runtime remove v0.0.0", "modus runtime remove all"];

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -17,7 +17,7 @@ import * as installer from "../../../util/installer.js";
 import { isOnline, withSpinner } from "../../../util/index.js";
 import { getHeader } from "../../../custom/header.js";
 import { SDK, parseSDK } from "../../../custom/globals.js";
-import { BaseCommand } from "../../baseCommand.js";
+import { BaseCommand } from "../../../baseCommand.js";
 
 export default class SDKInstallCommand extends BaseCommand {
   static args = {

--- a/cli/src/commands/sdk/install/index.ts
+++ b/cli/src/commands/sdk/install/index.ts
@@ -17,8 +17,9 @@ import * as installer from "../../../util/installer.js";
 import { isOnline, withSpinner } from "../../../util/index.js";
 import { getHeader } from "../../../custom/header.js";
 import { SDK, parseSDK } from "../../../custom/globals.js";
+import { BaseCommand } from "../../baseCommand.js";
 
-export default class SDKInstallCommand extends Command {
+export default class SDKInstallCommand extends BaseCommand {
   static args = {
     name: Args.string({
       description: "SDK name to install, or 'all' to install all SDKs",
@@ -34,15 +35,6 @@ export default class SDKInstallCommand extends Command {
   static examples = ["modus sdk install assemblyscript", "modus sdk install assemblyscript v1.2.3", "modus sdk install", "modus sdk install --prerelease"];
 
   static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
     force: Flags.boolean({
       char: "f",
       default: false,

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -12,22 +12,13 @@ import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";
 import { SDK } from "../../../custom/globals.js";
+import { BaseCommand } from "../../baseCommand.js";
 
-export default class SDKListCommand extends Command {
+export default class SDKListCommand extends BaseCommand {
   static args = {};
   static description = "List installed Modus SDKs";
   static examples = ["modus sdk list"];
-  static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
-    "no-logo": Flags.boolean({
-      aliases: ["nologo"],
-      hidden: true,
-    }),
-  };
+  static flags = {};
 
   async run(): Promise<void> {
     const { flags } = await this.parse(SDKListCommand);

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -12,7 +12,7 @@ import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";
 import { SDK } from "../../../custom/globals.js";
-import { BaseCommand } from "../../baseCommand.js";
+import { BaseCommand } from "../../../baseCommand.js";
 
 export default class SDKListCommand extends BaseCommand {
   static args = {};

--- a/cli/src/commands/sdk/list/index.ts
+++ b/cli/src/commands/sdk/list/index.ts
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Command, Flags } from "@oclif/core";
 import chalk from "chalk";
 import * as vi from "../../../util/versioninfo.js";
 import { getHeader } from "../../../custom/header.js";

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -15,7 +15,7 @@ import * as vi from "../../../util/versioninfo.js";
 import { parseSDK, SDK } from "../../../custom/globals.js";
 import { withSpinner } from "../../../util/index.js";
 import * as inquirer from "@inquirer/prompts";
-import { BaseCommand } from "../../baseCommand.js";
+import { BaseCommand } from "../../../baseCommand.js";
 
 export default class SDKRemoveCommand extends BaseCommand {
   static args = {

--- a/cli/src/commands/sdk/remove/index.ts
+++ b/cli/src/commands/sdk/remove/index.ts
@@ -15,8 +15,9 @@ import * as vi from "../../../util/versioninfo.js";
 import { parseSDK, SDK } from "../../../custom/globals.js";
 import { withSpinner } from "../../../util/index.js";
 import * as inquirer from "@inquirer/prompts";
+import { BaseCommand } from "../../baseCommand.js";
 
-export default class SDKRemoveCommand extends Command {
+export default class SDKRemoveCommand extends BaseCommand {
   static args = {
     name: Args.string({
       description: "SDK name to remove (or 'all' to remove all SDKs)",
@@ -29,11 +30,6 @@ export default class SDKRemoveCommand extends Command {
   };
 
   static flags = {
-    help: Flags.help({
-      char: "h",
-      helpLabel: "-h, --help",
-      description: "Show help message",
-    }),
     runtimes: Flags.boolean({
       char: "r",
       default: false,

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -180,7 +180,7 @@ export default class CustomHelp extends Help {
           desc = arg.description.split("-|-")[1];
         }
         if (arg.default) {
-          desc += chalk.dim(` (default: '${arg.default}')`);
+          desc += chalk.dim(` (default: ${arg.default})`);
         }
 
         if (arg.options) {

--- a/cli/src/custom/help.ts
+++ b/cli/src/custom/help.ts
@@ -108,7 +108,36 @@ export default class CustomHelp extends Help {
       this.log();
     }
 
+    const globalFlagTopics: Interfaces.Topic[] = [
+      {
+        name: "--help",
+        description: "Show help message",
+        shortName: "-h",
+      },
+      {
+        name: "--version",
+        description: "Show Modus version",
+        shortName: "-v",
+      },
+    ];
+    this.log(this.formatRootFlags(globalFlagTopics));
+    this.log();
+
     this.log(this.formatFooter());
+  }
+
+  formatRootFlags(topics: Interfaces.Topic[]): string {
+    let out = "";
+    if (topics.find((v) => !v.hidden)) out += chalk.bold("Flags:") + "\n";
+    else return out;
+
+    for (const topic of topics) {
+      if (topic.hidden) continue;
+
+      const fullName = topic.shortName ? `${topic.shortName}, ${topic.name}` : topic.name;
+      out += getMessageWithPad(chalk.bold.blue(fullName), topic.description || "", FIRST_PAD, SECOND_PAD, fullName.length) + "\n";
+    }
+    return out.trim();
   }
 
   async showTopicHelp(topic: Interfaces.Topic) {


### PR DESCRIPTION
# Description

- Make all commands inherit from a `BaseCommand` to avoid declaring the same flags multiple times
- Consistent padding in the help section
- `modus new`: Enum options need to print possible options
- Validate SDK prereq immediately after choosing SDK

# Checklist
- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
