### PR TITLE
fix: remove extraneous null check from DynamicMap parsing

### DIFF
--- a/sdk/assemblyscript/src/assembly/dynamicmap.ts
+++ b/sdk/assemblyscript/src/assembly/dynamicmap.ts
@@ -170,7 +170,7 @@ function deserializeRawMap(
                 /* empty */
               }
               const value = src.slice(lastIndex, index);
-              dst.set(key!, value);
+              dst.set(key, value);
               // console.log("Value (object): " + value);
               const last = index == end;
               if (!last && unsafeCharCodeAt(src, index) !== COMMA)
@@ -198,7 +198,7 @@ function deserializeRawMap(
                 /* empty */
               }
               const value = src.slice(lastIndex, index);
-              dst.set(key!, value);
+              dst.set(key, value);
               // console.log("Value (object): " + value);
               const last = index == end;
               if (!last && unsafeCharCodeAt(src, index) !== COMMA)
@@ -218,7 +218,7 @@ function deserializeRawMap(
       } else if (code == CHAR_T) {
         if (load<u64>(srcPtr + (index << 1)) == 28429475166421108) {
           const value = src.slice(lastIndex, (index += 4));
-          dst.set(key!, value);
+          dst.set(key, value);
           // console.log("Value (bool): " + value);
           while (isSpace(unsafeCharCodeAt(src, index + 1)) && index < end)
             index++;
@@ -244,7 +244,7 @@ function deserializeRawMap(
         // eslint-disable-next-line no-loss-of-precision
         if (load<u64>(srcPtr + (index << 1), 2) == 28429466576093281) {
           const value = src.slice(lastIndex, (index += 5));
-          dst.set(key!, value);
+          dst.set(key, value);
           // console.log("Value (bool): " + value);
           while (isSpace(unsafeCharCodeAt(src, index + 1)) && index < end)
             index++;
@@ -270,7 +270,7 @@ function deserializeRawMap(
         // eslint-disable-next-line no-loss-of-precision
         if (load<u64>(srcPtr + (index << 1)) == 30399761348886638) {
           const value = src.slice(lastIndex, (index += 4));
-          dst.set(key!, value);
+          dst.set(key, value);
           // console.log("Value (null): " + value);
           while (isSpace(unsafeCharCodeAt(src, index)) && index < end) index++;
           const last = index == end;
@@ -303,7 +303,7 @@ function deserializeRawMap(
               /* empty */
             }
             const value = src.slice(lastIndex, index);
-            dst.set(key!, value);
+            dst.set(key, value);
             // console.log("Value (string): " + value);
             const last = index == end;
             if (!last && unsafeCharCodeAt(src, index) !== COMMA)
@@ -325,7 +325,7 @@ function deserializeRawMap(
           const code = unsafeCharCodeAt(src, index);
           if (code == COMMA || code == BRACE_RIGHT || isSpace(code)) {
             const value = src.slice(lastIndex, index);
-            dst.set(key!, value);
+            dst.set(key, value);
             // console.log("Value (number): " + value);
             while (isSpace(unsafeCharCodeAt(src, index + 1)) && index < end)
               index++;


### PR DESCRIPTION
Removes an extraneous bang (`!`) operator