### PR TITLE
fix: Lookup of 'latest' SDK when no Modus SDK is referenced 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED - CLI 0.14.0
+
+- fix: Lookup of 'latest' SDK when no Modus SDK is referenced [#625](https://github.com/hypermodeinc/modus/pull/625)
+
 ## UNRELEASED - AssemblyScript SDK 0.14.2
 
 - chore: Export base Message class in OpenAI chat SDK [#616](https://github.com/hypermodeinc/modus/pull/616)

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -7,4 +7,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package main
+package modus

--- a/sdk/go/templates/default/go.mod
+++ b/sdk/go/templates/default/go.mod
@@ -1,3 +1,5 @@
 module my-modus-app
 
 go 1.23.0
+
+require github.com/hypermodeinc/modus/sdk/go v0.14.2

--- a/sdk/go/templates/default/go.sum
+++ b/sdk/go/templates/default/go.sum
@@ -1,0 +1,2 @@
+github.com/hypermodeinc/modus/sdk/go v0.14.2 h1:u8apLIaxQlE9sGVmhWNwWQCuvFIctZyse83nJiGB1/A=
+github.com/hypermodeinc/modus/sdk/go v0.14.2/go.mod h1:VDL2kAYHQtNEr7lxPynbchZ6HizLSSQ9cG4LrDnq3Vg=

--- a/sdk/go/templates/default/main.go
+++ b/sdk/go/templates/default/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+
+	_ "github.com/hypermodeinc/modus/sdk/go"
+)
 
 func SayHello(name *string) string {
 


### PR DESCRIPTION
**Description**

If no Modus SDK was used in `package.json` or `go.mod`, then the CLI would return "latest" - which would fail multiple steps in the CLI such as downloading the build tool for Go.

- Fixed the CLI to lookup latest when needed
- Updated the Go template to always reference the Go SDK

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
