### PR TITLE
chore: use `toolchain` to set Go version

### DIFF
--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          go-version: 1.23.4
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
-          go-version-file: "${{ matrix.dir }}/go.mod"
       - name: Run Linter
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          go-version: 1.23.4
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
-          go-version-file: "${{ matrix.dir }}/go.mod"
       - name: Run Unit Tests
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest

--- a/.github/workflows/ci-runtime-integration-tests.yml
+++ b/.github/workflows/ci-runtime-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.23.4
           cache-dependency-path: runtime/go.sum
       - name: Run Integration Tests
         working-directory: runtime

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          go-version: 1.23.4
           cache-dependency-path: ./sdk/go/go.sum
-          go-version-file: ./sdk/go/go.mod
       - name: Build Program
         run: go build .
 
@@ -78,8 +78,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          go-version: 1.23.4
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
-          go-version-file: "${{ matrix.dir }}/go.mod"
       - name: Setup TinyGo
         uses: acifani/setup-tinygo@v2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version-file: runtime/go.mod
+          go-version: 1.23.4
           cache-dependency-path: runtime/go.sum
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -32,8 +32,7 @@ jobs:
         run: npm run build
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23
-          check-latest: true
+          go-version: 1.23.4
           cache-dependency-path: runtime/go.sum
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
+          go-version: 1.23.4
           cache-dependency-path: ./sdk/go/go.sum
-          go-version-file: ./sdk/go/go.mod
       - name: Prepare Release
         working-directory: sdk/go
         run: ./scripts/prepare-release.sh ${{ steps.parse_sdk_version.outputs.sdk_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - chore: add timezone header to api explorer [#672](https://github.com/hypermodeinc/modus/pull/672)
 - fix: reimplement DynamicMap parsing [#678](https://github.com/hypermodeinc/modus/pull/678)
   [#681](https://github.com/hypermodeinc/modus/pull/681)
+- chore: use `toolchain` to set Go version [#684](https://github.com/hypermodeinc/modus/pull/684)
 
 ## 2025-01-06 - CLI 0.16.2
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,6 @@
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 use (
 	./lib/manifest

--- a/lib/manifest/go.mod
+++ b/lib/manifest/go.mod
@@ -1,6 +1,8 @@
 module github.com/hypermodeinc/modus/lib/manifest
 
-go 1.23
+go 1.23.1
+
+toolchain go1.23.4
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/lib/metadata/go.mod
+++ b/lib/metadata/go.mod
@@ -1,6 +1,8 @@
 module github.com/hypermodeinc/modus/lib/metadata
 
-go 1.23
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0
 

--- a/lib/wasmextractor/go.mod
+++ b/lib/wasmextractor/go.mod
@@ -1,3 +1,5 @@
 module github.com/hypermodeinc/modus/lib/wasmextractor
 
-go 1.23
+go 1.23.1
+
+toolchain go1.23.4

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -1,6 +1,8 @@
 module github.com/hypermodeinc/modus/runtime
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.15.0

--- a/runtime/languages/golang/testdata/go.mod
+++ b/runtime/languages/golang/testdata/go.mod
@@ -1,5 +1,7 @@
 module testdata
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/anthropic-functions/go.mod
+++ b/sdk/go/examples/anthropic-functions/go.mod
@@ -1,6 +1,8 @@
 module anthropic-functions-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/examples/auth/go.mod
+++ b/sdk/go/examples/auth/go.mod
@@ -1,5 +1,7 @@
 module auth-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/classification/go.mod
+++ b/sdk/go/examples/classification/go.mod
@@ -1,5 +1,7 @@
 module classification-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/collections/go.mod
+++ b/sdk/go/examples/collections/go.mod
@@ -1,5 +1,7 @@
 module collection-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/dgraph/go.mod
+++ b/sdk/go/examples/dgraph/go.mod
@@ -1,5 +1,7 @@
 module dgraph-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/embedding/go.mod
+++ b/sdk/go/examples/embedding/go.mod
@@ -1,6 +1,8 @@
 module embedding-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/examples/graphql/go.mod
+++ b/sdk/go/examples/graphql/go.mod
@@ -1,5 +1,7 @@
 module graphql-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/http/go.mod
+++ b/sdk/go/examples/http/go.mod
@@ -1,5 +1,7 @@
 module http-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/neo4j/go.mod
+++ b/sdk/go/examples/neo4j/go.mod
@@ -1,5 +1,7 @@
 module neo4j-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/postgresql/go.mod
+++ b/sdk/go/examples/postgresql/go.mod
@@ -1,5 +1,7 @@
 module postgresql-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/simple/go.mod
+++ b/sdk/go/examples/simple/go.mod
@@ -1,5 +1,7 @@
 module simple-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/textgeneration/go.mod
+++ b/sdk/go/examples/textgeneration/go.mod
@@ -1,6 +1,8 @@
 module text-generation-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/examples/time/go.mod
+++ b/sdk/go/examples/time/go.mod
@@ -1,5 +1,7 @@
 module time-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/vectors/go.mod
+++ b/sdk/go/examples/vectors/go.mod
@@ -1,6 +1,8 @@
 module vectors-example
 
-go 1.23.4
+go 1.23.1
+
+toolchain go1.23.4
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,6 +2,8 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.1
 
+toolchain go1.23.4
+
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.15.0
 	github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0

--- a/sdk/go/templates/default/go.mod
+++ b/sdk/go/templates/default/go.mod
@@ -2,4 +2,6 @@ module my-modus-app
 
 go 1.23.1
 
+toolchain go1.23.4
+
 require github.com/hypermodeinc/modus/sdk/go v0.16.0


### PR DESCRIPTION
## Description

This is a follow up to #660.  Going forward, all projects in the repo will behave the same way:

- Minimum Go version will be set with the `go` declaration in `go.mod` / `go.work` files.
  - High/Critical CVEs in Go will raise this version.  ie., it is currently `1.23.1`, even though the code will technically compile against `1.23.0`.
- Recommended Go version will be set with the `toolchain` declaration in `go.mod` / `go.work` files.
  - As new versions of Go are released, we will test Modus with them and raise this version as appropriate.
  - Github Actions workflows will be manually set to match this version, until https://github.com/actions/setup-go/issues/457 is resolved.

Currently, this means all projects should have:

```
go 1.23.1

toolchain go1.23.4
```

## Checklist

- [x] Code compiles correctly and linting passes locally
- [x] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR