### PR TITLE
chore: fix release workflows and re-release

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,10 +43,8 @@ jobs:
       - name: Publish NPM Package
         working-directory: cli
         run: >
-          npm publish
-            --provenance
-            --access public
-            --tag ${{ steps.parse_cli_version.outputs.npm_tag }}
+          npm publish --tag ${{ steps.parse_cli_version.outputs.npm_tag }} --access public
+          --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release

--- a/.github/workflows/release-sdk-as.yaml
+++ b/.github/workflows/release-sdk-as.yaml
@@ -41,10 +41,8 @@ jobs:
       - name: Publish NPM Package
         working-directory: sdk/assemblyscript/src
         run: >
-          npm publish
-            --provenance
-            --access public
-            --tag ${{ steps.parse_sdk_version.outputs.npm_tag }}
+          npm publish --tag ${{ steps.parse_sdk_version.outputs.npm_tag }} --access public
+          --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 2025-01-07 - CLI 0.16.4
+
+No changes. Re-released previous version to fix release issue.
+
+## 2025-01-07 - AssemblyScript SDK 0.16.2
+
+No changes. Re-released previous version to fix release issue.
+
 ## 2025-01-07 - CLI 0.16.3
 
 - chore: use `toolchain` to set Go version [#684](https://github.com/hypermodeinc/modus/pull/684)


### PR DESCRIPTION
The previous release workflows for the CLI and AssemblyScript SDK had a minor issue.  This fixes them and preps a new release.