### PR TITLE
feat: Support `MODUS_HOME` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED - CLI
+
+- feat: Support `MODUS_HOME` environment variable [#639](https://github.com/hypermodeinc/modus/pull/639)
+
 ## UNRELEASED - Runtime
 
 - fix: doc comments from object fields should be present in generated GraphQL schema [#630](https://github.com/hypermodeinc/modus/pull/630)

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -12,7 +12,7 @@
 # Config
 PACKAGE_ORG="@hypermode"
 PACKAGE_NAME="modus-cli"
-INSTALL_DIR="${MODUS_CLI:-"$HOME/.modus/cli"}"
+INSTALL_DIR="${MODUS_CLI:-"${MODUS_HOME:-"$HOME/.modus"}/cli"}"
 VERSION="latest"
 INSTALLER_VERSION="0.1.2"
 

--- a/cli/src/custom/globals.ts
+++ b/cli/src/custom/globals.ts
@@ -9,8 +9,9 @@
 
 import path from "node:path";
 import os from "node:os";
+import process from "node:process";
 
-export const ModusHomeDir = path.join(os.homedir(), ".modus");
+export const ModusHomeDir = process.env.MODUS_HOME || path.join(os.homedir(), ".modus");
 
 export const MinNodeVersion = "22.0.0";
 export const MinGoVersion = "1.23.0";


### PR DESCRIPTION
**Description**

The Modus CLI expects to be able to create a directory for its own use, to store SDKs, Runtimes, and other data.  In the case of installation via `install.sh` script, the CLI itself is stored in this directory.

The directory is currently hardcoded to `$HOME/.modus` on Linux/MacOS, and `%userprofile%/.modus` on Windows.

This PR allows the directory to be overridden with a `MODUS_HOME` environment variable.  This is useful in the case where the user desires to place Modus's files somewhere else, such as if they don't have permission to write directly to their home dir (while uncommon, this might be the case for certain Windows configurations).

For example, if desired, a Windows user could execute the following from a cmd terminal to set a persistent environment variable to their user settings:

```cmd
setx MODUS_HOME %APPDATA%\Modus
```

Docs: https://github.com/hypermodeinc/docs/pull/72

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
- [x] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs) staged and linked here
