### PR TITLE
chore: misc repository maintenance

### DIFF
--- a/.github/workflows/ci-cli-build.yml
+++ b/.github/workflows/ci-cli-build.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-cli-build.yml
       - cli/**
 
 permissions:

--- a/.github/workflows/ci-cli-lint.yml
+++ b/.github/workflows/ci-cli-lint.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-cli-lint.yml
       - cli/**
 
 permissions:

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           working-directory: ${{ matrix.dir }}
           version: latest
-          args: --timeout=10m
+          args: --timeout=10m --config=.trunk/configs/.golangci.yaml

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           working-directory: ${{ matrix.dir }}
           version: latest
-          args: --timeout=10m --config=/.trunk/configs/.golangci.yaml
+          args: --timeout=10m --config=${{ github.workspace }}/.trunk/configs/.golangci.yaml

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           working-directory: ${{ matrix.dir }}
           version: latest
-          args: --timeout=10m --config=.trunk/configs/.golangci.yaml
+          args: --timeout=10m --config=/.trunk/configs/.golangci.yaml

--- a/.github/workflows/ci-go-lint.yml
+++ b/.github/workflows/ci-go-lint.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-go-lint.yml
       - "**/*.go"
       - "**/go.mod"
 

--- a/.github/workflows/ci-go-test.yml
+++ b/.github/workflows/ci-go-test.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-go-test.yml
       - "**/*.go"
       - "**/go.mod"
       - "**/testdata/**"

--- a/.github/workflows/ci-release-info-build.yaml
+++ b/.github/workflows/ci-release-info-build.yaml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-release-info-build.yaml
       - tools/release-info/**
 
 permissions:

--- a/.github/workflows/ci-release-info-lint.yaml
+++ b/.github/workflows/ci-release-info-lint.yaml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-release-info-lint.yaml
       - tools/release-info/**
 
 permissions:

--- a/.github/workflows/ci-runtime-integration-tests.yml
+++ b/.github/workflows/ci-runtime-integration-tests.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-runtime-integration-tests.yml
       - runtime/**
 
 permissions:

--- a/.github/workflows/ci-sdk-as-build.yml
+++ b/.github/workflows/ci-sdk-as-build.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-sdk-as-build.yml
       - sdk/assemblyscript/**
 
 permissions:

--- a/.github/workflows/ci-sdk-as-lint.yml
+++ b/.github/workflows/ci-sdk-as-lint.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-sdk-as-lint.yml
       - sdk/assemblyscript/**
 
 permissions:

--- a/.github/workflows/ci-sdk-as-test.yml
+++ b/.github/workflows/ci-sdk-as-test.yml
@@ -8,6 +8,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - .github/workflows/ci-sdk-as-test.yml
       - sdk/assemblyscript/**
 
 permissions:

--- a/.trunk/configs/.golangci.yaml
+++ b/.trunk/configs/.golangci.yaml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.10
+  version: 1.22.12
 
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
@@ -22,23 +22,23 @@ runtimes:
 lint:
   enabled:
     - taplo@0.9.3
-    - trivy@0.60.0
-    - renovate@39.190.1
+    - trivy@0.61.0
+    - renovate@39.230.2
     - actionlint@1.7.7
-    - checkov@3.2.382
+    - checkov@3.2.396
     - git-diff-check
     - gofmt@1.20.4
-    - golangci-lint@1.64.6
+    - golangci-lint@1.64.8
     - hadolint@2.12.1-beta
     - markdownlint@0.44.0
-    - osv-scanner@1.9.2
+    - osv-scanner@2.0.0
     - prettier@3.5.3:
         packages:
           - assemblyscript-prettier@3.0.1
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trufflehog@3.88.15
-    - yamllint@1.35.1
+    - trufflehog@3.88.20
+    - yamllint@1.37.0
   definitions:
     - name: osv-scanner
       commands:

--- a/runtime/collections/vector.go
+++ b/runtime/collections/vector.go
@@ -74,7 +74,7 @@ func createIndexObject(searchMethod manifest.SearchMethodInfo, searchMethodName 
 		vectorIndex.Type = sequential.SequentialVectorIndexType
 		vectorIndex.VectorIndex = sequential.NewSequentialVectorIndex(searchMethodName, searchMethod.Embedder)
 	default:
-		return nil, fmt.Errorf("Unknown index type: %s", searchMethod.Index.Type)
+		return nil, fmt.Errorf("unknown index type: %s", searchMethod.Index.Type)
 	}
 
 	return vectorIndex, nil

--- a/runtime/graphql/graphql.go
+++ b/runtime/graphql/graphql.go
@@ -91,9 +91,9 @@ func handleGraphQLRequest(w http.ResponseWriter, r *http.Request) {
 		logger.Warn(ctx).Msg(msg)
 		utils.WriteJsonContentHeader(w)
 		if ok, _ := gqlRequest.IsIntrospectionQuery(); ok {
-			_, _ = w.Write([]byte(`{"data":{"__schema":{"types":[]}}}`))
+			fmt.Fprint(w, `{"data":{"__schema":{"types":[]}}}`)
 		} else {
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"errors":[{"message":"%s"}]}`, msg)))
+			fmt.Fprintf(w, `{"errors":[{"message":"%s"}]}`, msg)
 		}
 		return
 	}

--- a/runtime/languages/assemblyscript/tests/special_test.go
+++ b/runtime/languages/assemblyscript/tests/special_test.go
@@ -48,14 +48,14 @@ func GetRuntimeTypeInfo(mod wasm.Module, md *metadata.Metadata) (string, error) 
 	gbl := mod.ExportedGlobal("__rtti_base")
 	offset := uint32(gbl.Get())
 	sb.WriteString("\nRuntime type information:\n")
-	sb.WriteString(fmt.Sprintf("base: 0x%x\n", offset))
+	fmt.Fprintf(sb, "base: 0x%x\n", offset)
 
 	len, ok := mod.Memory().ReadUint32Le(offset)
 	offset += 4
 	if !ok {
 		return "", fmt.Errorf("failed to read length")
 	}
-	sb.WriteString(fmt.Sprintf("length: %v\n", len))
+	fmt.Fprintf(sb, "length: %v\n", len)
 
 	sb.WriteString("\n")
 
@@ -81,7 +81,7 @@ func GetRuntimeTypeInfo(mod wasm.Module, md *metadata.Metadata) (string, error) 
 			}
 		}
 
-		sb.WriteString(fmt.Sprintf("%v: %s\n", i, typeName))
+		fmt.Fprintf(sb, "%v: %s\n", i, typeName)
 
 		f, ok := mod.Memory().ReadUint32Le(offset)
 		offset += 4

--- a/runtime/middleware/jwt.go
+++ b/runtime/middleware/jwt.go
@@ -78,7 +78,7 @@ func Shutdown() {
 func HandleJWT(next http.Handler) http.Handler {
 	var jwtParser = jwt.NewParser()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var ctx context.Context = r.Context()
+		ctx := r.Context()
 		tokenStr := r.Header.Get("Authorization")
 		if tokenStr != "" {
 			if s, found := strings.CutPrefix(tokenStr, "Bearer "); found {

--- a/runtime/models/hypermode.go
+++ b/runtime/models/hypermode.go
@@ -36,7 +36,7 @@ func getHypermodeModelEndpointUrl(model *manifest.ModelInfo) (string, error) {
 	if _hypermodeModelHost == "" {
 		_hypermodeModelHost = os.Getenv("HYPERMODE_MODEL_HOST")
 		if _hypermodeModelHost == "" {
-			return "", fmt.Errorf("Hypermode hosted models are not available in this environment")
+			return "", fmt.Errorf("hypermode hosted models are not available in this environment")
 		}
 	}
 	endpoint := fmt.Sprintf("http://%s.%s/%[1]s:predict", strings.ToLower(model.Name), _hypermodeModelHost)

--- a/sdk/go/examples/http/main.go
+++ b/sdk/go/examples/http/main.go
@@ -32,7 +32,7 @@ func GetRandomQuote() (*Quote, error) {
 		return nil, err
 	}
 	if !response.Ok() {
-		return nil, fmt.Errorf("Failed to fetch quote. Received: %d %s", response.Status, response.StatusText)
+		return nil, fmt.Errorf("failed to fetch quote. Received: %d %s", response.Status, response.StatusText)
 	}
 
 	// The API returns an array of quotes, but we only want the first one.
@@ -119,7 +119,7 @@ func CreateGithubIssue(owner, repo, title, body string) (*Issue, error) {
 		return nil, err
 	}
 	if !response.Ok() {
-		return nil, fmt.Errorf("Failed to create issue. Received: %d %s", response.Status, response.StatusText)
+		return nil, fmt.Errorf("failed to create issue. Received: %d %s", response.Status, response.StatusText)
 	}
 
 	// The response will contain the issue data, including the URL of the issue on GitHub.

--- a/sdk/go/examples/mysql/main.go
+++ b/sdk/go/examples/mysql/main.go
@@ -53,7 +53,7 @@ func AddPerson(name string, age int) (*Person, error) {
 
 	response, err := mysql.Execute(connection, query, name, age)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to add person to database: %v", err)
+		return nil, fmt.Errorf("failed to add person to database: %v", err)
 	}
 
 	p := Person{Id: int(response.LastInsertId), Name: name, Age: age}
@@ -65,11 +65,11 @@ func UpdatePersonHome(id int, longitude, latitude float64) (*Person, error) {
 
 	response, err := mysql.Execute(connection, query, longitude, latitude, id)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to update person in database: %v", err)
+		return nil, fmt.Errorf("failed to update person in database: %v", err)
 	}
 
 	if response.RowsAffected != 1 {
-		return nil, fmt.Errorf("Failed to update person with id %d. The record may not exist.", id)
+		return nil, fmt.Errorf("failed to update person with id %d - the record may not exist", id)
 	}
 
 	return GetPerson(id)
@@ -80,11 +80,11 @@ func DeletePerson(id int) (string, error) {
 
 	response, err := mysql.Execute(connection, query, id)
 	if err != nil {
-		return "", fmt.Errorf("Failed to delete person from database: %v", err)
+		return "", fmt.Errorf("failed to delete person from database: %v", err)
 	}
 
 	if response.RowsAffected != 1 {
-		return "", fmt.Errorf("Failed to delete person with id %d. The record may not exist.", id)
+		return "", fmt.Errorf("failed to delete person with id %d - the record may not exist", id)
 	}
 
 	return "success", nil

--- a/sdk/go/examples/postgresql/main.go
+++ b/sdk/go/examples/postgresql/main.go
@@ -53,7 +53,7 @@ func AddPerson(name string, age int) (*Person, error) {
 
 	response, err := postgresql.QueryScalar[int](connection, query, name, age)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to add person to database: %v", err)
+		return nil, fmt.Errorf("failed to add person to database: %v", err)
 	}
 
 	p := Person{Id: response.Value, Name: name, Age: age}
@@ -65,11 +65,11 @@ func UpdatePersonHome(id int, longitude, latitude float64) (*Person, error) {
 
 	response, err := postgresql.Execute(connection, query, longitude, latitude, id)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to update person in database: %v", err)
+		return nil, fmt.Errorf("failed to update person in database: %v", err)
 	}
 
 	if response.RowsAffected != 1 {
-		return nil, fmt.Errorf("Failed to update person with id %d. The record may not exist.", id)
+		return nil, fmt.Errorf("failed to update person with id %d - the record may not exist", id)
 	}
 
 	return GetPerson(id)
@@ -80,11 +80,11 @@ func DeletePerson(id int) (string, error) {
 
 	response, err := postgresql.Execute(connection, query, id)
 	if err != nil {
-		return "", fmt.Errorf("Failed to delete person from database: %v", err)
+		return "", fmt.Errorf("failed to delete person from database: %v", err)
 	}
 
 	if response.RowsAffected != 1 {
-		return "", fmt.Errorf("Failed to delete person with id %d. The record may not exist.", id)
+		return "", fmt.Errorf("failed to delete person with id %d - the record may not exist", id)
 	}
 
 	return "success", nil

--- a/sdk/go/examples/textgeneration/toolcalling.go
+++ b/sdk/go/examples/textgeneration/toolcalling.go
@@ -112,7 +112,7 @@ func GenerateTextWithTools(prompt string) (string, error) {
 					}
 
 				default:
-					return "", fmt.Errorf("Unknown tool call: %s", tc.Function.Name)
+					return "", fmt.Errorf("unknown tool call: %s", tc.Function.Name)
 				}
 
 				// Add the tool's response to the conversation.
@@ -124,7 +124,7 @@ func GenerateTextWithTools(prompt string) (string, error) {
 			return strings.TrimSpace(msg.Content), nil
 		} else {
 			// If the model didn't ask for tools, and didn't return any content, something went wrong.
-			return "", errors.New("Invalid response from model.")
+			return "", errors.New("invalid response from model")
 		}
 	}
 }
@@ -135,7 +135,7 @@ func GenerateTextWithTools(prompt string) (string, error) {
 // This function will return the current time in a given time zone.
 func getCurrentTime(tz string) (string, error) {
 	if !localtime.IsValidTimeZone(tz) {
-		return "", errors.New("Invalid time zone.")
+		return "", errors.New("invalid time zone")
 	}
 
 	now, err := localtime.NowInZone(tz)
@@ -159,7 +159,7 @@ func getUserTimeZone() string {
 func getCurrentTimeInUserTimeZone() (*struct{ Time, Zone string }, error) {
 	tz := os.Getenv("TZ")
 	if tz == "" {
-		return nil, errors.New("Cannot determine user's time zone.")
+		return nil, errors.New("cannot determine user's time zone")
 	}
 	time, err := getCurrentTime(tz)
 	if err != nil {

--- a/sdk/go/pkg/collections/collections.go
+++ b/sdk/go/pkg/collections/collections.go
@@ -88,11 +88,11 @@ func WithNamespace(namespace string) NamespaceOption {
 
 func UpsertBatch(collection string, keys []string, texts []string, labelsArr [][]string, opts ...NamespaceOption) (*CollectionMutationResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if len(texts) == 0 {
-		return nil, fmt.Errorf("Texts is empty")
+		return nil, fmt.Errorf("texts is empty")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -114,7 +114,7 @@ func UpsertBatch(collection string, keys []string, texts []string, labelsArr [][
 	result := hostUpsert(&collection, &nsOpts.namespace, &keys, &texts, &labelsArr)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to upsert")
+		return nil, fmt.Errorf("failed to upsert")
 	}
 
 	return result, nil
@@ -122,7 +122,7 @@ func UpsertBatch(collection string, keys []string, texts []string, labelsArr [][
 
 func Upsert(collection string, key *string, text string, labels []string, opts ...NamespaceOption) (*CollectionMutationResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	keyArr := []string{}
@@ -138,7 +138,7 @@ func Upsert(collection string, key *string, text string, labels []string, opts .
 	}
 
 	if text == "" {
-		return nil, fmt.Errorf("Text is required")
+		return nil, fmt.Errorf("text is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -152,7 +152,7 @@ func Upsert(collection string, key *string, text string, labels []string, opts .
 	result := hostUpsert(&collection, &nsOpts.namespace, &keyArr, &[]string{text}, &labelsArr)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to upsert")
+		return nil, fmt.Errorf("failed to upsert")
 	}
 
 	return result, nil
@@ -160,11 +160,11 @@ func Upsert(collection string, key *string, text string, labels []string, opts .
 
 func Remove(collection, key string, opts ...NamespaceOption) (*CollectionMutationResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if key == "" {
-		return nil, fmt.Errorf("Key is required")
+		return nil, fmt.Errorf("key is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -178,7 +178,7 @@ func Remove(collection, key string, opts ...NamespaceOption) (*CollectionMutatio
 	result := hostDelete(&collection, &nsOpts.namespace, &key)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to delete")
+		return nil, fmt.Errorf("failed to delete")
 	}
 
 	return result, nil
@@ -212,15 +212,15 @@ func WithReturnText(returnText bool) SearchOption {
 
 func Search(collection, searchMethod, text string, opts ...SearchOption) (*CollectionSearchResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	if text == "" {
-		return nil, fmt.Errorf("Text is required")
+		return nil, fmt.Errorf("text is required")
 	}
 
 	sOpts := &SearchOptions{
@@ -236,7 +236,7 @@ func Search(collection, searchMethod, text string, opts ...SearchOption) (*Colle
 	result := hostSearch(&collection, &sOpts.namespaces, &searchMethod, &text, int32(sOpts.limit), sOpts.returnText)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to search")
+		return nil, fmt.Errorf("failed to search")
 	}
 
 	return result, nil
@@ -244,21 +244,21 @@ func Search(collection, searchMethod, text string, opts ...SearchOption) (*Colle
 
 func SearchByVector(collection, searchMethod string, vector []float32, opts ...SearchOption) (*CollectionSearchResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	if len(vector) == 0 {
 		return &CollectionSearchResult{
 			Collection:   collection,
 			Status:       Error,
-			Error:        "Vector is required",
+			Error:        "vector is required",
 			SearchMethod: "",
 			Objects:      nil,
-		}, fmt.Errorf("Vector is required")
+		}, fmt.Errorf("vector is required")
 	}
 
 	sOpts := &SearchOptions{
@@ -274,7 +274,7 @@ func SearchByVector(collection, searchMethod string, vector []float32, opts ...S
 	result := hostSearchByVector(&collection, &sOpts.namespaces, &searchMethod, &vector, int32(sOpts.limit), sOpts.returnText)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to search")
+		return nil, fmt.Errorf("failed to search")
 	}
 
 	return result, nil
@@ -282,15 +282,15 @@ func SearchByVector(collection, searchMethod string, vector []float32, opts ...S
 
 func NnClassify(collection, searchMethod, text string, opts ...NamespaceOption) (*CollectionClassificationResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	if text == "" {
-		return nil, fmt.Errorf("Text is required")
+		return nil, fmt.Errorf("text is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -304,7 +304,7 @@ func NnClassify(collection, searchMethod, text string, opts ...NamespaceOption) 
 	result := hostClassifyText(&collection, &nsOpts.namespace, &searchMethod, &text)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to classify")
+		return nil, fmt.Errorf("failed to classify")
 	}
 
 	return result, nil
@@ -312,11 +312,11 @@ func NnClassify(collection, searchMethod, text string, opts ...NamespaceOption) 
 
 func RecomputeSearchMethod(collection, searchMethod string, opts ...NamespaceOption) (*SearchMethodMutationResult, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -330,7 +330,7 @@ func RecomputeSearchMethod(collection, searchMethod string, opts ...NamespaceOpt
 	result := hostRecomputeIndex(&collection, &nsOpts.namespace, &searchMethod)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to recompute")
+		return nil, fmt.Errorf("failed to recompute")
 	}
 
 	return result, nil
@@ -338,19 +338,19 @@ func RecomputeSearchMethod(collection, searchMethod string, opts ...NamespaceOpt
 
 func ComputeDistance(collection, searchMethod, key1, key2 string, opts ...NamespaceOption) (*CollectionSearchResultObject, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	if key1 == "" {
-		return nil, fmt.Errorf("Key1 is required")
+		return nil, fmt.Errorf("key1 is required")
 	}
 
 	if key2 == "" {
-		return nil, fmt.Errorf("Key2 is required")
+		return nil, fmt.Errorf("key2 is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -364,7 +364,7 @@ func ComputeDistance(collection, searchMethod, key1, key2 string, opts ...Namesp
 	result := hostComputeDistance(&collection, &nsOpts.namespace, &searchMethod, &key1, &key2)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to compute distance")
+		return nil, fmt.Errorf("failed to compute distance")
 	}
 
 	return result, nil
@@ -372,11 +372,11 @@ func ComputeDistance(collection, searchMethod, key1, key2 string, opts ...Namesp
 
 func GetText(collection, key string, opts ...NamespaceOption) (string, error) {
 	if collection == "" {
-		return "", fmt.Errorf("Collection name is required")
+		return "", fmt.Errorf("collection name is required")
 	}
 
 	if key == "" {
-		return "", fmt.Errorf("Key is required")
+		return "", fmt.Errorf("key is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -390,7 +390,7 @@ func GetText(collection, key string, opts ...NamespaceOption) (string, error) {
 	result := hostGetText(&collection, &nsOpts.namespace, &key)
 
 	if result == nil {
-		return "", fmt.Errorf("Failed to get text for key")
+		return "", fmt.Errorf("failed to get text for key")
 	}
 
 	return *result, nil
@@ -398,7 +398,7 @@ func GetText(collection, key string, opts ...NamespaceOption) (string, error) {
 
 func GetTexts(collection string, opts ...NamespaceOption) (map[string]string, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -412,7 +412,7 @@ func GetTexts(collection string, opts ...NamespaceOption) (map[string]string, er
 	result := hostDumpTexts(&collection, &nsOpts.namespace)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to get texts")
+		return nil, fmt.Errorf("failed to get texts")
 	}
 
 	return *result, nil
@@ -420,13 +420,13 @@ func GetTexts(collection string, opts ...NamespaceOption) (map[string]string, er
 
 func GetNamespaces(collection string) ([]string, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	result := hostGetNamespaces(&collection)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to get namespaces")
+		return nil, fmt.Errorf("failed to get namespaces")
 	}
 
 	return *result, nil
@@ -434,15 +434,15 @@ func GetNamespaces(collection string) ([]string, error) {
 
 func GetVector(collection, searchMethod, key string, opts ...NamespaceOption) ([]float32, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if searchMethod == "" {
-		return nil, fmt.Errorf("Search method is required")
+		return nil, fmt.Errorf("search method is required")
 	}
 
 	if key == "" {
-		return nil, fmt.Errorf("Key is required")
+		return nil, fmt.Errorf("key is required")
 	}
 
 	nsOpts := &NamespaceOptions{
@@ -456,7 +456,7 @@ func GetVector(collection, searchMethod, key string, opts ...NamespaceOption) ([
 	result := hostGetVector(&collection, &nsOpts.namespace, &searchMethod, &key)
 
 	if result == nil {
-		return nil, fmt.Errorf("Failed to get vector for key")
+		return nil, fmt.Errorf("failed to get vector for key")
 	}
 
 	return *result, nil
@@ -464,11 +464,11 @@ func GetVector(collection, searchMethod, key string, opts ...NamespaceOption) ([
 
 func GetLabels(collection, key string, opts ...NamespaceOption) ([]string, error) {
 	if collection == "" {
-		return nil, fmt.Errorf("Collection name is required")
+		return nil, fmt.Errorf("collection name is required")
 	}
 
 	if key == "" {
-		return nil, fmt.Errorf("Key is required")
+		return nil, fmt.Errorf("key is required")
 	}
 
 	nsOpts := &NamespaceOptions{

--- a/sdk/go/pkg/dgraph/dgraph.go
+++ b/sdk/go/pkg/dgraph/dgraph.go
@@ -119,7 +119,7 @@ func (m *Mutation) WithCondition(cond string) *Mutation {
 func Execute(connection string, request *Request) (*Response, error) {
 	response := hostExecuteQuery(&connection, request)
 	if response == nil {
-		return nil, errors.New("Failed to execute the DQL query.")
+		return nil, errors.New("failed to execute the DQL query")
 	}
 
 	return response, nil
@@ -148,7 +148,7 @@ func ExecuteMutations(connection string, mutations ...*Mutation) (*Response, err
 func AlterSchema(connection, schema string) error {
 	resp := hostAlterSchema(&connection, &schema)
 	if resp == nil {
-		return errors.New("Failed to alter the schema.")
+		return errors.New("failed to alter the schema")
 	}
 
 	return nil
@@ -158,7 +158,7 @@ func AlterSchema(connection, schema string) error {
 func DropAttr(connection, attr string) error {
 	response := hostDropAttribute(&connection, &attr)
 	if response == nil {
-		return errors.New("Failed to drop the attribute.")
+		return errors.New("failed to drop the attribute")
 	}
 
 	return nil
@@ -168,7 +168,7 @@ func DropAttr(connection, attr string) error {
 func DropAll(connection string) error {
 	response := hostDropAllData(&connection)
 	if response == nil {
-		return errors.New("Failed to drop all data.")
+		return errors.New("failed to drop all data")
 	}
 
 	return nil

--- a/sdk/go/pkg/graphql/graphql.go
+++ b/sdk/go/pkg/graphql/graphql.go
@@ -29,7 +29,7 @@ func Execute[T any](connection, statement string, variables map[string]any) (*Re
 	response := hostExecuteQuery(&connection, &statement, &varsStr)
 
 	if response == nil {
-		return nil, errors.New("Failed to execute the GQL query.")
+		return nil, errors.New("failed to execute the GQL query")
 	}
 
 	var result Response[T]

--- a/sdk/go/pkg/http/http.go
+++ b/sdk/go/pkg/http/http.go
@@ -29,13 +29,12 @@ func Fetch[T *Request | string](requestOrUrl T, options ...*RequestOptions) (*Re
 	}
 
 	if _, err := url.ParseRequestURI(request.Url); err != nil {
-		return nil, errors.New("Invalid URL")
+		return nil, errors.New("invalid URL")
 	}
 
 	response := hostFetch(request)
 	if response == nil {
-		msg := "HTTP fetch failed. Check the logs for more information."
-		return nil, errors.New(msg)
+		return nil, errors.New("HTTP fetch failed - check the logs for more information")
 	}
 
 	return response, nil

--- a/sdk/go/pkg/neo4j/neo4j.go
+++ b/sdk/go/pkg/neo4j/neo4j.go
@@ -159,7 +159,7 @@ func GetRecordValue[T RecordValue](record *Record, key string) (T, error) {
 			}
 		}
 	}
-	return *new(T), fmt.Errorf("Key not found in record")
+	return *new(T), fmt.Errorf("key not found in record")
 
 }
 
@@ -201,7 +201,7 @@ func GetProperty[T PropertyValue](e Entity, key string) (T, error) {
 	var val T
 	rawVal, ok := e.GetProperties()[key]
 	if !ok {
-		return *new(T), fmt.Errorf("Key not found in node")
+		return *new(T), fmt.Errorf("key not found in node")
 	}
 	switch any(val).(type) {
 	case int64:

--- a/sdk/go/pkg/vectors/vectors.go
+++ b/sdk/go/pkg/vectors/vectors.go
@@ -165,7 +165,7 @@ func Mean[T constraints.Integer | constraints.Float](a []T) T {
 // Min computes the minimum element in a vector.
 func Min[T constraints.Integer | constraints.Float](a []T) T {
 	assertNonEmpty(a)
-	var result T = a[0]
+	result := a[0]
 	for i := 0; i < len(a); i++ {
 		if a[i] < result {
 			result = a[i]
@@ -177,7 +177,7 @@ func Min[T constraints.Integer | constraints.Float](a []T) T {
 // Max computes the maximum element in a vector.
 func Max[T constraints.Integer | constraints.Float](a []T) T {
 	assertNonEmpty(a)
-	var result T = a[0]
+	result := a[0]
 	for i := 0; i < len(a); i++ {
 		if a[i] > result {
 			result = a[i]

--- a/sdk/go/tools/modus-go-build/codegen/postprocess.go
+++ b/sdk/go/tools/modus-go-build/codegen/postprocess.go
@@ -54,9 +54,9 @@ func writePostProcessHeader(b *bytes.Buffer, meta *metadata.Metadata, imports ma
 	for pkg, name := range imports {
 		if pkg != "" && pkg != "unsafe" && pkg != meta.Module {
 			if pkg == name || strings.HasSuffix(pkg, "/"+name) {
-				b.WriteString(fmt.Sprintf("\t\"%s\"\n", pkg))
+				fmt.Fprintf(b, "\t\"%s\"\n", pkg)
 			} else {
-				b.WriteString(fmt.Sprintf("\t%s \"%s\"\n", name, pkg))
+				fmt.Fprintf(b, "\t%s \"%s\"\n", name, pkg)
 			}
 		}
 	}
@@ -97,12 +97,12 @@ func __new(id int) unsafe.Pointer {
 		ptrName := utils.GetNameForType(t.Name, imports)
 		elementName := utils.GetUnderlyingType(ptrName)
 		found = true
-		buf.WriteString(fmt.Sprintf(`	case %d:
+		fmt.Fprintf(buf, `	case %d:
 		o := new(%s)
 		p := unsafe.Pointer(o)
 		__pins[p]++
 		return p
-`, t.Id, elementName))
+`, t.Id, elementName)
 	}
 	buf.WriteString("\t}\n\n")
 	buf.WriteString("\treturn nil\n}\n")
@@ -133,12 +133,12 @@ func __make(id, size int) unsafe.Pointer {
 	for _, t := range types {
 		name := utils.GetNameForType(t.Name, imports)
 		if utils.IsSliceType(name) || utils.IsMapType(name) {
-			b.WriteString(fmt.Sprintf(`	case %d:
+			fmt.Fprintf(b, `	case %d:
 		o := make(%s, size)
 		p := unsafe.Pointer(&o)
 		__pins[p]++
 		return p
-`, t.Id, name))
+`, t.Id, name)
 		}
 	}
 
@@ -159,9 +159,9 @@ func __read_map(id int, m unsafe.Pointer) uint64 {
 		if utils.IsMapType(t.Name) {
 			found = true
 			typeName := utils.GetNameForType(t.Name, imports)
-			buf.WriteString(fmt.Sprintf(`	case %d:
+			fmt.Fprintf(buf, `	case %d:
 		return __doReadMap(*(*%s)(m))
-`, t.Id, typeName))
+`, t.Id, typeName)
 		}
 	}
 	buf.WriteString("\t}\n\n")
@@ -207,9 +207,9 @@ func __write_map(id int, m, keys, values unsafe.Pointer) {
 			kt, vt := utils.GetMapSubtypes(t.Name)
 			keyTypeName := utils.GetNameForType(kt, imports)
 			valTypeName := utils.GetNameForType(vt, imports)
-			buf.WriteString(fmt.Sprintf(`	case %d:
+			fmt.Fprintf(buf, `	case %d:
 		__doWriteMap(*(*%s)(m), *(*[]%s)(keys), *(*[]%s)(values))
-`, t.Id, typeName, keyTypeName, valTypeName))
+`, t.Id, typeName, keyTypeName, valTypeName)
 		}
 	}
 	buf.WriteString("\t}\n")

--- a/sdk/go/tools/modus-go-build/codegen/preprocess.go
+++ b/sdk/go/tools/modus-go-build/codegen/preprocess.go
@@ -221,9 +221,9 @@ func writePreProcessHeader(b *bytes.Buffer, imports map[string]string) {
 	b.WriteString("import (\n")
 	for pkg, name := range imports {
 		if pkg == name || strings.HasSuffix(pkg, "/"+name) {
-			b.WriteString(fmt.Sprintf("\t\"%s\"\n", pkg))
+			fmt.Fprintf(b, "\t\"%s\"\n", pkg)
 		} else {
-			b.WriteString(fmt.Sprintf("\t%s \"%s\"\n", name, pkg))
+			fmt.Fprintf(b, "\t%s \"%s\"\n", name, pkg)
 		}
 	}
 	b.WriteString(")\n\n")

--- a/sdk/go/tools/modus-go-build/config/config.go
+++ b/sdk/go/tools/modus-go-build/config/config.go
@@ -95,7 +95,7 @@ func getCompilerDefaultPath() (string, error) {
 
 	path, err := exec.LookPath("tinygo")
 	if err != nil {
-		return "", fmt.Errorf("TinyGo not found in PATH.\nSee https://tinygo.org/getting-started/install for installation instructions.")
+		return "", fmt.Errorf("tinygo not found in PATH - see https://tinygo.org/getting-started/install for installation instructions")
 	}
 
 	return path, nil


### PR DESCRIPTION
#807 broke the linter workflows.  These changes are as a direct result.

- Ensure all workflows with path filters include the workflow file.  That would have caught this in the checks for #807 itself.
- Add a config file for `golangci-lint`.  Put it in the Trunk configs dir, so Trunk will use it also.
- Address remaining linter warnings coming out of the new `golangci-lint`
- Update Trunk and all Trunk plugins to latest.

Note that Trunk is still using v1 of `golangci-lint`.  When it updates to v2, then I'll remove the separate linting workflows and we can just use Trunk alone.