### PR TITLE
fix: Don't empty previous contents of build dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED - AssemblyScript SDK
+
+- fix: Don't empty previous contents of build dir [#568](https://github.com/hypermodeinc/modus/pull/568)
+
 ## UNRELEASED - CLI
 
 - feat: Add API Explorer stub to CLI [#554](https://github.com/hypermodeinc/modus/pull/554)
@@ -9,10 +13,10 @@
 ## UNRELEASED - Runtime
 
 - fix: Introspection query should succeed when only mutations exist [#558](https://github.com/hypermodeinc/modus/pull/558)
-- fix: "WASM Host not found in context" error on shutdown [#566](https://github.com/hypermodeinc/modus/pull/566)
 - ci: Add `secrets: inherit` when calling release-info workflow [#555](https://github.com/hypermodeinc/modus/pull/555)
 - chore: Refactor metadata dependencies [#564](https://github.com/hypermodeinc/modus/pull/564)
 - chore: Use Go workspace to simplify project dependencies [#565](https://github.com/hypermodeinc/modus/pull/565)
+- fix: "WASM Host not found in context" error on shutdown [#566](https://github.com/hypermodeinc/modus/pull/566)
 
 ## 2024-11-04 - CLI 0.13.7
 

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -10,7 +10,7 @@
  */
 
 import { execFileSync } from "child_process";
-import { copyFile, readFile, readdir, mkdir, unlink } from "fs/promises";
+import { copyFile, readFile, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import process from "process";
 import console from "console";
@@ -40,11 +40,6 @@ await validateAsJson();
 
 if (!existsSync("build")) {
   await mkdir("build");
-} else {
-  const files = await readdir("build");
-  for (const file of files) {
-    await unlink(`build/${file}`);
-  }
 }
 
 const manifestFile = "modus.json";


### PR DESCRIPTION
**Description**

In the AssemblyScript SDK, the build script wipes the contents of the `build` directory clean before writing new files.  While this may sound good, there are two side effects that appear when using `modus dev`:

- The `.wasm` file is removed, then re-added.  So the runtime will see it as unregister/register, rather than just re-register.
- Any files the CLI copies to the build folder (namely `.env` and `.env.*`) are removed any time a code change is made.

The Go SDK doesn't have this issue, because it doesn't wipe the `build` directory.  It just overwrites as needed.

Removing the file deletion code from the build script will fix the issues and align the two SDKs to have the same behavior.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
