### PR TITLE
chore: add runtime build workflow

### DIFF
--- a/.github/workflows/ci-runtime-build.yml
+++ b/.github/workflows/ci-runtime-build.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-runtime-build.yml
       - runtime/**/*.go
       - runtime/go.mod
       - runtime/go.sum

--- a/.github/workflows/ci-runtime-build.yml
+++ b/.github/workflows/ci-runtime-build.yml
@@ -1,0 +1,39 @@
+name: Build Runtime
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - runtime/**/*.go
+      - runtime/go.mod
+      - runtime/go.sum
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}
+    runs-on:
+      "${{ matrix.os == 'linux' && 'warp-ubuntu-latest-x64-4x' || matrix.os == 'macos' &&
+      'warp-macos-15-arm64-6x' || 'warp-windows-latest-x64-4x' }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [linux, macos, windows]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.4
+          cache-dependency-path: runtime/go.sum
+      - name: Build Runtime
+        working-directory: runtime
+        run: go build

--- a/.github/workflows/ci-runtime-build.yml
+++ b/.github/workflows/ci-runtime-build.yml
@@ -37,4 +37,4 @@ jobs:
           cache-dependency-path: runtime/go.sum
       - name: Build Runtime
         working-directory: runtime
-        run: go build
+        run: go build ${{ matrix.os == 'windows' && '-ldflags "-checklinkname=0"' || '' }}


### PR DESCRIPTION
## Description

Adds a CI workflow to ensure the Runtime build successfully on Linux, Windows, and macOS.

This is important to ensure that we don't accidentally introduce incompatible platform-specific dependencies.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).
