### PR TITLE
fix: revert invalid change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - chore: add timezone header to api explorer
 
+## 2025-01-06 - CLI 0.16.2
+
+- fix: revert invalid change [#680](https://github.com/hypermodeinc/modus/pull/680)
+
+## 2025-01-04 - CLI 0.16.1
+
+- fix: attempt to fix windows issue [#677](https://github.com/hypermodeinc/modus/pull/677)
+
 ## 2024-12-23 - Runtime 0.16.1
 
 - fix: resolve time zone issues [#666](https://github.com/hypermodeinc/modus/pull/666)

--- a/cli/src/commands/build/index.ts
+++ b/cli/src/commands/build/index.ts
@@ -82,10 +82,7 @@ export default class BuildCommand extends BaseCommand {
             return;
           }
           let buildTool = path.join(vi.getSdkPath(app.sdk, version), "modus-go-build");
-          if (os.platform() === "win32"){
-            buildTool += ".exe";
-            buildTool = '"' + buildTool + '"';
-          }
+          if (os.platform() === "win32") buildTool += ".exe";
           if (!(await fs.exists(buildTool))) {
             this.logError("Modus Go Build tool is not installed");
             return;


### PR DESCRIPTION
**Description**

The change in #677 breaks `modus build` and `modus dev` on Windows, giving an error "Modus Go Build tool is not installed".

This PR reverts the change.

**Checklist**

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to this PR
