### PR TITLE
fix: embed runtime version with correct path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-03-19 - Runtime 0.17.5
+
+- fix: embed runtime version with correct path [#796](https://github.com/hypermodeinc/modus/pull/796)
+
 ## 2025-03-19 - AssemblyScript SDK 0.17.4
 
 - fix: correct json input/output of model invocations [#795](https://github.com/hypermodeinc/modus/pull/795)

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=node-builder /src/dist ./explorer/content/dist
 
 # build the runtime binary
 ARG TARGETOS TARGETARCH RUNTIME_RELEASE_VERSION
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime -ldflags "-s -w -X github.com/hypermodeinc/modus/runtime/config.version=$RUNTIME_RELEASE_VERSION" .
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime -ldflags "-s -w -X github.com/hypermodeinc/modus/runtime/app.version=$RUNTIME_RELEASE_VERSION" .
 
 # build the container image
 FROM ubuntu:24.04

--- a/runtime/.goreleaser.yaml
+++ b/runtime/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X github.com/hypermodeinc/modus/runtime/config.version={{.Version}}
+      - -X github.com/hypermodeinc/modus/runtime/app.version={{.Version}}
       - >-
         {{- if eq .Os "windows"}}
           -checklinkname=0

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,6 +1,6 @@
 EXECUTABLE := modus_runtime
 VERSION := $(shell git describe --tags --always --match 'runtime/*' | sed 's/^runtime\///')
-LDFLAGS := -s -w -X github.com/hypermodeinc/modus/runtime/config.version=$(VERSION)
+LDFLAGS := -s -w -X github.com/hypermodeinc/modus/runtime/app.version=$(VERSION)
 
 ifneq ($(OS), Windows_NT)
 	OS := $(shell uname -s)


### PR DESCRIPTION
## Description

This fixes an issue where the Runtime version is reported as `"(unknown)"`.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
