### PR TITLE
ci/fix: improve error handling in release-info script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 # Change Log
 
-## UNRELEASED
-
-- ci/fix: improve error handling in release-info script [#815](https://github.com/hypermodeinc/modus/pull/815)
-
 ## 2025-04-08 - Runtime 0.17.9
 
 - fix: initialize the main HTTP handler before starting background services [#812](https://github.com/hypermodeinc/modus/pull/812)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- ci/fix: improve error handling in release-info script [#815](https://github.com/hypermodeinc/modus/pull/815)
+
 ## 2025-04-08 - Runtime 0.17.9
 
 - fix: initialize the main HTTP handler before starting background services [#812](https://github.com/hypermodeinc/modus/pull/812)

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -40,7 +40,7 @@ async function getLatestVersion(owner: string, repo: string, prefix: string, inc
       return tag.slice(prefix.length);
     }
   } catch (e) {
-    console.error(e);
+    throw new Error(`Error fetching latest release tag of ${owner}/${repo}: ${e}`);
   }
 }
 
@@ -73,8 +73,7 @@ async function getAllVersions(owner: string, repo: string, prefix: string, inclu
     versions = semver.rsort(versions);
     return versions.map((v) => "v" + v);
   } catch (e) {
-    console.error(e);
-    return [];
+    throw new Error(`Error fetching release tags of ${owner}/${repo}: ${e}`);
   }
 }
 


### PR DESCRIPTION
## Description

Previously, errors in this script were only logged to the console. This is dangerous as failures during CI won't be caught, unless you look at the logs. Meaning, the script could generate bad output files and still be released to our releases bucket. And it could go unnoticed for a while, since it looked like the CI pipeline is all green.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [ ] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
