### PR TITLE
fix: Dgraph AssemblyScript example query issues

### DIFF
--- a/sdk/assemblyscript/examples/dgraph/assembly/index.ts
+++ b/sdk/assemblyscript/examples/dgraph/assembly/index.ts
@@ -119,6 +119,7 @@ export function upsertPerson(
   const query = `
   query {
     person as var(func: eq(firstName, "${nameToChangeFrom}"))
+  }
   `;
   const mutation = `
     uid(person) <firstName> "${nameToChangeTo}" .`;
@@ -139,7 +140,9 @@ export function upsertPerson(
 export function deletePerson(uid: string): Map<string, string> | null {
   const mutation = `<${uid}> * * .`;
 
-  const mutations: dgraph.Mutation[] = [new dgraph.Mutation("", "", mutation)];
+  const mutations: dgraph.Mutation[] = [
+    new dgraph.Mutation("", "", "", mutation),
+  ];
 
   return dgraph.execute(hostName, new dgraph.Request(null, mutations)).Uids;
 }


### PR DESCRIPTION
**Description**

Correct delete example and upsert query

- corrected the mutation to do a delete and not a set in the deletePerson example
- close the query statement in the upsert example.


**Checklist**

- [x] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
