### PR TITLE
fix: `modus --version` should just print modus CLI's version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add API Explorer stub to CLI [#554](https://github.com/hypermodeinc/modus/pull/554) [#556](https://github.com/hypermodeinc/modus/pull/556)
 - Add `secrets: inherit` when calling release-info workflow [#555](https://github.com/hypermodeinc/modus/pull/555)
 - Fix introspection query when only mutations exist [#558](https://github.com/hypermodeinc/modus/pull/558)
+- Make `modus --version` just print modus CLI's version [#563](https://github.com/hypermodeinc/modus/pull/563)
 
 ## 2024-11-04 - CLI 0.13.7
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -67,6 +67,9 @@
     "helpClass": "./dist/custom/help",
     "dirname": "modus",
     "commands": "./dist/commands",
+    "hooks": {
+      "init": "./dist/hooks/init"
+    },
     "topicSeparator": " ",
     "topics": {
       "sdk": {

--- a/cli/src/hooks/init.ts
+++ b/cli/src/hooks/init.ts
@@ -1,0 +1,10 @@
+import { Hook } from "@oclif/core";
+
+const hook: Hook.Init = async function (options) {
+  if (["-v", "--version"].includes(process.argv[2])) {
+    this.log(`v${options.config.version}`);
+    process.exit(0);
+  }
+};
+
+export default hook;


### PR DESCRIPTION
**Description**

Add a hook that intercepts `modus -v` and `modus --version`

Related: https://github.com/oclif/oclif/issues/254

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] Tests for new functionality and regression tests for bug fixes added
- [x] Documentation added or updated
- [x] Entry added to the `CHANGELOG.md` file describing and linking to this PR

Thank you for your contribution to the Modus project!
