### PR TITLE
chore: update Go toolchain to 1.23.6

### DIFF
--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
       - name: Run Linter
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
       - name: Run Unit Tests
         run: |

--- a/.github/workflows/ci-runtime-build.yml
+++ b/.github/workflows/ci-runtime-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: runtime/go.sum
       - name: Build Runtime
         working-directory: runtime

--- a/.github/workflows/ci-runtime-integration-tests.yml
+++ b/.github/workflows/ci-runtime-integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: runtime/go.sum
       - name: Run Integration Tests
         working-directory: runtime

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: ./sdk/go/go.sum
       - name: Build Program
         run: go build .
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
       - name: Setup TinyGo
         uses: acifani/setup-tinygo@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: runtime/go.sum
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/release-runtime.yaml
+++ b/.github/workflows/release-runtime.yaml
@@ -32,7 +32,7 @@ jobs:
         run: npm run build
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: runtime/go.sum
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release-sdk-go.yaml
+++ b/.github/workflows/release-sdk-go.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.5
+          go-version: 1.23.6
           cache-dependency-path: ./sdk/go/go.sum
       - name: Prepare Release
         working-directory: sdk/go

--- a/.trunk/configs/osv-scanner.toml
+++ b/.trunk/configs/osv-scanner.toml
@@ -1,0 +1,11 @@
+[[IgnoredVulns]]
+id = "CVE-2024-45336"
+reason = "This is a false positive."
+
+[[IgnoredVulns]]
+id = "CVE-2024-45341"
+reason = "This is a false positive."
+
+[[IgnoredVulns]]
+id = "CVE-2025-22866"
+reason = "This is a false positive."

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -38,6 +38,12 @@ lint:
     - shfmt@3.6.0
     - trufflehog@3.88.5
     - yamllint@1.35.1
+  definitions:
+    - name: osv-scanner
+      commands:
+        - name: scan
+          run:
+            osv-scanner --lockfile=${target} --format json --config=.trunk/configs/osv-scanner.toml
 actions:
   enabled:
     - trunk-announce

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,9 +22,9 @@ runtimes:
 lint:
   enabled:
     - trivy@0.59.1
-    - renovate@39.161.0
+    - renovate@39.163.0
     - actionlint@1.7.7
-    - checkov@3.2.365
+    - checkov@3.2.368
     - git-diff-check
     - gofmt@1.20.4
     - golangci-lint@1.63.4
@@ -36,7 +36,7 @@ lint:
           - assemblyscript-prettier@3.0.1
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trufflehog@3.88.4
+    - trufflehog@3.88.5
     - yamllint@1.35.1
 actions:
   enabled:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.23.5
+    - go@1.23.6
     - node@18.20.5
     - python@3.10.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix: wasm filename should be last part of package name [#754](https://github.com/hypermodeinc/modus/pull/754)
 - chore: update ModusDB [#755](https://github.com/hypermodeinc/modus/pull/755)
 - chore: bump tailwind to v4 [#756](https://github.com/hypermodeinc/modus/pull/756)
+- chore: update Go toolchain to 1.23.6 [#757](https://github.com/hypermodeinc/modus/pull/757)
 
 ## 2025-01-24 - Runtime 0.17.1
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 use (
 	./lib/manifest

--- a/lib/manifest/go.mod
+++ b/lib/manifest/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/lib/manifest
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1

--- a/lib/metadata/go.mod
+++ b/lib/metadata/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/lib/metadata
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0
 

--- a/lib/wasmextractor/go.mod
+++ b/lib/wasmextractor/go.mod
@@ -2,4 +2,4 @@ module github.com/hypermodeinc/modus/lib/wasmextractor
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6

--- a/runtime/go.mod
+++ b/runtime/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/runtime
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.17.0

--- a/runtime/languages/golang/testdata/go.mod
+++ b/runtime/languages/golang/testdata/go.mod
@@ -2,6 +2,6 @@ module testdata
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0

--- a/sdk/go/examples/anthropic-functions/go.mod
+++ b/sdk/go/examples/anthropic-functions/go.mod
@@ -2,7 +2,7 @@ module anthropic-functions-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/examples/auth/go.mod
+++ b/sdk/go/examples/auth/go.mod
@@ -2,6 +2,6 @@ module auth-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/classification/go.mod
+++ b/sdk/go/examples/classification/go.mod
@@ -2,6 +2,6 @@ module classification-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/collections/go.mod
+++ b/sdk/go/examples/collections/go.mod
@@ -2,6 +2,6 @@ module collection-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/dgraph/go.mod
+++ b/sdk/go/examples/dgraph/go.mod
@@ -2,6 +2,6 @@ module dgraph-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/embedding/go.mod
+++ b/sdk/go/examples/embedding/go.mod
@@ -2,7 +2,7 @@ module embedding-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/examples/graphql/go.mod
+++ b/sdk/go/examples/graphql/go.mod
@@ -2,6 +2,6 @@ module graphql-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/http/go.mod
+++ b/sdk/go/examples/http/go.mod
@@ -2,6 +2,6 @@ module http-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/mysql/go.mod
+++ b/sdk/go/examples/mysql/go.mod
@@ -2,6 +2,6 @@ module mysql-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/neo4j/go.mod
+++ b/sdk/go/examples/neo4j/go.mod
@@ -2,6 +2,6 @@ module neo4j-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/postgresql/go.mod
+++ b/sdk/go/examples/postgresql/go.mod
@@ -2,6 +2,6 @@ module postgresql-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/simple/go.mod
+++ b/sdk/go/examples/simple/go.mod
@@ -2,6 +2,6 @@ module simple-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/textgeneration/go.mod
+++ b/sdk/go/examples/textgeneration/go.mod
@@ -2,7 +2,7 @@ module text-generation-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/time/go.mod
+++ b/sdk/go/examples/time/go.mod
@@ -2,6 +2,6 @@ module time-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0

--- a/sdk/go/examples/vectors/go.mod
+++ b/sdk/go/examples/vectors/go.mod
@@ -2,7 +2,7 @@ module vectors-example
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.16.0
 

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.17.0

--- a/sdk/go/templates/default/go.mod
+++ b/sdk/go/templates/default/go.mod
@@ -2,6 +2,6 @@ module my-modus-app
 
 go 1.23.1
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0


### PR DESCRIPTION
## Description

- Use Go 1.23.6 toolchain
- Update Trunk plugins to latest versions
- Ignore the three CVEs that OSV-Scanner (via Trunk) is reporting, as they do not apply.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [ ] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
