### PR TITLE
fix: make jwk conversion warn to remove sentry overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ## UNRELEASED - CLI
 
 - feat: Support `MODUS_HOME` environment variable [#639](https://github.com/hypermodeinc/modus/pull/639)
-- fix: make jwk conversion warn to remove sentry overflow [#641](https://github.com/hypermodeinc/modus/pull/641)
 
 ## UNRELEASED - Runtime
 
 - fix: doc comments from object fields should be present in generated GraphQL schema [#630](https://github.com/hypermodeinc/modus/pull/630)
 - feat: add neo4j support in modus [#636](https://github.com/hypermodeinc/modus/pull/636)
 - perf: improve locking code [#637](https://github.com/hypermodeinc/modus/pull/637)
+- fix: make jwk conversion warn to remove sentry overflow [#641](https://github.com/hypermodeinc/modus/pull/641)
 
 ## UNRELEASED - Go SDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED - CLI
 
 - feat: Support `MODUS_HOME` environment variable [#639](https://github.com/hypermodeinc/modus/pull/639)
+- fix: make jwk conversion warn to remove sentry overflow [#641](https://github.com/hypermodeinc/modus/pull/641)
 
 ## UNRELEASED - Runtime
 

--- a/runtime/middleware/authKeys.go
+++ b/runtime/middleware/authKeys.go
@@ -90,7 +90,7 @@ func (ak *AuthKeys) worker(ctx context.Context) {
 			if keysStr != "" {
 				keys, err := jwksEndpointsJsonToKeys(ctx, keysStr)
 				if err != nil {
-					logger.Error(ctx).Err(err).Msg("Auth JWKS public keys deserializing error")
+					logger.Warn(ctx).Err(err).Msg("Auth JWKS public keys deserializing error")
 				} else {
 					ak.setJwksPublicKeys(keys)
 				}


### PR DESCRIPTION
**Description**

If someone puts in an incorrect jwk endpoint, we throw a logger error, meaning it propogates to sentry. this overflows our logs. Changing this to a warn to still see it in logs, while also not overflowing sentry.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR


