### PR TITLE
fix: separate modusdb instance by app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,14 @@
 *.gz
 *.zip
 
-# Ignore Go debuger and generated files
+# Ignore Go debugger and generated files
 __debug_bin*
 *_generated.go
 *.generated.go
 
-# Ignore build output directories
+# Ignore build output directories and modus databases
 build/
+.modusdb/
 
 # Ignore node_modules folders
 node_modules/

--- a/.trunk/configs/cspell.json
+++ b/.trunk/configs/cspell.json
@@ -117,6 +117,7 @@
     "millis",
     "minilm",
     "modfile",
+    "modusdb",
     "Msgf",
     "mydb",
     "mydgraph",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2025-01-24 - Runtime 0.17.1
+
+- fix: separate modusdb instance by app [#729](https://github.com/hypermodeinc/modus/pull/729)
+
 ## 2025-01-24 - Runtime 0.17.0
 
 - feat: add modusdb model tracing for local dev

--- a/runtime/db/modusdb.go
+++ b/runtime/db/modusdb.go
@@ -10,7 +10,10 @@
 package db
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -22,18 +25,70 @@ import (
 var GlobalModusDbEngine *modusdb.Engine
 
 func InitModusDb(ctx context.Context) {
-	if app.IsDevEnvironment() && runtime.GOOS != "windows" {
-		dataDir := filepath.Join(app.ModusHomeDir(), "data")
-		if eng, err := modusdb.NewEngine(modusdb.NewDefaultConfig(dataDir)); err != nil {
-			logger.Fatal(ctx).Err(err).Msg("Failed to initialize modusdb.")
-		} else {
-			GlobalModusDbEngine = eng
-		}
+	if !app.IsDevEnvironment() || runtime.GOOS == "windows" {
+		// ModusDB should only be initialized in dev environment,
+		// and currently does not work on Windows.
+		return
+	}
+
+	var dataDir string
+	appPath := app.Config().AppPath()
+	if filepath.Base(appPath) == "build" {
+		// this keeps the data directory outside of the build directory
+		dataDir = filepath.Join(appPath, "..", ".modusdb")
+		addToGitIgnore(ctx, filepath.Dir(appPath))
+	} else {
+		dataDir = filepath.Join(appPath, ".modusdb")
+	}
+
+	if eng, err := modusdb.NewEngine(modusdb.NewDefaultConfig(dataDir)); err != nil {
+		logger.Fatal(ctx).Err(err).Msg("Failed to initialize modusdb.")
+	} else {
+		GlobalModusDbEngine = eng
 	}
 }
 
 func CloseModusDb(ctx context.Context) {
 	if GlobalModusDbEngine != nil {
 		GlobalModusDbEngine.Close()
+	}
+}
+
+func addToGitIgnore(ctx context.Context, rootPath string) {
+	gitIgnorePath := filepath.Join(rootPath, ".gitignore")
+	gitIgnoreContents := ".modusdb/"
+
+	// if .gitignore file does not exist, create it and add .modusdb/ to it
+	if _, err := os.Stat(gitIgnorePath); errors.Is(err, os.ErrNotExist) {
+		if err := os.WriteFile(gitIgnorePath, []byte(gitIgnoreContents+"\n"), 0644); err != nil {
+			logger.Err(ctx, err).Msg("Failed to create .gitignore file.")
+		}
+		return
+	}
+
+	// check if .modusdb/ is already in the .gitignore file
+	file, err := os.Open(gitIgnorePath)
+	if err != nil {
+		logger.Err(ctx, err).Msg("Failed to open .gitignore file.")
+		return
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if scanner.Text() == gitIgnoreContents {
+			// found .modusdb/ in the file
+			return
+		}
+	}
+
+	// .modusdb/ is not in the file, so append it
+	file, err = os.OpenFile(gitIgnorePath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		logger.Err(ctx, err).Msg("Failed to open .gitignore file.")
+		return
+	}
+	defer file.Close()
+	if _, err := file.WriteString("\n" + gitIgnoreContents + "\n"); err != nil {
+		logger.Err(ctx, err).Msg("Failed to append .modusdb/ to .gitignore file.")
 	}
 }


### PR DESCRIPTION
## Description

When we added ModusDB in `v0.17.0`, we didn't consider that multiple applications should not share the same database instance.  Instead, we'll create a separate `.modusdb` in the project folder, and ensure it's in a `.gitignore` file so it doesn't get committed.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
