### PR TITLE
feat: Reduce logger output during development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED - Runtime
+
+- feat: Reduce logger output during development [#576](https://github.com/hypermodeinc/modus/pull/576)
+
 ## 2024-11-08 - CLI 0.13.8
 
 - fix: Make `modus --version` just print modus CLI's version [#563](https://github.com/hypermodeinc/modus/pull/563)

--- a/runtime/logger/logger.go
+++ b/runtime/logger/logger.go
@@ -41,10 +41,28 @@ func Initialize() *zerolog.Logger {
 		// In console mode, we can use local time and be a bit prettier.
 		// We'll still log with millisecond precision.
 		zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
-		writer = zerolog.ConsoleWriter{
-			Out:        os.Stderr,
-			TimeFormat: "2006-01-02 15:04:05.000 -07:00",
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stderr}
+		if config.IsDevEnvironment() {
+			consoleWriter.TimeFormat = "15:04:05.000"
+			consoleWriter.FieldsExclude = []string{
+				"build_id",
+				"build_ts",
+				"git_commit",
+				"git_repo",
+				"plugin",
+				"user_visible",
+			}
+			consoleWriter.FieldsOrder = []string{
+				"detail",
+				"function",
+				"execution_id",
+				"duration_ms",
+			}
+		} else {
+			consoleWriter.TimeFormat = "2006-01-02 15:04:05.000 -07:00"
 		}
+
+		writer = consoleWriter
 	}
 
 	// Log the runtime version to every log line, except in development.


### PR DESCRIPTION
**Description**

This reduces the logger output during local development, and organizes some of the fields logged.

Before:

![image](https://github.com/user-attachments/assets/fe6b17cc-f677-47ec-a04f-d6e32bee7d36)


After:

![image](https://github.com/user-attachments/assets/e7668b03-b283-47a6-a18e-a0d8f0353e6c)


**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
