### PR TITLE
fix: improve dgraph auth header passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix: serialization of OpenAI `ToolChoice` [#739](https://github.com/hypermodeinc/modus/pull/739)
 - perf: use xsync's `LoadOrTryCompute` [#740](https://github.com/hypermodeinc/modus/pull/740)
 - fix: CORS: allow all request headers [#741](https://github.com/hypermodeinc/modus/pull/741)
+- fix: improve dgraph auth header passing [#752](https://github.com/hypermodeinc/modus/pull/752)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/runtime/dgraphclient/registry.go
+++ b/runtime/dgraphclient/registry.go
@@ -38,10 +38,23 @@ type authCreds struct {
 	token string
 }
 
-func (a *authCreds) GetRequestMetadata(ctx context.Context, uri ...string) (
-	map[string]string, error) {
+func (a *authCreds) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	if len(a.token) == 0 {
+		return nil, nil
+	}
 
-	return map[string]string{"Authorization": a.token}, nil
+	headers := make(map[string]string, 1)
+	if len(uri) > 0 && strings.Contains(strings.ToLower(uri[0]), "cloud.dgraph.io") {
+		headers["X-Auth-Token"] = a.token
+	} else {
+		token := a.token
+		if !strings.HasPrefix(token, "Bearer ") {
+			token = "Bearer " + token
+		}
+		headers["Authorization"] = token
+	}
+
+	return headers, nil
 }
 
 func (a *authCreds) RequireTransportSecurity() bool {


### PR DESCRIPTION
## Description

Improves the handling of auth headers for Dgraph, as follows:

- When connecting to Dgraph Cloud instances, use the `X-Auth-Header`
- Otherwise use the `Authorization` header, ensuring that the `"Bearer "` prefix is provided, for RFC 9110 & RFC 6750 compliance.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
