### PR TITLE
fix: handle space in user profile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2025-01-07 - CLI 0.16.5
+
+- fix: handle space in user profile path [#696](https://github.com/hypermodeinc/modus/pull/696)
+
 ## 2025-01-07 - CLI 0.16.4
 
 No changes. Re-released previous version to fix release issue.

--- a/cli/src/util/cp.ts
+++ b/cli/src/util/cp.ts
@@ -27,6 +27,10 @@ export { exec };
  */
 export async function execFileWithExitCode(file: string, args?: string[], options?: cp.ExecFileOptions): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
+    if (options?.shell) {
+      file = `"${file}"`;
+    }
+
     cp.execFile(file, args, options, (error, stdout, stderr) => {
       if (typeof stdout !== "string") stdout = stdout.toString();
       if (typeof stderr !== "string") stderr = stderr.toString();


### PR DESCRIPTION
## Description

Fixes an issue found when a space character is in the user's home path, which appears only when doing `modus build` or `modus dev` on a Go project.

See https://discord.com/channels/1267579648657850441/1325117493886455811

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
