### PR TITLE
fix: logic for jwks endpoint unmarshalling was incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - chore: Trigger internal release pipeline at the end of the release-runtime workflow [#577](https://github.com/hypermodeinc/modus/pull/577)
 - feat: Add API explorer to runtime [#578](https://github.com/hypermodeinc/modus/pull/578)
 - feat: Add API explorer component to runtime [#584](https://github.com/hypermodeinc/modus/pull/584)
+- fix: logic for jwks endpoint unmarshalling was incorrect [#594](https://github.com/hypermodeinc/modus/pull/594)
 
 ## 2024-11-18 - AssemblyScript SDK 0.13.5
 

--- a/runtime/middleware/authKeys.go
+++ b/runtime/middleware/authKeys.go
@@ -88,8 +88,6 @@ func (ak *AuthKeys) worker(ctx context.Context) {
 			// refresh JWKS keys
 			keysStr := os.Getenv("MODUS_JWKS_ENDPOINTS")
 			if keysStr != "" {
-				timer.Reset(time.Duration(getJwksRefreshMinutes(ctx)) * time.Minute)
-			} else {
 				keys, err := jwksEndpointsJsonToKeys(ctx, keysStr)
 				if err != nil {
 					logger.Error(ctx).Err(err).Msg("Auth JWKS public keys deserializing error")
@@ -97,6 +95,7 @@ func (ak *AuthKeys) worker(ctx context.Context) {
 					ak.setJwksPublicKeys(keys)
 				}
 			}
+			timer.Reset(time.Duration(getJwksRefreshMinutes(ctx)) * time.Minute)
 		case <-ak.quit:
 			return
 		}


### PR DESCRIPTION
**Description**

The loop currently checks for when the jwks env var isempty to unmarshall, when it should be the opposite. also it only resets the timer if it doesnt ifnd the env var, when it should do it regardless

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here
