### PR TITLE
fix: wasm filename should be last part of package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix: CORS: allow all request headers [#741](https://github.com/hypermodeinc/modus/pull/741)
 - fix: accept long base64 strings [#742](https://github.com/hypermodeinc/modus/pull/742)
 - fix: improve dgraph auth header passing [#752](https://github.com/hypermodeinc/modus/pull/752)
+- fix: wasm filename should be last part of package name [#754](https://github.com/hypermodeinc/modus/pull/754)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/sdk/assemblyscript/src/bin/build-plugin.js
+++ b/sdk/assemblyscript/src/bin/build-plugin.js
@@ -17,7 +17,7 @@ import console from "console";
 import semver from "semver";
 
 const npmPath = process.env.npm_execpath;
-const pkg = process.env.npm_package_name;
+let pkg = process.env.npm_package_name;
 
 if (!npmPath) {
   console.error("This script must be run with npm.");
@@ -28,6 +28,9 @@ if (!pkg) {
   console.error("A package name must be defined in package.json.");
   process.exit(1);
 }
+
+// take only the last segment of the package name (e.g. @my-org/my-project -> my-project)
+pkg = pkg.split("/").pop();
 
 const target = process.argv[2] || "debug";
 if (target !== "debug" && target !== "release") {


### PR DESCRIPTION
## Description

In an AssemblyScript project, if the package name in `package.json` contains an org or other multiple parts, such as `@foo/bar/baz` then the wasm filename should just be the last part, ie. `baz`.

Fixes #751 

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
