### PR TITLE
fix: `__typename` should succeed on root fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - chore: Refactor metadata dependencies [#564](https://github.com/hypermodeinc/modus/pull/564)
 - chore: Use Go workspace to simplify project dependencies [#565](https://github.com/hypermodeinc/modus/pull/565)
 - fix: "WASM Host not found in context" error on shutdown [#566](https://github.com/hypermodeinc/modus/pull/566)
+- fix: `__typename` should succeed on root fields [#573](https://github.com/hypermodeinc/modus/pull/573)
 
 ## 2024-11-06 - AssemblyScript SDK 0.13.4
 

--- a/runtime/graphql/datasource/planner.go
+++ b/runtime/graphql/datasource/planner.go
@@ -38,13 +38,14 @@ type HypDSPlanner struct {
 }
 
 type fieldInfo struct {
-	ref       int         `json:"-"`
-	Name      string      `json:"name"`
-	Alias     string      `json:"alias,omitempty"`
-	TypeName  string      `json:"type,omitempty"`
-	Fields    []fieldInfo `json:"fields,omitempty"`
-	IsMapType bool        `json:"isMapType,omitempty"`
-	fieldRefs []int       `json:"-"`
+	ref        int         `json:"-"`
+	Name       string      `json:"name"`
+	Alias      string      `json:"alias,omitempty"`
+	TypeName   string      `json:"type,omitempty"`
+	ParentType string      `json:"parentType,omitempty"`
+	Fields     []fieldInfo `json:"fields,omitempty"`
+	IsMapType  bool        `json:"isMapType,omitempty"`
+	fieldRefs  []int       `json:"-"`
 }
 
 func (t *fieldInfo) AliasOrName() string {
@@ -168,6 +169,7 @@ func (p *HypDSPlanner) captureField(ref int) *fieldInfo {
 	def, ok := walker.FieldDefinition(ref)
 	if ok {
 		f.TypeName = definition.FieldDefinitionTypeNameString(def)
+		f.ParentType = walker.EnclosingTypeDefinition.NameString(definition)
 		f.IsMapType = slices.Contains(p.config.MapTypes, f.TypeName)
 	}
 

--- a/runtime/graphql/datasource/source.go
+++ b/runtime/graphql/datasource/source.go
@@ -65,6 +65,11 @@ func (*ModusDataSource) LoadWithFiles(ctx context.Context, input []byte, files [
 
 func (ds *ModusDataSource) callFunction(ctx context.Context, callInfo *callInfo) (any, []resolve.GraphQLError, error) {
 
+	// Handle special case for __typename on root Query or Mutation
+	if callInfo.FieldInfo.Name == "__typename" {
+		return callInfo.FieldInfo.ParentType, nil, nil
+	}
+
 	// Get the function info
 	fnInfo, err := ds.WasmHost.GetFunctionInfo(callInfo.FunctionName)
 	if err != nil {


### PR DESCRIPTION
**Description**

We already support returning `__typename` fields on user-defined types, such as:

```graphql
query {
    people {
        __typename
        firstName
        lastName
        fullName
    }
}
```

... which would give `"Person"` for the `__typename` field.

However, asking for `__typename` on the root `Query` or `Mutation` currently fails, and it should succeed.  This is important because some GraphQL clients add `__typename` to _every_ field in a query, including the root fields.

In other words, these should succeed:

```graphql
query {
   __typename
}

mutation {
   __typename
}
```

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
