### PR TITLE
chore: bump api explorer, add time zone header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## UNRELEASED
+
+- chore: add timezone header to api explorer
+
 ## 2024-12-23 - Runtime 0.16.1
 
 - fix: resolve time zone issues [#666](https://github.com/hypermodeinc/modus/pull/666)

--- a/runtime/explorer/content/package-lock.json
+++ b/runtime/explorer/content/package-lock.json
@@ -8,7 +8,7 @@
       "name": "api-explorer",
       "version": "1.0.0",
       "dependencies": {
-        "@hypermode/react-api-explorer": "1.0.0-alpha.15",
+        "@hypermode/react-api-explorer": "^1.0.0-alpha.16",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -871,9 +871,9 @@
       }
     },
     "node_modules/@hypermode/react-api-explorer": {
-      "version": "1.0.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@hypermode/react-api-explorer/-/react-api-explorer-1.0.0-alpha.15.tgz",
-      "integrity": "sha512-Oky7Th7sCxuCaYlaZdDfiFRoLTEFbaMlS/OhZUBB5nDhHoqJw9NtPrBhY7nv4h2biUU2uTlFMAcGfL8xalvDWg==",
+      "version": "1.0.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/@hypermode/react-api-explorer/-/react-api-explorer-1.0.0-alpha.16.tgz",
+      "integrity": "sha512-y0TLgLO50ug48lug/SKP0l5bAx8XQKNrP0U9IvXvc1uBIro6i7PL4Mu72Od1Dx3/A6xZzALEQRGL9sM7HOvZhQ==",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.2",
         "@graphiql/toolkit": "^0.11.0",

--- a/runtime/explorer/content/package.json
+++ b/runtime/explorer/content/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@hypermode/react-api-explorer": "1.0.0-alpha.15",
+    "@hypermode/react-api-explorer": "^1.0.0-alpha.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },


### PR DESCRIPTION
**Description**

In the Modus API explorer, GraphQL requests should pass the `X-Time-Zone` header, setting it to the value returned from the following JavaScript:

```js
Intl.DateTimeFormat().resolvedOptions().timeZone
```

This will allow the Modus runtime to automatically use the user's time zone when calling the function.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
