### PR TITLE
Mjp/hyp 2920 modus cli errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - fix: resolve warning in `deserializeRawMap` [#692](https://github.com/hypermodeinc/modus/pull/692)
 
+## 2025-01-09 - CLI 0.16.6
+
+- fix: assemblyscript builds failing [#698](https://github.com/hypermodeinc/modus/pull/698)
+
 ## 2025-01-07 - CLI 0.16.5
 
 - fix: handle space in user profile path [#696](https://github.com/hypermodeinc/modus/pull/696)

--- a/cli/src/util/cp.ts
+++ b/cli/src/util/cp.ts
@@ -9,6 +9,7 @@
 
 import util from "node:util";
 import cp from "node:child_process";
+import path from "node:path";
 
 /**
  * Promisified version of `child_process.execFile`.
@@ -27,7 +28,7 @@ export { exec };
  */
 export async function execFileWithExitCode(file: string, args?: string[], options?: cp.ExecFileOptions): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
-    if (options?.shell) {
+    if (options?.shell && path.isAbsolute(file)) {
       file = `"${file}"`;
     }
 


### PR DESCRIPTION
## Description

#696 fixed Go builds when the user had a space in their user home directory, but it broke AssemblyScript builds on Windows.  This fixes the problem.

See https://discord.com/channels/1267579648657850441/1301895154264965141/1327049139963301900 for discussion.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.

