### PR TITLE
chore: update dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat: add neo4j support in modus [#636](https://github.com/hypermodeinc/modus/pull/636)
 - perf: improve locking code [#637](https://github.com/hypermodeinc/modus/pull/637)
 - fix: make jwk conversion warn to remove sentry overflow [#641](https://github.com/hypermodeinc/modus/pull/641)
+- chore: update dockerfile [#642](https://github.com/hypermodeinc/modus/pull/642)
 
 ## UNRELEASED - Go SDK
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
-# build the application binary
+# set up the image to build the explorer app
+FROM --platform=$BUILDPLATFORM node:alpine AS node-builder
+WORKDIR /src
+
+# install dependencies first
+COPY ./runtime/explorer/content/package*.json ./
+RUN npm ci
+
+# copy and build the rest of the application
+COPY ./runtime/explorer/content .
+RUN npm run build
+
+# set up the image to build the runtime
 FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 WORKDIR /src
 
-# copy dependencies then switch to the runtime directory
+# copy lib dependencies
 COPY ./lib ./lib
+
+# Copy and modify go.work file
+COPY ./go.work ./
+RUN sed -i '/^[[:space:]]*\.\/sdk\//d' ./go.work
+RUN sed -i '/^[[:space:]]*\.\/.*\/testdata/d' ./go.work
+
+# switch to the runtime directory
 WORKDIR /src/runtime
 
 # copy go.mod and go.sum files separately so that the download step
@@ -11,7 +30,11 @@ WORKDIR /src/runtime
 COPY runtime/go.mod runtime/go.sum ./
 RUN go mod download
 
+# copy the rest of the runtime source and the compiled explorer app
 COPY runtime/ ./
+COPY --from=node-builder /src/dist ./explorer/content/dist
+
+# build the runtime binary
 ARG TARGETOS TARGETARCH RUNTIME_RELEASE_VERSION
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime -ldflags "-s -w -X github.com/hypermodeinc/modus/runtime/config.version=$RUNTIME_RELEASE_VERSION" .
 


### PR DESCRIPTION
**Description**

Docker builds are failing due to `go.work` synchronization issues.  It also doesn't include the pre-build step for the API explorer.  This PR addresses both issues.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
