### PR TITLE
fix: use git commit with double quotes for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- fix: use git commit with double quotes for Windows [#612](https://github.com/hypermodeinc/modus/pull/612)
+
 ## 2024-11-23 - Runtime 0.14.0
 
 - feat: Apply in-code documentation to generated GraphQL [#519](https://github.com/hypermodeinc/modus/pull/519)

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -334,7 +334,7 @@ export default class NewCommand extends BaseCommand {
       if (createGitRepo) {
         await execFile("git", ["init"], execOpts);
         await execFile("git", ["add", "."], execOpts);
-        await execFile("git", ["commit", "-m", "'Initial Commit'"], execOpts);
+        await execFile("git", ["commit", "-m", `"Initial Commit"`], execOpts);
       }
     });
 


### PR DESCRIPTION
**Description**

`git commit -m 'commit'` might fail on Windows.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here
