### PR TITLE
fix: Relax postgresql connString regex to allow host to be templated

### DIFF
--- a/lib/manifest/modus_schema.json
+++ b/lib/manifest/modus_schema.json
@@ -211,7 +211,7 @@
                   "connString": {
                     "type": "string",
                     "minLength": 1,
-                    "pattern": "^postgres(?:ql)?:\\/\\/(.*?@)?([0-9a-zA-Z.-]*?)(:\\d+)?(\\/[0-9a-zA-Z.-]+)?(\\?.+)?$",
+                    "pattern": "^postgres(?:ql)?:\\/\\/(.*?@)?([0-9a-zA-Z.{}_-]*?)(:\\d+)?(\\/[0-9a-zA-Z.-]+)?(\\?.+)?$",
                     "description": "The PostgreSQL connection string in URI format.",
                     "markdownDescription": "The PostgreSQL connection string in URI format.\n\nReference: https://docs.hypermode.com/modus/app-manifest#postgresql-connection"
                   }

--- a/lib/manifest/test/manifest_test.go
+++ b/lib/manifest/test/manifest_test.go
@@ -288,6 +288,7 @@ func TestGetVariablesFromManifest(t *testing.T) {
 		"my-rest-api":              {"API_TOKEN"},
 		"another-rest-api":         {"USERNAME", "PASSWORD"},
 		"neon":                     {"POSTGRESQL_USERNAME", "POSTGRESQL_PASSWORD"},
+		"pg-host":                  {"POSTGRESQL_USERNAME", "POSTGRESQL_PASSWORD", "POSTGRESQL_HOST"},
 		"my-mysql":                 {"MYSQL_USERNAME", "MYSQL_PASSWORD"},
 		"my-dgraph-cloud":          {"DGRAPH_KEY"},
 		"my-neo4j":                 {"NEO4J_USERNAME", "NEO4J_PASSWORD"},

--- a/lib/manifest/test/manifest_test.go
+++ b/lib/manifest/test/manifest_test.go
@@ -97,6 +97,11 @@ func TestReadManifest(t *testing.T) {
 				Type:    manifest.ConnectionTypePostgresql,
 				ConnStr: "postgresql://{{POSTGRESQL_USERNAME}}:{{POSTGRESQL_PASSWORD}}@1.2.3.4:5432/data?sslmode=disable",
 			},
+			"pg-host": manifest.PostgresqlConnectionInfo{
+				Name:    "pg-host",
+				Type:    manifest.ConnectionTypePostgresql,
+				ConnStr: "postgresql://{{POSTGRESQL_USERNAME}}:{{POSTGRESQL_PASSWORD}}@{{POSTGRESQL_HOST}}/db?sslmode=require",
+			},
 			"my-mysql": manifest.MysqlConnectionInfo{
 				Name:    "my-mysql",
 				Type:    manifest.ConnectionTypeMysql,

--- a/lib/manifest/test/valid_modus.json
+++ b/lib/manifest/test/valid_modus.json
@@ -64,6 +64,10 @@
       "type": "postgresql",
       "connString": "postgresql://{{POSTGRESQL_USERNAME}}:{{POSTGRESQL_PASSWORD}}@1.2.3.4:5432/data?sslmode=disable"
     },
+    "pg-host": {
+      "type": "postgresql",
+      "connString": "postgresql://{{POSTGRESQL_USERNAME}}:{{POSTGRESQL_PASSWORD}}@{{POSTGRESQL_HOST}}/db?sslmode=require"
+    },
     "my-mysql": {
       "type": "mysql",
       "connString": "mysql://{{MYSQL_USERNAME}}:{{MYSQL_PASSWORD}}@1.2.3.4:3306/mydb?sslmode=disable"


### PR DESCRIPTION
## Description

Previously, if we set the connection string to something like: `postgresql://{{PG_USER}}:{{PG_PASSWORD}}@{{PG_HOST}}/db?sslmode=require`, the json schema validation will complain, as it is only expecting these set of characters `0-9a-zA-Z.-` for the `host`.

So we can't pass in a different `PG_HOST` based on the environment variable.

This PR fixes this, by relaxing the regex to allow these additional chars `{}_` on the `host`.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [ ] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
