### PR TITLE
chore: replace GitHub API calls with git ls-remote in release info script

### DIFF
--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -116,7 +116,7 @@ function parseGitTagsOutput(output: string, normalizedPrefix: string): string[] 
 
 async function findLatestReleaseTag(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string | undefined> {
   const repoUrl = `https://github.com/${owner}/${repo}`;
-  const normalizedPrefix = prefix.endsWith("/") ? prefix : prefix;
+  const normalizedPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
   const pattern = `refs/tags/${normalizedPrefix}*`;
 
   const command = `git ls-remote --refs ${repoUrl} ${pattern}`;

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -154,7 +154,7 @@ async function findLatestReleaseTag(owner: string, repo: string, prefix: string,
 
 async function getAllReleaseTags(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string[]> {
   const repoUrl = `https://github.com/${owner}/${repo}`;
-  const normalizedPrefix = prefix.endsWith("/") ? prefix : prefix;
+  const normalizedPrefix = normalizePrefix(prefix);
   const pattern = `refs/tags/${normalizedPrefix}*`;
 
   const command = `git ls-remote --refs ${repoUrl} ${pattern}`;

--- a/tools/release-info/versioninfo.ts
+++ b/tools/release-info/versioninfo.ts
@@ -154,7 +154,7 @@ async function findLatestReleaseTag(owner: string, repo: string, prefix: string,
 
 async function getAllReleaseTags(owner: string, repo: string, prefix: string, includePrerelease: boolean): Promise<string[]> {
   const repoUrl = `https://github.com/${owner}/${repo}`;
-  const normalizedPrefix = normalizePrefix(prefix);
+  const normalizedPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
   const pattern = `refs/tags/${normalizedPrefix}*`;
 
   const command = `git ls-remote --refs ${repoUrl} ${pattern}`;


### PR DESCRIPTION

## Description

This PR replaces the previous approach of using the GitHub REST API (which was prone to rate-limiting), to using git ls-remote.


## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with ,
      , , , etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [ ] I have added an entry to the  file.
  - Add to the UNRELEASED section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
