### PR TITLE
fix: decode base64 strings to binary data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 - fix: AssemblyScript ESLint import path [#737](https://github.com/hypermodeinc/modus/pull/737)
+- fix: decode base64 strings to binary data types [#738](https://github.com/hypermodeinc/modus/pull/738)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/runtime/languages/assemblyscript/handler_arraybuffers.go
+++ b/runtime/languages/assemblyscript/handler_arraybuffers.go
@@ -11,6 +11,7 @@ package assemblyscript
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -115,7 +116,11 @@ func (h *arrayBufferHandler) doWriteBytes(ctx context.Context, wa langsupport.Wa
 	case []byte:
 		bytes = obj
 	case string:
-		bytes = []byte(obj)
+		if b, err := base64.StdEncoding.DecodeString(obj); err != nil {
+			return 0, nil, utils.NewUserError(fmt.Errorf("failed to decode base64 string: %w", err))
+		} else {
+			bytes = b
+		}
 	case []any:
 		for _, item := range obj {
 			if item == nil {

--- a/runtime/utils/errors.go
+++ b/runtime/utils/errors.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Hypermode Inc.
+ * Licensed under the terms of the Apache License, Version 2.0
+ * See the LICENSE file that accompanied this code for further details.
+ *
+ * SPDX-FileCopyrightText: 2025 Hypermode Inc. <hello@hypermode.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrUserError = errors.New("")
+
+func NewUserError(err error) error {
+	return fmt.Errorf("%w%w", ErrUserError, err)
+}

--- a/runtime/wasmhost/fncall.go
+++ b/runtime/wasmhost/fncall.go
@@ -156,6 +156,13 @@ func (host *wasmHost) CallFunction(ctx context.Context, fnInfo functions.Functio
 			Dur("duration_ms", duration).
 			Bool("user_visible", true).
 			Msg("Function execution was canceled.")
+	} else if errors.Is(err, utils.ErrUserError) {
+		// If we specifically wrapped an error with ErrUserError, then we want to log it as a user-visible error.
+		logger.Err(ctx, err).
+			Str("function", fnName).
+			Dur("duration_ms", duration).
+			Bool("user_visible", true).
+			Msg("Error while executing function.")
 	} else {
 		// While debugging, it helps if we can see the error in the console without escaped newlines and other json formatting.
 		if utils.DebugModeEnabled() {


### PR DESCRIPTION
## Description

The Modus Runtime should properly decode base64 strings when presented as input to binary data types `Uint8Array` or `ArrayBuffer` in AssemblyScript, or `[]byte` in Go.

Previously, this was working for output only.  This PR fixes it for input parameters.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
