### PR TITLE
fix: Update Hypermode api key reading for modus local dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - fix: Update Hypermode api key reading for modus local dev [#805](https://github.com/hypermodeinc/modus/pull/805)
 
-## 2025-04-01 - CLI 0.17.8
+## 2025-04-01 - CLI 0.17.2
 
 - fix: Update Hypermode api key reading for modus local dev [#805](https://github.com/hypermodeinc/modus/pull/805)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # Change Log
 
-## 2025-03-29 - Runtime 0.17.8
+## 2025-04-01 - Runtime 0.17.8
+
+- fix: Update Hypermode api key reading for modus local dev [#805](https://github.com/hypermodeinc/modus/pull/805)
+
+## 2025-04-01 - CLI 0.17.8
 
 - fix: Update Hypermode api key reading for modus local dev [#805](https://github.com/hypermodeinc/modus/pull/805)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-03-29 - Runtime 0.17.8
+
+- fix: Update Hypermode api key reading for modus local dev [#805](https://github.com/hypermodeinc/modus/pull/805)
+
 ## 2025-03-28 - Runtime 0.17.7
 
 - feat: support new Dgraph connection string format [#803](https://github.com/hypermodeinc/modus/pull/803)

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -164,8 +164,8 @@ export default class DevCommand extends BaseCommand {
       ...process.env,
       MODUS_ENV: "dev",
       HYP_EMAIL: hypSettings.email,
-      HYP_JWT: hypSettings.jwt,
-      HYP_ORG_ID: hypSettings.orgId,
+      HYP_API_KEY: hypSettings.apiKey,
+      HYP_WORKSPACE_ID: hypSettings.workspaceId,
     };
 
     // Spawn the runtime child process

--- a/cli/src/util/hypermode.ts
+++ b/cli/src/util/hypermode.ts
@@ -14,8 +14,8 @@ import chalk from "chalk";
 
 type HypSettings = {
   email?: string;
-  jwt?: string;
-  orgId?: string;
+  apiKey?: string;
+  workspaceId?: string;
 };
 
 export async function readHypermodeSettings(): Promise<HypSettings> {
@@ -28,8 +28,8 @@ export async function readHypermodeSettings(): Promise<HypSettings> {
     const settings = JSON.parse(await fs.readFile(path, "utf-8"));
     return {
       email: settings.HYP_EMAIL,
-      jwt: settings.HYP_JWT,
-      orgId: settings.HYP_ORG_ID,
+      apiKey: settings.HYP_API_KEY,
+      workspaceId: settings.HYP_WORKSPACE_ID,
     };
   } catch (e) {
     console.warn(chalk.yellow("Error reading " + path), e);

--- a/runtime/models/models.go
+++ b/runtime/models/models.go
@@ -99,7 +99,7 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 					return empty, fmt.Errorf("model %s is not available in the local dev environment", model.SourceModel)
 				}
 			case http.StatusUnauthorized:
-				return empty, fmt.Errorf("invalid or expired API key")
+				return empty, fmt.Errorf("invalid or expired API key. Please use `hyp login` to create a new API key")
 			case http.StatusForbidden:
 				return empty, fmt.Errorf("API key is disabled or usage limit exceeded")
 			case http.StatusTooManyRequests:

--- a/runtime/models/models.go
+++ b/runtime/models/models.go
@@ -93,8 +93,17 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 		var empty TResult
 		var httpe *utils.HttpError
 		if errors.As(err, &httpe) {
-			if app.IsDevEnvironment() && httpe.StatusCode == http.StatusNotFound {
-				return empty, fmt.Errorf("model %s is not available in the local dev environment", model.SourceModel)
+			switch httpe.StatusCode {
+			case http.StatusNotFound:
+				if app.IsDevEnvironment() {
+					return empty, fmt.Errorf("model %s is not available in the local dev environment", model.SourceModel)
+				}
+			case http.StatusUnauthorized:
+				return empty, fmt.Errorf("invalid or expired API key")
+			case http.StatusForbidden:
+				return empty, fmt.Errorf("API key is disabled or usage limit exceeded")
+			case http.StatusTooManyRequests:
+				return empty, fmt.Errorf("rate limit exceeded")
 			}
 		}
 


### PR DESCRIPTION
## Description

Based on the `hyp-cli` change:

<img width="977" alt="image" src="https://github.com/user-attachments/assets/6127990a-f48b-438d-8fc9-c03cff87ab61" />

Update the CLI/runtime code to handle `HYP_API_KEY` and `HYP_WORKSPACE_ID`.
This makes sure modus local dev with shared Hypermode models work again.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
