### PR TITLE
fix: Introspection query should succeed when only mutations exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add API Explorer stub to CLI [#554](https://github.com/hypermodeinc/modus/pull/554) [#556](https://github.com/hypermodeinc/modus/pull/556)
 - Add `secrets: inherit` when calling release-info workflow [#555](https://github.com/hypermodeinc/modus/pull/555)
+- Fix introspection query when only mutations exist [#558](https://github.com/hypermodeinc/modus/pull/558)
 
 ## 2024-11-04 - CLI 0.13.7
 

--- a/runtime/graphql/graphql.go
+++ b/runtime/graphql/graphql.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hypermodeinc/modus/runtime/utils"
 	"github.com/hypermodeinc/modus/runtime/wasmhost"
 
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	eng "github.com/wundergraph/graphql-go-tools/execution/engine"
 	gql "github.com/wundergraph/graphql-go-tools/execution/graphql"
@@ -140,6 +141,20 @@ func handleGraphQLRequest(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("%s\n%v", msg, err), http.StatusInternalServerError)
 	} else {
 		utils.WriteJsonContentHeader(w)
+
+		// An introspection query will always return a Query type, but if only mutations were defined,
+		// the fields of the Query type will be null.  That will fail the introspection query, so we need
+		// to replace the null with an empty array.
+		if ok, _ := gqlRequest.IsIntrospectionQuery(); ok {
+			if q := gjson.GetBytes(response, `data.__schema.types.#(name="Query")`); q.Exists() {
+				if f := q.Get("fields"); f.Type == gjson.Null {
+					response[f.Index] = '['
+					response[f.Index+1] = ']'
+					response = append(response[:f.Index+2], response[f.Index+4:]...)
+				}
+			}
+		}
+
 		_, _ = w.Write(response)
 	}
 }


### PR DESCRIPTION
**Description**

If you only define a function that is a mutation (ex: `CreateProduct`), then the generated GraphQL schema won't have a `Query` type.  Since that would be [invalid by the GraphQL spec](https://spec.graphql.org/October2021/#sec-Executing-Operations), introspection queries would fail.

However, because we use GraphQL Go Tools, and it normalizes the schema when parsed, the introspection _does_ end up getting a `Query` type added - so introspection _should_ pass.  However, it adds the type with `"fields": null` instead of `"fields": []` - which is failing in Postman with:

<img width="647" alt="image" src="https://github.com/user-attachments/assets/7ea7dd57-324d-488b-b7b6-5618ac6c8ce9">

It could be that Postman is pickier than it needs to be, but it still is in the way.

Ideally this would be fixed upstream in GraphQL Go Tools.  I'll send a PR there. But in the meantime we can patch the outgoing introspection response.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR
