### PR TITLE
feat: Add API Explorer stub to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- Add API Explorer stub to CLI [#554](https://github.com/hypermodeinc/modus/pull/554)
+
 ## 2024-11-04 - CLI 0.13.7
 
 - Automatically generate and push releases info to R2 bucket on every release [#526](https://github.com/hypermodeinc/modus/pull/526)

--- a/cli/content/index.html
+++ b/cli/content/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Modus API Explorer</title>
+  </head>
+  <body>
+    <h1>Modus API Explorer</h1>
+    <p>This is the Modus API Explorer. You can use this tool to explore the API and test the endpoints.</p>
+    <p>Note, this works, but will soon be replaced by something much nicer!</p>
+
+    <h2>Available Endpoints</h2>
+    <select id="endpoint"></select>
+
+    <h2>GraphQL Query</h2>
+    <textarea id="query" rows="10" cols="50" placeholder="Enter your GraphQL query here..."></textarea>
+
+    <button id="submit">Submit Query</button>
+
+    <h2>Response</h2>
+    <textarea id="response" rows="10" cols="50" readonly></textarea>
+
+    <script>
+      // Populate the endpoint dropdown from the "endpoints" parameter on the query string, which
+      // is a json-encoded object of endpoint names to urls as key-value pairs.
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const endpoints = JSON.parse(urlParams.get("endpoints"));
+
+      const endpointSelect = document.getElementById("endpoint");
+      for (const [name, url] of Object.entries(endpoints)) {
+        const option = document.createElement("option");
+        option.value = url;
+        option.text = `${name}: ${url}`;
+        endpointSelect.appendChild(option);
+      }
+
+      document.getElementById("submit").addEventListener("click", async () => {
+        const endpoint = document.getElementById("endpoint").value;
+        const query = document.getElementById("query").value;
+        const responseTextarea = document.getElementById("response");
+
+        try {
+          const response = await fetch(endpoint, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ query }),
+          });
+
+          const result = await response.json();
+          responseTextarea.value = JSON.stringify(result, null, 2);
+        } catch (error) {
+          responseTextarea.value = `Error: ${error.message}`;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^5.3.0",
         "chokidar": "^4.0.1",
         "gradient-string": "^3.0.0",
+        "open": "^10.1.0",
         "ora": "^8.1.0",
         "picomatch": "^4.0.2",
         "semver": "^7.6.3"
@@ -3497,6 +3498,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -3796,6 +3812,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -3804,6 +3848,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/detect-indent": {
@@ -5271,6 +5327,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5674,6 +5748,18 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,6 +34,7 @@
     "chalk": "^5.3.0",
     "chokidar": "^4.0.1",
     "gradient-string": "^3.0.0",
+    "open": "^10.1.0",
     "ora": "^8.1.0",
     "picomatch": "^4.0.2",
     "semver": "^7.6.3"
@@ -55,6 +56,7 @@
   },
   "files": [
     "/bin",
+    "/content",
     "/dist",
     "/oclif.manifest.json"
   ],

--- a/cli/src/custom/apiExplorer.ts
+++ b/cli/src/custom/apiExplorer.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import open from "open";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const filePath = path.resolve(__dirname, "../../content/index.html");
+
+export async function openApiExplorer(endpoints: { [key: string]: string }) {
+  const server = http.createServer((req, res) => {
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        res.writeHead(500);
+        res.end(`Error loading file: ${err}`);
+      } else {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(content);
+      }
+    });
+  });
+
+  const port = await findAvailablePort(3000, 3100);
+  server.listen(port, async () => {
+    console.log(`API Explorer running at http://localhost:${port}`);
+    await open(`http://localhost:${port}?endpoints=${encodeURIComponent(JSON.stringify(endpoints))}`);
+  });
+}
+
+async function findAvailablePort(start: number, end: number): Promise<number> {
+  for (let port = start; port <= end; port++) {
+    const isAvailable = await checkPort(port);
+    if (isAvailable) {
+      return port;
+    }
+  }
+  throw new Error(`No available port found in range ${start}-${end}`);
+}
+
+function checkPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+
+    server.once("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        resolve(false);
+      } else {
+        resolve(false);
+      }
+    });
+
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+
+    server.listen(port);
+  });
+}


### PR DESCRIPTION
**Description**

This adds a rudimentary API Explorer page that is hosted by the CLI and launched in a browser when `modus dev` is run.

The content of the API Explorer is a placeholder for proof-of-concept.  It will soon be replaced by an actual interactive API Explorer.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
