### PR TITLE
fix: resolve time zone issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2024-12-23 - Runtime 0.16.1
+
+- fix: resolve time zone issues [#666](https://github.com/hypermodeinc/modus/pull/666)
+
 ## 2024-12-23 - Runtime 0.16.0
 
 - fix: unused imports should not be included in metadata [#657](https://github.com/hypermodeinc/modus/pull/657)

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # copy runtime binary from the build phase
 COPY --from=builder /src/runtime/modus_runtime /usr/bin/modus_runtime
 
-# update certificates every build
+# update certificates and time zones every build
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # set the default entrypoint and options

--- a/runtime/timezones/timezones.go
+++ b/runtime/timezones/timezones.go
@@ -10,7 +10,6 @@
 package timezones
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -29,7 +28,7 @@ func init() {
 	if tz, err := getSystemLocalTimeZone(); err == nil {
 		systemTimeZone = tz
 	} else {
-		fmt.Fprintf(os.Stderr, "failed to determine system local time zone (using UTC): %v\n", err)
+		// silently fallback to UTC
 		systemTimeZone = "UTC"
 	}
 }


### PR DESCRIPTION
**Description**

The container image for the runtime needs `tzdata` installed.  Additionally, we should not warn about falling back to UTC when there's no local time set.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
