### PR TITLE
fix: return immediately after encountering JWT parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: return immediately after encountering JWT parse error [#826](https://github.com/hypermodeinc/modus/pull/826)
+
 ## 2025-04-09 - AssemblyScript SDK 0.17.5
 
 - chore: convert model name to lowercase in OpenAI Models SDK [#818](https://github.com/hypermodeinc/modus/pull/818)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Change Log
 
-## UNRELEASED
+## 2025-04-18 - Runtime 0.17.10
 
 - fix: return immediately after encountering JWT parse error [#826](https://github.com/hypermodeinc/modus/pull/826)
 

--- a/runtime/middleware/jwt.go
+++ b/runtime/middleware/jwt.go
@@ -81,7 +81,6 @@ func HandleJWT(next http.Handler) http.Handler {
 			if s, found := strings.CutPrefix(tokenStr, "Bearer "); found {
 				tokenStr = s
 			} else {
-				logger.Error(ctx).Msg("Invalid JWT token format, Bearer required")
 				http.Error(w, "Invalid JWT token format, Bearer required", http.StatusBadRequest)
 				return
 			}
@@ -112,7 +111,6 @@ func HandleJWT(next http.Handler) http.Handler {
 		}
 
 		if tokenStr == "" {
-			logger.Error(ctx).Msg("JWT token not found")
 			http.Error(w, "Access Denied", http.StatusUnauthorized)
 			return
 		}
@@ -148,7 +146,6 @@ func HandleJWT(next http.Handler) http.Handler {
 			}
 		}
 		if !found {
-			logger.Error(ctx).Err(err).Msg("JWT parse error")
 			http.Error(w, "Access Denied", http.StatusUnauthorized)
 			return
 		}

--- a/runtime/middleware/jwt.go
+++ b/runtime/middleware/jwt.go
@@ -150,6 +150,7 @@ func HandleJWT(next http.Handler) http.Handler {
 		if !found {
 			logger.Error(ctx).Err(err).Msg("JWT parse error")
 			http.Error(w, "Access Denied", http.StatusUnauthorized)
+			return
 		}
 
 		if claims, ok := token.Claims.(jwt.MapClaims); ok {

--- a/runtime/middleware/jwt_test.go
+++ b/runtime/middleware/jwt_test.go
@@ -1,0 +1,135 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Dummy http.Handler to track invocation
+func dummyNextHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func generateRSAKey() (*rsa.PrivateKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	return priv, nil
+}
+
+func generateSignedJWT(priv *rsa.PrivateKey, claims jwt.MapClaims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return token.SignedString(priv)
+}
+
+func TestHandleJWT(t *testing.T) {
+	var generatedJWT string
+
+	tests := []struct {
+		name           string
+		headerFunc     func() string
+		setupFunc      func()
+		expectStatus   int
+		expectNextCall bool
+	}{
+		{
+			name:       "Valid JWT",
+			headerFunc: func() string { return "Bearer " + generatedJWT },
+			setupFunc: func() {
+				priv, err := generateRSAKey()
+				if err != nil {
+					panic(err)
+				}
+				claims := jwt.MapClaims{"sub": "test", "exp": time.Now().Add(time.Hour).Unix()}
+				signedJWT, err := generateSignedJWT(priv, claims)
+				if err != nil {
+					panic(err)
+				}
+				globalAuthKeys = &AuthKeys{}
+				globalAuthKeys.setPemPublicKeys(map[string]any{"testkey": &priv.PublicKey})
+				generatedJWT = signedJWT
+			},
+			expectStatus:   http.StatusOK,
+			expectNextCall: true,
+		},
+		{
+			name:       "Expired JWT",
+			headerFunc: func() string { return "Bearer " + generatedJWT },
+			setupFunc: func() {
+				priv, err := generateRSAKey()
+				if err != nil {
+					panic(err)
+				}
+				claims := jwt.MapClaims{"sub": "test", "exp": time.Now().Add(-time.Hour).Unix()}
+				signedJWT, err := generateSignedJWT(priv, claims)
+				if err != nil {
+					panic(err)
+				}
+				globalAuthKeys = &AuthKeys{}
+				globalAuthKeys.setPemPublicKeys(map[string]any{"testkey": &priv.PublicKey})
+				generatedJWT = signedJWT
+			},
+			expectStatus:   http.StatusUnauthorized,
+			expectNextCall: false,
+		},
+		{
+			name:       "No Authorization header",
+			headerFunc: func() string { return "" },
+			setupFunc: func() {
+				globalAuthKeys = &AuthKeys{}
+				globalAuthKeys.setPemPublicKeys(map[string]any{"dummy": []byte("dummy")})
+			},
+			expectStatus:   http.StatusUnauthorized,
+			expectNextCall: false,
+		},
+		{
+			name:       "Malformed JWT",
+			headerFunc: func() string { return "Bearer bad.token" },
+			setupFunc: func() {
+				globalAuthKeys = &AuthKeys{}
+				globalAuthKeys.setPemPublicKeys(map[string]any{"dummy": []byte("dummy")})
+			},
+			expectStatus:   http.StatusUnauthorized,
+			expectNextCall: false,
+		},
+		{
+			name:       "Bad Bearer Prefix",
+			headerFunc: func() string { return "Token sometoken" },
+			setupFunc: func() {
+				globalAuthKeys = &AuthKeys{}
+				globalAuthKeys.setPemPublicKeys(map[string]any{"dummy": []byte("dummy")})
+			},
+			expectStatus:   http.StatusBadRequest,
+			expectNextCall: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/", nil)
+			tt.setupFunc()
+			req.Header.Set("Authorization", tt.headerFunc())
+			mw := HandleJWT(dummyNextHandler(&called))
+			mw.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectStatus {
+				t.Errorf("expected status %d, got %d", tt.expectStatus, rec.Code)
+			}
+			if called != tt.expectNextCall {
+				t.Errorf("expected next handler called: %v, got %v", tt.expectNextCall, called)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

We were missing a return after writing a 401 response upon encountering a JWT parse error. This resulted in the request still going through and eventually calling the function.

This PR fixes this, and adds some unit tests as well for `HandleJWT`.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
