### PR TITLE
chore: convert model name to lowercase in OpenAI Models SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- chore: convert model name to lowercase in OpenAI Models SDK [#818](https://github.com/hypermodeinc/modus/pull/818)
+
 ## 2025-04-09 - Go SDK 0.17.3
 
 - fix: validate manifest with new dgraph connection string format [#817](https://github.com/hypermodeinc/modus/pull/817)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 # Change Log
 
-## UNRELEASED
+## 2025-04-09 - AssemblyScript SDK 0.17.5
 
 - chore: convert model name to lowercase in OpenAI Models SDK [#818](https://github.com/hypermodeinc/modus/pull/818)
 
 ## 2025-04-09 - Go SDK 0.17.3
 
 - fix: validate manifest with new dgraph connection string format [#817](https://github.com/hypermodeinc/modus/pull/817)
+- chore: convert model name to lowercase in OpenAI Models SDK [#818](https://github.com/hypermodeinc/modus/pull/818)
 
 ## 2025-04-09 - Runtime 0.17.9
 

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -24,7 +24,7 @@ export class OpenAIChatModel extends Model<OpenAIChatInput, OpenAIChatOutput> {
    * @returns An input object that can be passed to the `invoke` method.
    */
   createInput(messages: RequestMessage[]): OpenAIChatInput {
-    const model = this.info.fullName;
+    const model = this.info.fullName.toLowerCase();
     return <OpenAIChatInput>{ model, messages };
   }
 }

--- a/sdk/assemblyscript/src/models/openai/embeddings.ts
+++ b/sdk/assemblyscript/src/models/openai/embeddings.ts
@@ -33,7 +33,7 @@ export class OpenAIEmbeddingsModel extends Model<
    * The input content must not exceed the maximum token limit of the model.
    */
   createInput<T>(content: T): OpenAIEmbeddingsInput {
-    const model = this.info.fullName;
+    const model = this.info.fullName.toLowerCase();
 
     switch (idof<T>()) {
       case idof<string>():

--- a/sdk/go/pkg/models/openai/chat.go
+++ b/sdk/go/pkg/models/openai/chat.go
@@ -1173,7 +1173,7 @@ type FunctionDefinition struct {
 // Creates an input object for the OpenAI Chat API.
 func (m *ChatModel) CreateInput(messages ...RequestMessage) (*ChatModelInput, error) {
 	return &ChatModelInput{
-		Model:             m.Info().FullName,
+		Model:             strings.ToLower(m.Info().FullName),
 		Messages:          messages,
 		ResponseFormat:    ResponseFormatText,
 		Temperature:       1.0,

--- a/sdk/go/pkg/models/openai/embeddings.go
+++ b/sdk/go/pkg/models/openai/embeddings.go
@@ -11,6 +11,7 @@ package openai
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hypermodeinc/modus/sdk/go/pkg/models"
 )
@@ -118,7 +119,7 @@ func (m *EmbeddingsModel) CreateInput(content any) (*EmbeddingsModelInput, error
 		[][]int, [][]int8, [][]int16, [][]int32, [][]int64:
 
 		return &EmbeddingsModelInput{
-			Model: m.Info().FullName,
+			Model: strings.ToLower(m.Info().FullName),
 			Input: content,
 		}, nil
 	}


### PR DESCRIPTION
## Description

For our upcoming Model Router, we plan to standardize many different providers (Anthropic, Gemini, Hypermode-hosted models from Hugging Face) to the v1 OpenAI API.

One part of that is normalizing the model names to lowercase, because models from Hugging Face are typically mixed case. For example when our user copies the model name from https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct, it will be copied as `meta-llama/Llama-3.2-3B-Instruct`. But we want the Models SDK to send it as `meta-llama/llama-3.2-3b-instruct` in the request body, as our hosted models will now expect them to be lowercased.

Groq also does this for example: https://console.groq.com/docs/model/llama-4-scout-17b-16e-instruct

The OpenAI model names are all lowercased as of today, so this change shouldn't be breaking.

For reference, this is the change to support this normalization on the infra side: https://github.com/hypermodeinc/hyp-cluster/commit/58579478d40fb1a93cc85867832643b3d79c57f7.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
