### PR TITLE
feat: set scarfSettings.allowTopLevel to track modus-cli install through curl

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -84,5 +84,8 @@
     "additionalVersionFlags": [
       "-v"
     ]
+  },
+  "scarfSettings": {
+    "allowTopLevel": true
   }
 }

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -171,7 +171,9 @@ export default class NewCommand extends BaseCommand {
         const arch = os.arch();
         const nodeVersion = process.version;
 
-        await http.get(`https://${SCARF_ENDPOINT}.scarf.sh/${version}/${platform}/${arch}/${nodeVersion}/${sdk}/${sdkVersion}`);
+        const variables: string[] = [version.toLowerCase(), platform.toLowerCase(), arch.toLowerCase(), nodeVersion.toLowerCase(), sdk.toLowerCase(), sdkVersion.toLowerCase()];
+
+        await http.get(`https://${SCARF_ENDPOINT}.scarf.sh/${variables.join("/")}`);
       }
     } catch (_error) {
       // Fail silently if an error occurs during the analytics call


### PR DESCRIPTION
**Description**

- set `scarfSettings.allowTopLevel` to track `modus-cli` install through `curl`
- normalize all variables collected to lower case

See https://docs.scarf.sh/package-analytics/#configuration
Basically, we install the CLI into a global folder instead of doing `npm i -g`, so this install will not trigger scarf.
Caveat: When someone is setting up CLI dev locally for first time, `npm i` will trigger one install count. This install will be cached and subsequent `npm i` won't trigger it.

This is just to follow up with the previous PR, so I won't write a new Changelog entry.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here