### PR TITLE
fix: initialize the main HTTP handler before starting background services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-04-08 - Runtime 0.17.9
+
+- fix: initialize the main HTTP handler before starting background services [#812](https://github.com/hypermodeinc/modus/pull/812)
+
 ## 2025-04-08 - CLI 0.17.3
 
 - feat: Add update prompt on CLI usage [#811](https://github.com/hypermodeinc/modus/pull/811)

--- a/runtime/httpserver/server.go
+++ b/runtime/httpserver/server.go
@@ -43,7 +43,7 @@ var warningColor = color.New(color.FgYellow)
 // ShutdownTimeout is the time to wait for the server to shutdown gracefully.
 const shutdownTimeout = 5 * time.Second
 
-func Start(ctx context.Context, local bool) {
+func Start(ctx context.Context, mux http.Handler, local bool) {
 
 	port := app.Config().Port()
 
@@ -55,19 +55,15 @@ func Start(ctx context.Context, local bool) {
 		if isIPv6Available() {
 			addresses = append(addresses, fmt.Sprintf("[::1]:%d", port))
 		}
-		startHttpServer(ctx, addresses...)
+		startHttpServer(ctx, mux, addresses...)
 	} else {
 		// Otherwise, listen on all interfaces.
 		addr := fmt.Sprintf(":%d", port)
-		startHttpServer(ctx, addr)
+		startHttpServer(ctx, mux, addr)
 	}
 }
 
-func startHttpServer(ctx context.Context, addresses ...string) {
-
-	// Get the main handler for the server.
-	// Note: This must be done first, because it registers for callback events.
-	mux := GetMainHandler()
+func startHttpServer(ctx context.Context, mux http.Handler, addresses ...string) {
 
 	// Initialize our middleware before starting the server.
 	middleware.Init(ctx)

--- a/runtime/integration_tests/postgresql_integration_test.go
+++ b/runtime/integration_tests/postgresql_integration_test.go
@@ -118,6 +118,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	// setup runtime services
+	mux := httpserver.GetMainHandler()
 	services.Start(ctx)
 	defer services.Stop(ctx)
 
@@ -125,7 +126,7 @@ func TestMain(m *testing.M) {
 	ctx, stop := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
-		httpserver.Start(ctx, true)
+		httpserver.Start(ctx, mux, true)
 		close(done)
 	}()
 

--- a/runtime/main.go
+++ b/runtime/main.go
@@ -41,6 +41,10 @@ func main() {
 	utils.InitSentry()
 	defer utils.FlushSentryEvents()
 
+	// Get the main handler for the HTTP server before starting the services,
+	// so it can register the endpoints as the manifest is loaded.
+	mux := httpserver.GetMainHandler()
+
 	// Start the background services
 	ctx = services.Start(ctx)
 	defer services.Stop(ctx)
@@ -50,5 +54,5 @@ func main() {
 
 	// Start the HTTP server to listen for requests.
 	// Note, this function blocks, and handles shutdown gracefully.
-	httpserver.Start(ctx, local)
+	httpserver.Start(ctx, mux, local)
 }


### PR DESCRIPTION
## Description

This fixes a race condition during startup of the Modus Runtime that would sometimes cause the `/graphql` endpoint to not load.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
