### PR TITLE
Update go sdk version in examples

### DIFF
--- a/runtime/languages/golang/testdata/go.mod
+++ b/runtime/languages/golang/testdata/go.mod
@@ -2,4 +2,4 @@ module testdata
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/runtime/languages/golang/testdata/go.sum
+++ b/runtime/languages/golang/testdata/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/anthropic-functions/go.mod
+++ b/sdk/go/examples/anthropic-functions/go.mod
@@ -2,7 +2,7 @@ module anthropic-functions-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0
 
 require (
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/sdk/go/examples/anthropic-functions/go.sum
+++ b/sdk/go/examples/anthropic-functions/go.sum
@@ -1,5 +1,5 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/sdk/go/examples/auth/go.mod
+++ b/sdk/go/examples/auth/go.mod
@@ -2,4 +2,4 @@ module auth-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/auth/go.sum
+++ b/sdk/go/examples/auth/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/classification/go.mod
+++ b/sdk/go/examples/classification/go.mod
@@ -2,4 +2,4 @@ module classification-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/classification/go.sum
+++ b/sdk/go/examples/classification/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/collections/go.mod
+++ b/sdk/go/examples/collections/go.mod
@@ -2,4 +2,4 @@ module collection-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/collections/go.sum
+++ b/sdk/go/examples/collections/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/dgraph/go.mod
+++ b/sdk/go/examples/dgraph/go.mod
@@ -2,4 +2,4 @@ module dgraph-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/dgraph/go.sum
+++ b/sdk/go/examples/dgraph/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/embedding/go.mod
+++ b/sdk/go/examples/embedding/go.mod
@@ -2,7 +2,7 @@ module embedding-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0
 
 require (
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/sdk/go/examples/embedding/go.sum
+++ b/sdk/go/examples/embedding/go.sum
@@ -1,5 +1,5 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/sdk/go/examples/graphql/go.mod
+++ b/sdk/go/examples/graphql/go.mod
@@ -2,4 +2,4 @@ module graphql-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/graphql/go.sum
+++ b/sdk/go/examples/graphql/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/http/go.mod
+++ b/sdk/go/examples/http/go.mod
@@ -2,4 +2,4 @@ module http-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/http/go.sum
+++ b/sdk/go/examples/http/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/neo4j/go.mod
+++ b/sdk/go/examples/neo4j/go.mod
@@ -2,4 +2,4 @@ module neo4j-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/neo4j/go.sum
+++ b/sdk/go/examples/neo4j/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/postgresql/go.mod
+++ b/sdk/go/examples/postgresql/go.mod
@@ -2,4 +2,4 @@ module postgresql-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/postgresql/go.sum
+++ b/sdk/go/examples/postgresql/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/simple/go.mod
+++ b/sdk/go/examples/simple/go.mod
@@ -2,4 +2,4 @@ module simple-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/simple/go.sum
+++ b/sdk/go/examples/simple/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/textgeneration/go.mod
+++ b/sdk/go/examples/textgeneration/go.mod
@@ -2,7 +2,7 @@ module text-generation-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0
 
 require (
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/sdk/go/examples/textgeneration/go.sum
+++ b/sdk/go/examples/textgeneration/go.sum
@@ -1,5 +1,5 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/sdk/go/examples/time/go.mod
+++ b/sdk/go/examples/time/go.mod
@@ -2,4 +2,4 @@ module time-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/time/go.sum
+++ b/sdk/go/examples/time/go.sum
@@ -1,2 +1,2 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=

--- a/sdk/go/examples/vectors/go.mod
+++ b/sdk/go/examples/vectors/go.mod
@@ -2,6 +2,6 @@ module vectors-example
 
 go 1.23.4
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0
 
 require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect

--- a/sdk/go/examples/vectors/go.sum
+++ b/sdk/go/examples/vectors/go.sum
@@ -1,6 +1,4 @@
-github.com/hypermodeinc/modus/sdk/go v0.15.0 h1:xRD4swlxdug4fVVKzY2FQKGUTKK2qLSDb0k/wqDDTOw=
-github.com/hypermodeinc/modus/sdk/go v0.15.0/go.mod h1:Tgh2CfZztlmsAi5DAF1s2LhoARF6P61huICuuAd7hvY=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f h1:XdNn9LlyWAhLVp6P/i8QYBW+hlyhrhei9uErw2B5GJo=
-golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f/go.mod h1:D5SMRVC3C2/4+F/DB1wZsLRnSNimn2Sp/NPsCrsv8ak=
+github.com/hypermodeinc/modus/sdk/go v0.16.0 h1:kO43jI1RfDgDJAEg+ilNSJIUHfsSXM2pGuHh/dT0Zec=
+github.com/hypermodeinc/modus/sdk/go v0.16.0/go.mod h1:wXGlRRd/Rkxv7QwYfHzc2VoaU91lzWpiZ/zm4sTuD/U=
 golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
 golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/sdk/go/templates/default/go.mod
+++ b/sdk/go/templates/default/go.mod
@@ -2,4 +2,4 @@ module my-modus-app
 
 go 1.23.1
 
-require github.com/hypermodeinc/modus/sdk/go v0.15.0
+require github.com/hypermodeinc/modus/sdk/go v0.16.0


### PR DESCRIPTION
Update go sdk version in examples, post `v0.16.0` release