### PR TITLE
chore: temporarily use Go 1.23 toolchain for SDK

### DIFF
--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
+          go-version: 1.24.0
           cache-dependency-path: ./sdk/go/go.sum
       - name: Build Program
         run: go build .

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.0
+          go-version: 1.23.6
           cache-dependency-path: ./sdk/go/go.sum
       - name: Build Program
         run: go build .

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.0
+          go-version: 1.23.6
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
       - name: Setup TinyGo
         uses: acifani/setup-tinygo@v2

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -86,3 +86,5 @@ jobs:
           tinygo-version: 0.35.0
       - name: Build Program
         run: ./build.sh
+        env:
+          GOTOOLCHAIN: go1.23.6

--- a/lib/manifest/go.mod
+++ b/lib/manifest/go.mod
@@ -2,8 +2,6 @@ module github.com/hypermodeinc/modus/lib/manifest
 
 go 1.23.1
 
-toolchain go1.24.0
-
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/tidwall/gjson v1.18.0

--- a/lib/metadata/go.mod
+++ b/lib/metadata/go.mod
@@ -2,8 +2,6 @@ module github.com/hypermodeinc/modus/lib/metadata
 
 go 1.23.1
 
-toolchain go1.24.0
-
 require github.com/hypermodeinc/modus/lib/wasmextractor v0.13.0
 
 require github.com/tidwall/gjson v1.18.0

--- a/lib/wasmextractor/go.mod
+++ b/lib/wasmextractor/go.mod
@@ -1,5 +1,3 @@
 module github.com/hypermodeinc/modus/lib/wasmextractor
 
 go 1.23.1
-
-toolchain go1.24.0

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.1
 
-toolchain go1.24.0
+toolchain go1.23.6
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.17.0

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -2,7 +2,7 @@ module github.com/hypermodeinc/modus/sdk/go
 
 go 1.23.1
 
-toolchain go1.23.6
+toolchain go1.24.0
 
 require (
 	github.com/hypermodeinc/modus/lib/manifest v0.17.0


### PR DESCRIPTION
We're working on Go 1.24 support for the Modus Go SDK.  In the meantime, we need to tell TinyGo to build the examples with the Go 1.23.6 toolchain.

This should resolve errors such as those seen with https://github.com/hypermodeinc/modus/actions/runs/13587636026

Also, remove the `toolchain` directive from libraries in the `/lib` folder, as they have no effect.