### PR TITLE
fix: improve Go version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - chore: lint example test [#656](https://github.com/hypermodeinc/modus/pull/656)
 - fix: unused imports should not be included in metadata [#657](https://github.com/hypermodeinc/modus/pull/657)
+- fix: improve Go version handling [#660](https://github.com/hypermodeinc/modus/pull/660)
 
 ## 2024-12-13 - Runtime 0.15.0
 

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -321,14 +321,19 @@ export default class NewCommand extends BaseCommand {
       // Apply SDK-specific modifications
       const execOpts = { env: process.env, cwd: dir, shell: true };
       switch (sdk) {
-        case SDK.AssemblyScript:
+        case SDK.AssemblyScript: {
           await execFile("npm", ["pkg", "set", `name=${name}`], execOpts);
           await execFile("npm", ["install"], execOpts);
           break;
-        case SDK.Go:
+        }
+        case SDK.Go: {
+          const goVersion = await getGoVersion();
+          await execFile("go", ["mod", "edit", "-go", goVersion!], execOpts);
           await execFile("go", ["mod", "edit", "-module", name], execOpts);
           await execFile("go", ["mod", "download"], execOpts);
+          await execFile("go", ["mod", "tidy"], execOpts);
           break;
+        }
       }
 
       if (createGitRepo) {

--- a/cli/src/custom/globals.ts
+++ b/cli/src/custom/globals.ts
@@ -14,7 +14,7 @@ import process from "node:process";
 export const ModusHomeDir = process.env.MODUS_HOME || path.join(os.homedir(), ".modus");
 
 export const MinNodeVersion = "22.0.0";
-export const MinGoVersion = "1.23.0";
+export const MinGoVersion = "1.23.1";
 export const MinTinyGoVersion = "0.33.0";
 
 export const GitHubOwner = "hypermodeinc";

--- a/runtime/languages/golang/testdata/go.mod
+++ b/runtime/languages/golang/testdata/go.mod
@@ -1,5 +1,5 @@
 module testdata
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/anthropic-functions/go.mod
+++ b/sdk/go/examples/anthropic-functions/go.mod
@@ -1,6 +1,6 @@
 module anthropic-functions-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0
 

--- a/sdk/go/examples/auth/go.mod
+++ b/sdk/go/examples/auth/go.mod
@@ -1,5 +1,5 @@
 module auth-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/classification/go.mod
+++ b/sdk/go/examples/classification/go.mod
@@ -1,5 +1,5 @@
 module classification-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/collections/go.mod
+++ b/sdk/go/examples/collections/go.mod
@@ -1,5 +1,5 @@
 module collection-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/dgraph/go.mod
+++ b/sdk/go/examples/dgraph/go.mod
@@ -1,5 +1,5 @@
 module dgraph-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/embedding/go.mod
+++ b/sdk/go/examples/embedding/go.mod
@@ -1,6 +1,6 @@
 module embedding-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0
 

--- a/sdk/go/examples/graphql/go.mod
+++ b/sdk/go/examples/graphql/go.mod
@@ -1,5 +1,5 @@
 module graphql-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/http/go.mod
+++ b/sdk/go/examples/http/go.mod
@@ -1,5 +1,5 @@
 module http-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/neo4j/go.mod
+++ b/sdk/go/examples/neo4j/go.mod
@@ -1,5 +1,5 @@
 module neo4j-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/postgresql/go.mod
+++ b/sdk/go/examples/postgresql/go.mod
@@ -1,5 +1,5 @@
 module postgresql-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/simple/go.mod
+++ b/sdk/go/examples/simple/go.mod
@@ -1,5 +1,5 @@
 module simple-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0

--- a/sdk/go/examples/textgeneration/go.mod
+++ b/sdk/go/examples/textgeneration/go.mod
@@ -1,6 +1,6 @@
 module text-generation-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0
 

--- a/sdk/go/examples/vectors/go.mod
+++ b/sdk/go/examples/vectors/go.mod
@@ -1,6 +1,6 @@
 module vectors-example
 
-go 1.23.0
+go 1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0
 

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/hypermodeinc/modus/sdk/go
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.15.0

--- a/sdk/go/templates/default/go.mod
+++ b/sdk/go/templates/default/go.mod
@@ -1,5 +1,5 @@
 module my-modus-app
 
-go 1.23.0
+go 1.23.1
 
 require github.com/hypermodeinc/modus/sdk/go v0.15.0


### PR DESCRIPTION
**Description**

Currently, the Modus Runtime uses Go 1.23.4, but other projects are targeting Go 1.23.0.  This should only be the case for the shared libraries in `/lib`, because Go 1.23.1 fixed several security-related issues with CVEs.  Instead, we should do the following:

- The Modus Runtime should continue to be built with Go 1.23.4, and updated with new Go releases.
- Shared libraries in `/lib` should continue to target Go 1.23.0 for compatibility.  (The consuming app will set the actual Go version used.)
- Examples and test projects in the Modus repo should be updated to Go 1.23.4.
- The minimum version of Go needed to build modus apps should be set to 1.23.1, both in the Modus SDK and in the CLI's version checks.  That will ensure that Modus apps will be built with Go 1.23.1 or higher.
- During `modus new`, after validating that the minimum Go version is met, the CLI should set the version in the created project's `go.mod` file to the version actually installed.  For example, if I have Go 1.23.2, `modus new` should make me a project with `1.23.2` - even if the version in the template is lower or if there's a higher version available.  This mirrors the behavior of `go mod init` for regular Go projects.

This PR implements these changes.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
