### PR TITLE
fix: dgraph connection should ignore key for localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## Runtime 0.17.4
+
+- fix: dgraph connection should ignore key for localhost [#793](https://github.com/hypermodeinc/modus/pull/793)
+
 ## 2025-03-13 - CLI 0.17.1
 
 - chore: cleanup unused dependencies and update remaining [#790](https://github.com/hypermodeinc/modus/pull/790)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Change Log
 
-## Runtime 0.17.4
+## 2025-03-18 - Runtime 0.17.4
 
 - fix: dgraph connection should ignore key for localhost [#793](https://github.com/hypermodeinc/modus/pull/793)
 


### PR DESCRIPTION
## Description

When connecting to a dgraph instance on `localhost`, the `key` value should be ignored.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
