### PR TITLE
fix: serialization of OpenAI `ToolChoice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - fix: AssemblyScript ESLint import path [#737](https://github.com/hypermodeinc/modus/pull/737)
 - fix: decode base64 strings to binary data types [#738](https://github.com/hypermodeinc/modus/pull/738)
+- fix: serialization of OpenAI `ToolChoice` [#739](https://github.com/hypermodeinc/modus/pull/739)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -285,7 +285,6 @@ export class ToolChoice {
   /**
    * The function to call.
    */
-  @omitnull()
   function: ToolChoiceFunction | null = null;
 
   /**
@@ -316,6 +315,29 @@ export class ToolChoice {
    */
   static Function(name: string): ToolChoice {
     return new ToolChoice("function", name);
+  }
+
+  __INITIALIZE(): this {
+    return this;
+  }
+
+  __SERIALIZE(): string {
+    if (this.type == "function") {
+      return `{"type":"function","function":{"name":${JSON.stringify(this.function!.name)}}}`;
+    }
+
+    return `"${this.type}"`;
+  }
+
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  __DESERIALIZE(
+    data: string,
+    key_start: i32,
+    key_end: i32,
+    value_start: i32,
+    value_end: i32,
+  ): boolean {
+    throw new Error("Not implemented.");
   }
 }
 


### PR DESCRIPTION
## Description

The `ToolChoice` object for the OpenAI model interface in the Modus AssemblyScript SDK was not serialized correctly.  It requires custom serialization, as it can be represented by either a string or an object, depending on type.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
