### PR TITLE
chore: Remove extraneous package reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## UNRELEASED - Go SDK
 
 - fix: vector package should return generic type in computations [#628](https://github.com/hypermodeinc/modus/pull/628)
+- chore: Remove unused go package reference [#632](https://github.com/hypermodeinc/modus/pull/632)
 
 ## UNRELEASED - AssemblyScript SDK
 

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,10 +2,7 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.0
 
-require (
-	github.com/hypermodeinc/modus/lib/manifest v0.13.0
-	github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0
-)
+require github.com/hypermodeinc/modus/lib/manifest v0.13.0
 
 require (
 	github.com/fatih/color v1.18.0

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -4,8 +4,6 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hypermodeinc/modus/lib/manifest v0.13.0 h1:hIQQoeqeUUh9y+YkqcJRla9KCevS06F2veiFoleq4dg=
 github.com/hypermodeinc/modus/lib/manifest v0.13.0/go.mod h1:ymRlTZWerFnIUVpvEonTMTo38EDYzHcGSNYTOv2MITk=
-github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0 h1:9o8qqAllL9qIPYqc5adF+Aw3XWLmLqPiBPMu0AIyiMI=
-github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0/go.mod h1:YCesMU95vF5qkscLMKSYr92OloLe1KGwyiqW2i4OmnE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
**Description**

Following #615, the `wasmextractor` package is no longer needed in the Go SDK.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR

