### PR TITLE
fix: remove fallback to default time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## UNRELEASED
 
-- chore: update api-explorer to react 19 [#700](https://github.com/hypermodeinc/modus/pull/700)
-
 - fix: resolve warning in `deserializeRawMap` [#692](https://github.com/hypermodeinc/modus/pull/692)
 - fix: add json serialization support for neo4j sdk types
   [#699](https://github.com/hypermodeinc/modus/pull/699)
+- chore: update api-explorer to react 19 [#700](https://github.com/hypermodeinc/modus/pull/700)
+- fix: remove fallback to default time zone [#706](https://github.com/hypermodeinc/modus/pull/706)
 
 ## 2025-01-09 - CLI 0.16.6
 

--- a/runtime/hostfunctions/system.go
+++ b/runtime/hostfunctions/system.go
@@ -61,11 +61,11 @@ func GetTimeInZone(ctx context.Context, tz *string) *string {
 		loc = timezones.GetLocation(tz)
 	}
 
-	if loc != nil {
-		now = now.In(loc)
+	if loc == nil {
+		return nil
 	}
 
-	s := now.Format(time.RFC3339Nano)
+	s := now.In(loc).Format(time.RFC3339Nano)
 	return &s
 }
 


### PR DESCRIPTION
## Description

Currently, the `GetTimeInTimeZone` host function will use the default (system local) time zone when the provided time zone string is invalid.  This is bad because it hides errors and results in incorrect data returned.  It should just return nil so error handling can work correctly.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
