### PR TITLE
fix: validate manifest with new dgraph connection string format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # Change Log
 
-## 2025-04-08 - Runtime 0.17.9
+## 2025-04-09 - Go SDK 0.17.3
+
+- fix: validate manifest with new dgraph connection string format [#817](https://github.com/hypermodeinc/modus/pull/817)
+
+## 2025-04-09 - Runtime 0.17.9
 
 - fix: initialize the main HTTP handler before starting background services [#812](https://github.com/hypermodeinc/modus/pull/812)
 

--- a/sdk/assemblyscript/examples/dgraph/modus.json
+++ b/sdk/assemblyscript/examples/dgraph/modus.json
@@ -12,8 +12,7 @@
     // The {{API_KEY}} will be replaced by the secret provided in the Hypermode Console.
     "dgraph": {
       "type": "dgraph",
-      "grpcTarget": "frozen-mango.grpc.eu-central-1.aws.cloud.dgraph.io:443",
-      "key": "{{API_KEY}}"
+      "connString": "dgraph://example.hypermode.host:443?sslmode=verify-ca&bearertoken={{API_KEY}}"
     }
   }
 }

--- a/sdk/go/examples/dgraph/modus.json
+++ b/sdk/go/examples/dgraph/modus.json
@@ -12,8 +12,7 @@
     // The {{API_KEY}} will be replaced by the secret's value at run time.
     "dgraph": {
       "type": "dgraph",
-      "grpcTarget": "frozen-mango.grpc.eu-central-1.aws.cloud.dgraph.io:443",
-      "key": "{{API_KEY}}"
+      "connString": "dgraph://example.hypermode.host:443?sslmode=verify-ca&bearertoken={{API_KEY}}"
     }
   }
 }


### PR DESCRIPTION
In #803 we added support for the new Dgraph connection string format in the Modus Runtime, and updated the manifest library and Go SDK at that time - but we didn't release an update for the Go SDK (oops).

So mainly this PR is to update the changelog and serve as a commit for the release tag, but the work was already done in #803.

Also updating the examples of both SDKs to use the new format.