### PR TITLE
chore: Use Go 1.24 and TinyGo 0.36 in SDK workflow

### DIFF
--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - ./github/workflows/ci-sdk-go-build.yml
       - sdk/go/**
 
 permissions:

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -8,7 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
-      - ./github/workflows/ci-sdk-go-build.yml
+      - .github/workflows/ci-sdk-go-build.yml
       - sdk/go/**
 
 permissions:

--- a/.github/workflows/ci-sdk-go-build.yml
+++ b/.github/workflows/ci-sdk-go-build.yml
@@ -78,13 +78,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.6
+          go-version: 1.24.0
           cache-dependency-path: "${{ matrix.dir }}/go.sum"
       - name: Setup TinyGo
         uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: 0.35.0
+          tinygo-version: 0.36.0
       - name: Build Program
         run: ./build.sh
-        env:
-          GOTOOLCHAIN: go1.23.6


### PR DESCRIPTION
Update SDK workflows to use Go 1.24 and TinyGo 0.36.

Reverts the temporary use of Go 1.23.6 set in #775.

Also, update the workflow so that it runs when only the workflow itself has changed, otherwise the workflow would not have run in this PR.