### PR TITLE
feat: Add support for passing in environment variables to the WASM module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-04-29 - Runtime 0.17.11
+
+- feat: Add support for passing in environment variables to the WASM module [#831](https://github.com/hypermodeinc/modus/pull/831)
+
 ## 2025-04-18 - Runtime 0.17.10
 
 - fix: return immediately after encountering JWT parse error [#826](https://github.com/hypermodeinc/modus/pull/826)

--- a/runtime/wasmhost/wasmhost.go
+++ b/runtime/wasmhost/wasmhost.go
@@ -14,6 +14,8 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/hypermodeinc/modus/runtime/functions"
 	"github.com/hypermodeinc/modus/runtime/logger"
@@ -134,6 +136,15 @@ func (host *wasmHost) GetModuleInstance(ctx context.Context, plugin *plugins.Plu
 		WithStdout(wOut).WithStderr(wErr).
 		WithEnv("TZ", timeZone).
 		WithEnv("CLAIMS", jwtClaims)
+
+	for _, env := range os.Environ() {
+		split := strings.SplitN(env, "=", 2)
+		key, val := split[0], split[1]
+		if strings.HasPrefix(key, "MODUS_") {
+			// Remove the MODUS_ prefix
+			cfg = cfg.WithEnv(key[6:], val)
+		}
+	}
 
 	// Instantiate the plugin as a module.
 	// NOTE: This will also invoke the plugin's `_start` function,


### PR DESCRIPTION
## Description

We do not yet have a way to pass in environment variables to the WASM module running the app. That is possible only for variables used in a Modus connection, where you could pass variables with the format `MODUS_<CONNECTION NAME>_<KEY>`, but within the app code users write, that is not accessible, as it's only accessible on the Runtime, and not passed down to the WASM module.

This PR improves this by passing in all environment variables prefixed with `MODUS_` to the WASM module, so that the Modus app code can read it. Note that the `MODUS_` prefix will be stripped before being passed in.

This also implies that if you have a connection secret `MODUS_DGRAPH_API_KEY` for example, then that would be passed to the WASM module as `DGRAPH_API_KEY`.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [ ] I have added or updated unit tests where appropriate, if applicable.
