### PR TITLE
fix: unused imports should not be included in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - chore: lint example test [#656](https://github.com/hypermodeinc/modus/pull/656)
+- fix: unused imports should not be included in metadata [#657](https://github.com/hypermodeinc/modus/pull/657)
 
 ## 2024-12-13 - Runtime 0.15.0
 

--- a/runtime/plugins/plugins.go
+++ b/runtime/plugins/plugins.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hypermodeinc/modus/lib/metadata"
 	"github.com/hypermodeinc/modus/runtime/langsupport"
 	"github.com/hypermodeinc/modus/runtime/languages"
+	"github.com/hypermodeinc/modus/runtime/logger"
 	"github.com/hypermodeinc/modus/runtime/utils"
 
 	"github.com/tetratelabs/wazero"
@@ -71,7 +72,8 @@ func NewPlugin(ctx context.Context, cm wazero.CompiledModule, filename string, m
 	for importName, fnMeta := range md.FnImports {
 		fnDef, ok := importsMap[importName]
 		if !ok {
-			return nil, fmt.Errorf("no wasm function definition found for %s", importName)
+			logger.Warn(ctx).Msgf("Unused import %s in plugin metadata. Please update your Modus SDK.", importName)
+			continue
 		}
 
 		plan, err := planner.GetPlan(ctx, fnMeta, fnDef)

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,7 +2,10 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.0
 
-require github.com/hypermodeinc/modus/lib/manifest v0.15.0
+require (
+	github.com/hypermodeinc/modus/lib/manifest v0.15.0
+	github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0
+)
 
 require (
 	github.com/fatih/color v1.18.0

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -6,6 +6,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hypermodeinc/modus/lib/manifest v0.15.0 h1:YZmSmneGD/rrUdjf2Qnr0ACi562uZjmdwMnLw5P3tvI=
 github.com/hypermodeinc/modus/lib/manifest v0.15.0/go.mod h1:ymRlTZWerFnIUVpvEonTMTo38EDYzHcGSNYTOv2MITk=
+github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0 h1:9o8qqAllL9qIPYqc5adF+Aw3XWLmLqPiBPMu0AIyiMI=
+github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0/go.mod h1:YCesMU95vF5qkscLMKSYr92OloLe1KGwyiqW2i4OmnE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/sdk/go/tools/modus-go-build/main.go
+++ b/sdk/go/tools/modus-go-build/main.go
@@ -93,6 +93,14 @@ func main() {
 		log.Println("Wasm compiled.")
 	}
 
+	if err := wasm.FilterMetadata(config, meta); err != nil {
+		exitWithError("Error filtering metadata", err)
+	}
+
+	if trace {
+		log.Println("Metadata filtered.")
+	}
+
 	if err := wasm.WriteMetadata(config, meta); err != nil {
 		exitWithError("Error writing metadata", err)
 	}

--- a/sdk/go/tools/modus-go-build/wasm/filters.go
+++ b/sdk/go/tools/modus-go-build/wasm/filters.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package wasm
+
+import (
+	"path/filepath"
+
+	"github.com/hypermodeinc/modus/lib/wasmextractor"
+	"github.com/hypermodeinc/modus/sdk/go/tools/modus-go-build/config"
+	"github.com/hypermodeinc/modus/sdk/go/tools/modus-go-build/metadata"
+)
+
+func FilterMetadata(config *config.Config, meta *metadata.Metadata) error {
+	wasmFilePath := filepath.Join(config.OutputDir, config.WasmFileName)
+
+	bytes, err := wasmextractor.ReadWasmFile(wasmFilePath)
+	if err != nil {
+		return err
+	}
+
+	info, err := wasmextractor.ExtractWasmInfo(bytes)
+	if err != nil {
+		return err
+	}
+
+	// Remove unused imports (can easily happen when user code doesn't use all imports from a package)
+	imports := make(map[string]bool, len(info.Imports))
+	for _, i := range info.Imports {
+		imports[i.Name] = true
+	}
+	for name := range meta.FnImports {
+		if _, ok := imports[name]; !ok {
+			delete(meta.FnImports, name)
+		}
+	}
+
+	// Remove unused exports (less likely to happen, but still check)
+	exports := make(map[string]bool, len(info.Exports))
+	for _, e := range info.Exports {
+		exports[e.Name] = true
+	}
+	for name := range meta.FnExports {
+		if _, ok := exports[name]; !ok {
+			delete(meta.FnExports, name)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**Description**

In the Modus Go SDK, if a file references a file that has one or more wasm imports, those imports are all added to the metadata during the pre-compile analysis phase of the Modus Go build tool.

If one or more of those imports is unused, the Go compiler will optimize it away, so the resulting WASM code doesn't call for the import.  This creates a runtime error later, because the metadata says there's an import to generate an invocation plan for, but then the import can't be found.

The error will be similar to:

```
no wasm function definition found for <module:function>
```

There are two paths to fixing this.  This PR covers both:

- In the Modus Go SDK, prevent unused imports from being listed in the metadata
- In the Modus Runtime, when loading a plugin with such an issue, warn and continue (instead of error and quit)

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
