### PR TITLE
fix: modus new set default branch name to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- fix: modus new rename branch to main if not [#613](https://github.com/hypermodeinc/modus/pull/613)
+
 ## 2024-11-23 - Runtime 0.14.0
 
 - feat: Apply in-code documentation to generated GraphQL [#519](https://github.com/hypermodeinc/modus/pull/519)

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -333,6 +333,13 @@ export default class NewCommand extends BaseCommand {
 
       if (createGitRepo) {
         await execFile("git", ["init"], execOpts);
+
+        // If branch name is not `main`, rename it to `main`
+        const { stdout: currentBranch } = await execFile("git", ["symbolic-ref", "--short", "HEAD"], execOpts);
+        if (currentBranch.trim() !== "main") {
+          await execFile("git", ["branch", "-m", "main"], execOpts);
+        }
+
         await execFile("git", ["add", "."], execOpts);
         await execFile("git", ["commit", "-m", "'Initial Commit'"], execOpts);
       }

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -332,14 +332,7 @@ export default class NewCommand extends BaseCommand {
       }
 
       if (createGitRepo) {
-        await execFile("git", ["init"], execOpts);
-
-        // If branch name is not `main`, rename it to `main`
-        const { stdout: currentBranch } = await execFile("git", ["symbolic-ref", "--short", "HEAD"], execOpts);
-        if (currentBranch.trim() !== "main") {
-          await execFile("git", ["branch", "-m", "main"], execOpts);
-        }
-
+        await execFile("git", ["init", "-b", "main"], execOpts);
         await execFile("git", ["add", "."], execOpts);
         await execFile("git", ["commit", "-m", `"Initial Commit"`], execOpts);
       }


### PR DESCRIPTION
**Description**

`modus new` rename branch to `main` if not, as we don't support branch name other than `main` on our infrastructure right now.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
- [x] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [x] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here