### PR TITLE
fix: AssemblyScript ESLint import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: AssemblyScript ESLint import path [#737](https://github.com/hypermodeinc/modus/pull/737)
+
 ## 2025-01-24 - Runtime 0.17.1
 
 - fix: separate modusdb instance by app [#729](https://github.com/hypermodeinc/modus/pull/729)

--- a/sdk/assemblyscript/examples/anthropic-functions/eslint.config.js
+++ b/sdk/assemblyscript/examples/anthropic-functions/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/auth/eslint.config.js
+++ b/sdk/assemblyscript/examples/auth/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/classification/eslint.config.js
+++ b/sdk/assemblyscript/examples/classification/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/collections/eslint.config.js
+++ b/sdk/assemblyscript/examples/collections/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/dgraph/eslint.config.js
+++ b/sdk/assemblyscript/examples/dgraph/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/embedding/eslint.config.js
+++ b/sdk/assemblyscript/examples/embedding/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/graphql/eslint.config.js
+++ b/sdk/assemblyscript/examples/graphql/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/http/eslint.config.js
+++ b/sdk/assemblyscript/examples/http/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/mysql/eslint.config.js
+++ b/sdk/assemblyscript/examples/mysql/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/neo4j/eslint.config.js
+++ b/sdk/assemblyscript/examples/neo4j/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/postgresql/eslint.config.js
+++ b/sdk/assemblyscript/examples/postgresql/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/simple/eslint.config.js
+++ b/sdk/assemblyscript/examples/simple/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/textgeneration/eslint.config.js
+++ b/sdk/assemblyscript/examples/textgeneration/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/time/eslint.config.js
+++ b/sdk/assemblyscript/examples/time/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/examples/vectors/eslint.config.js
+++ b/sdk/assemblyscript/examples/vectors/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint";
+import aseslint from "@hypermode/modus-sdk-as/tools/assemblyscript-eslint-local";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/src/eslint.config.js
+++ b/sdk/assemblyscript/src/eslint.config.js
@@ -2,7 +2,7 @@
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
-import aseslint from "./tools/assemblyscript-eslint.js";
+import aseslint from "./tools/assemblyscript-eslint-local.js";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -48,7 +48,8 @@
   },
   "exports": {
     "./transform": "./transform/lib/index.js",
-    "./tools/assemblyscript-eslint": "./tools/assemblyscript-eslint.js"
+    "./tools/assemblyscript-eslint": "./tools/assemblyscript-eslint.js",
+    "./tools/assemblyscript-eslint-local": "./tools/assemblyscript-eslint-local.js"
   },
   "files": [
     "index.ts",

--- a/sdk/assemblyscript/src/tools/assemblyscript-eslint-local.js
+++ b/sdk/assemblyscript/src/tools/assemblyscript-eslint-local.js
@@ -1,9 +1,9 @@
 /*
- * Copyright 2024 Hypermode Inc.
+ * Copyright 2025 Hypermode Inc.
  * Licensed under the terms of the Apache License, Version 2.0
  * See the LICENSE file that accompanied this code for further details.
  *
- * SPDX-FileCopyrightText: 2024 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-FileCopyrightText: 2025 Hypermode Inc. <hello@hypermode.com>
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@
 
 import * as ts from "typescript";
 import * as parser from "@typescript-eslint/parser";
-import utils from "../../../@typescript-eslint/typescript-estree/dist/node-utils.js";
+import utils from "../node_modules/@typescript-eslint/typescript-estree/dist/node-utils.js";
 
 // In AssemblyScript, functions and variables can be decorated
 const nodeCanBeDecorated = utils.nodeCanBeDecorated;


### PR DESCRIPTION
## Description

Our monkey-patch for typescript-eslint was only working on projects in the Modus repo.  For other Modus AssemblyScript projects, `npm run lint` would give an error such as:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/matt/modustemp/as1/node_modules/@hypermode/modus-sdk-as/node_modules/@typescript-eslint/typescript-estree/dist/node-utils.js' imported from /Users/matt/modustemp/as1/node_modules/@hypermode/modus-sdk-as/tools/assemblyscript-eslint.js
    at finalizeResolution (node:internal/modules/esm/resolve:257:11)
    at moduleResolve (node:internal/modules/esm/resolve:913:10)
    at defaultResolve (node:internal/modules/esm/resolve:1037:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:650:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:599:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:582:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:241:38)
```

This fixes the issue by updating the import path to the file we're patching.  It also creates a separate copy of the patch to use locally.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
