### PR TITLE
feat: support type aliases and redefinitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - fix: remove fallback to default time zone [#706](https://github.com/hypermodeinc/modus/pull/706)
 - feat: improve OpenAI model APIs and examples to better support audio, images, and tool calling
   [#707](https://github.com/hypermodeinc/modus/pull/707)
+- feat: support type aliases and redefinitions
+  [#721](https://github.com/hypermodeinc/modus/pull/721)
 
 ## 2025-01-09 - CLI 0.16.6
 

--- a/sdk/go/tools/modus-go-build/extractor/functions.go
+++ b/sdk/go/tools/modus-go-build/extractor/functions.go
@@ -227,6 +227,11 @@ func addRequiredTypes(t types.Type, m map[string]types.Type) bool {
 			m[name] = t
 			return true
 		}
+	case *types.Alias:
+		if addRequiredTypes(t.Rhs(), m) {
+			m[name] = t
+			return true
+		}
 	case *types.Struct:
 		// TODO: handle unnamed structs
 	case *types.Slice:


### PR DESCRIPTION
## Description

In a Modus Go app, a type alias such as:

```go
type Foo = Bar
```

or a type re-definition such as:

```go
type Foo Bar
```

... should be discoverable as valid types for imports and exports.

Previously this was not working correctly, resulting in a panic at build time.  This PR adds support for this language feature.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
