### PR TITLE
fix: CORS: allow all request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - fix: decode base64 strings to binary data types [#738](https://github.com/hypermodeinc/modus/pull/738)
 - fix: serialization of OpenAI `ToolChoice` [#739](https://github.com/hypermodeinc/modus/pull/739)
 - perf: use xsync's `LoadOrTryCompute` [#740](https://github.com/hypermodeinc/modus/pull/740)
+- fix: CORS: allow all request headers [#741](https://github.com/hypermodeinc/modus/pull/741)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/runtime/httpserver/server.go
+++ b/runtime/httpserver/server.go
@@ -237,8 +237,11 @@ func GetMainHandler(options ...func(map[string]http.Handler)) http.Handler {
 	handler := restrictHttpMethods(mux)
 
 	// Add CORS support to all endpoints.
+	// The default options allow all origins and methods.
+	// We also allow all headers.
+	// TODO: Consider passing non-sensitive request headers to the Modus app.
 	c := cors.New(cors.Options{
-		AllowedHeaders: []string{"Authorization", "Content-Type"},
+		AllowedHeaders: []string{"*"},
 	})
 
 	return c.Handler(handler)


### PR DESCRIPTION
## Description

This allows all request headers in the GraphQL request.  In particular, it avoids CORS errors when passing `X-Time-Zone` for Modus's local time feature.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
