### PR TITLE
ci: Add `secrets: inherit` when calling release-info workflow

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -54,3 +54,4 @@ jobs:
     needs: release
     name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml
+    secrets: inherit

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -42,3 +42,4 @@ jobs:
     needs: release
     name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml
+    secrets: inherit

--- a/.github/workflows/release-sdk-as.yaml
+++ b/.github/workflows/release-sdk-as.yaml
@@ -54,3 +54,4 @@ jobs:
     needs: release
     name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml
+    secrets: inherit

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -43,3 +43,4 @@ jobs:
     needs: release
     name: Generate Release Info
     uses: ./.github/workflows/release-info.yaml
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## UNRELEASED
+- Add `secrets: inherit` when calling release-info workflow [#555](https://github.com/hypermodeinc/modus/pull/555)
+
 ## 2024-11-04 - CLI 0.13.7
 
 - Automatically generate and push releases info to R2 bucket on every release [#526](https://github.com/hypermodeinc/modus/pull/526)


### PR DESCRIPTION
**Description**

https://github.com/hypermodeinc/modus/actions/runs/11673114915/job/32503157055 was failing as it didn't have access to the workflow secrets.

To solve this, we add `secrets: inherit` to pass all the calling workflow's secrets to the called workflow. This includes all secrets the calling workflow has access to, namely organization, repository, and environment secrets.

References:
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
- https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] Tests for new functionality and regression tests for bug fixes added
- [ ] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
