### PR TITLE
chore: resolve GoReleaser warnings

### DIFF
--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -49,11 +49,11 @@ archives:
       - ../README.md
       - ../LICENSE
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    formats: ["tar.gz"]
+    formats: [tar.gz]
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        formats: ["zip"]
+        formats: [zip]
 checksum:
   name_template: checksums.txt
 release:

--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -49,11 +49,11 @@ archives:
       - ../README.md
       - ../LICENSE
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
+    format: ["tar.gz"]
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 checksum:
   name_template: checksums.txt
 release:

--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -49,7 +49,7 @@ archives:
       - ../README.md
       - ../LICENSE
     name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format: ["tar.gz"]
+    formats: ["tar.gz"]
     # use zip for windows archives
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Address deprecation warnings from last release.

https://github.com/hypermodeinc/modus/actions/runs/12958939309/job/36150300412#step:9:31