### PR TITLE
Update installer script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - remove all github api call references, add prerelease support to CLI [#545](https://github.com/hypermodeinc/modus/pull/545)
 - Add CLI build CI [#547](https://github.com/hypermodeinc/modus/pull/547)
 - Add CLI Lint CI [#550](https://github.com/hypermodeinc/modus/pull/550)
+- Update installer script [#551](https://github.com/hypermodeinc/modus/pull/551)
 
 ## 2024-10-30 - CLI 0.13.6
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -14,7 +14,7 @@ PACKAGE_ORG="@hypermode"
 PACKAGE_NAME="modus-cli"
 INSTALL_DIR="${MODUS_CLI:-"$HOME/.modus/cli"}"
 VERSION="latest"
-INSTALLER_VERSION="0.1.1"
+INSTALLER_VERSION="0.1.2"
 
 NODE_MIN=22
 NODE_PATH="$(which node)"
@@ -44,9 +44,8 @@ else
 fi
 
 get_latest_version() {
-  local url="https://registry.npmjs.org/${PACKAGE_ORG:+$PACKAGE_ORG/}$PACKAGE_NAME"
-
-  curl --silent "$url" | jq -r '.["dist-tags"].latest'
+  local url="https://releases.hypermode.com/modus-latest.json"
+  curl -sL "$url" | grep '"cli"' | sed -E 's/.*"cli": "v([^"]+)".*/\1/'
 }
 
 ARCHIVE_URL=""

--- a/cli/src/util/versioninfo.ts
+++ b/cli/src/util/versioninfo.ts
@@ -11,7 +11,6 @@ import semver from "semver";
 import path from "node:path";
 import * as fs from "./fs.js";
 import * as globals from "../custom/globals.js";
-import { getGitHubApiHeaders } from "./index.js";
 
 export function getSdkPath(sdk: globals.SDK, version: string): string {
   return path.join(globals.ModusHomeDir, "sdk", sdk.toLowerCase(), version);


### PR DESCRIPTION
**Description**

- Removes `jq` from the install script, because it's not pre-installed on MacOS by default.  (Replace with `grep` / `sed` which are.)
- Use our CDN for the version check, instead of NPM.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

