### PR TITLE
fix: support float32 vector arrays in DQL query variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - deps: update json-as to v1.0.0 and upgrade related code [#799](https://github.com/hypermodeinc/modus/pull/779)
 - fix: bump api explorer to account for recursive types, default required variables with falsy values [#766](https://github.com/hypermodeinc/modus/pull/766)
+- fix: support float32 vector arrays in DQL query variables [#781](https://github.com/hypermodeinc/modus/pull/781)
 
 ## 2025-02-10 - AssemblyScript SDK 0.17.1
 

--- a/sdk/assemblyscript/src/assembly/dgraph.ts
+++ b/sdk/assemblyscript/src/assembly/dgraph.ts
@@ -167,6 +167,9 @@ export class Query {
     } else if (isBoolean<T>()) {
       this.variables.set(name, JSON.stringify(value));
       return this;
+    } else if (isArray<T>()) {
+      this.variables.set(name, JSON.stringify(value));
+      return this;
     } else {
       throw new Error(
         "Unsupported DQL variable type. Must be string, integer, float, or boolean.",

--- a/sdk/assemblyscript/src/assembly/dgraph.ts
+++ b/sdk/assemblyscript/src/assembly/dgraph.ts
@@ -155,26 +155,8 @@ export class Query {
    * Adds a variable to the query.
    */
   withVariable<T>(name: string, value: T): this {
-    if (isString<T>()) {
-      this.variables.set(name, value as string);
-      return this;
-    } else if (isInteger<T>()) {
-      this.variables.set(name, JSON.stringify(value));
-      return this;
-    } else if (isFloat<T>()) {
-      this.variables.set(name, JSON.stringify(value));
-      return this;
-    } else if (isBoolean<T>()) {
-      this.variables.set(name, JSON.stringify(value));
-      return this;
-    } else if (isArray<T>()) {
-      this.variables.set(name, JSON.stringify(value));
-      return this;
-    } else {
-      throw new Error(
-        "Unsupported DQL variable type. Must be string, integer, float, or boolean.",
-      );
-    }
+    this.variables.set(name, encodeVariable(value));
+    return this;
   }
 }
 
@@ -257,28 +239,33 @@ export class Variables {
   private data: Map<string, string> = new Map<string, string>();
 
   public set<T>(name: string, value: T): void {
-    if (isString<T>()) {
-      this.data.set(name, value as string);
-      return;
-    } else if (isInteger<T>()) {
-      this.data.set(name, JSON.stringify(value));
-      return;
-    } else if (isFloat<T>()) {
-      this.data.set(name, JSON.stringify(value));
-      return;
-    } else if (isBoolean<T>()) {
-      this.data.set(name, JSON.stringify(value));
-      return;
-    } else {
-      throw new Error(
-        "Unsupported DQL variable type. Must be string, integer, float, or boolean.",
-      );
-    }
+    this.data.set(name, encodeVariable(value));
   }
 
   public toMap(): Map<string, string> {
     return this.data;
   }
+}
+
+function encodeVariable<T>(value: T): string {
+  if (isString<T>()) {
+    // strings are passed as-is, without extra encoding
+    return value as string;
+  }
+
+  if (
+    isInteger<T>() ||
+    isFloat<T>() ||
+    isBoolean<T>() ||
+    idof<T>() == idof<f32[]>()
+  ) {
+    // other supported types are JSON-encoded and passed as strings
+    return JSON.stringify(value);
+  }
+
+  throw new Error(
+    "Unsupported DQL variable type. Must be string, integer, float, boolean, or f32[].",
+  );
 }
 
 /**

--- a/sdk/go/pkg/dgraph/dgraph.go
+++ b/sdk/go/pkg/dgraph/dgraph.go
@@ -10,6 +10,7 @@
 package dgraph
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -64,13 +65,16 @@ func NewQuery(query string) *Query {
 func (q *Query) WithVariable(key string, value any) *Query {
 	switch value := value.(type) {
 	case string:
+		// strings are passed as-is, without extra encoding
 		q.Variables[key] = value
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
-		float32, float64, bool:
-		q.Variables[key] = fmt.Sprint(value)
+		float32, float64, bool,
+		[]float32:
+		s, _ := json.Marshal(value)
+		q.Variables[key] = string(s)
 	default:
-		panic(fmt.Errorf("unsupported DQL variable type: %T (must be string, integer, float or boolean)", value))
+		panic(fmt.Errorf("unsupported DQL variable type: %T (must be string, integer, float, bool, or []float32)", value))
 	}
 
 	return q


### PR DESCRIPTION
## Description

Updated the Dgraph client APIs to support vector arrays (`f32[]` in AssemblyScript, `[]float32` in Go) as parameters to DQL queries.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
