### PR TITLE
fix: Filter imports to modus host functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## UNRELEASED - Go SDK 0.14.3
 
 - chore: Export base Message class in OpenAI chat SDK [#616](https://github.com/hypermodeinc/modus/pull/616)
+- fix: Filter imports to modus host functions [#623](https://github.com/hypermodeinc/modus/pull/623)
 
 ## 2024-11-25 - Go SDK 0.14.2
 

--- a/sdk/go/tools/modus-go-build/extractor/functions.go
+++ b/sdk/go/tools/modus-go-build/extractor/functions.go
@@ -87,7 +87,10 @@ func getImportedFunctions(pkgs map[string]*packages.Package) map[string]*types.F
 				if fd, ok := decl.(*ast.FuncDecl); ok {
 					if name := getImportedFuncName(fd); name != "" {
 						if f, ok := pkg.TypesInfo.Defs[fd.Name].(*types.Func); ok {
-							results[name] = f
+							// we only care about imported modus host functions
+							if strings.HasPrefix(name, "modus_") {
+								results[name] = f
+							}
 						}
 					}
 				}


### PR DESCRIPTION
**Description**

The change in #615 had the side effect of adding all wasi functions as imports in the metadata, which created a runtime error of `"no wasm function definition found for wasi_snapshot_preview1.proc_exit"`

This filters the collected imports to those that belong to Modus to fix the issue.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
