### PR TITLE
fix: fully install go sdk in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-05-06 - CLI 0.17.4
+
+- fix: fully install go sdk in dev mode [#811](https://github.com/hypermodeinc/modus/pull/811)
+
 ## 2025-04-29 - Go SDK 0.17.4
 
 - fix: Relax postgresql connString regex to allow host to be templated [#830](https://github.com/hypermodeinc/modus/pull/830)

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -25,6 +25,7 @@ import { getAppInfo } from "../../util/appinfo.js";
 import { isOnline, withSpinner } from "../../util/index.js";
 import { readHypermodeSettings } from "../../util/hypermode.js";
 import BuildCommand from "../build/index.js";
+import SDKInstallCommand from "../sdk/install/index.js";
 import { BaseCommand } from "../../baseCommand.js";
 
 const MANIFEST_FILE = "modus.json";
@@ -85,16 +86,7 @@ export default class DevCommand extends BaseCommand {
     }
 
     if (!(await vi.sdkVersionIsInstalled(sdk, sdkVersion))) {
-      const sdkText = `Modus ${sdk} SDK ${sdkVersion}`;
-      await withSpinner(chalk.dim("Downloading and installing " + sdkText), async (spinner) => {
-        try {
-          await installer.installSDK(sdk, sdkVersion);
-        } catch (e) {
-          spinner.fail(chalk.red(`Failed to download ${sdkText}`));
-          throw e;
-        }
-        spinner.succeed(chalk.dim(`Installed ${sdkText}`));
-      });
+      await SDKInstallCommand.run([sdk, sdkVersion, "--no-logo"]);
     }
 
     let runtimeVersion = flags.runtime;

--- a/cli/src/util/versioninfo.ts
+++ b/cli/src/util/versioninfo.ts
@@ -7,7 +7,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import chalk from "chalk";
 import semver from "semver";
+import os from "node:os";
 import path from "node:path";
 import * as http from "./http.js";
 import * as fs from "./fs.js";
@@ -179,7 +181,28 @@ export async function runtimeReleaseExists(version: string): Promise<boolean> {
 }
 
 export async function sdkVersionIsInstalled(sdk: globals.SDK, version: string): Promise<boolean> {
-  return await fs.exists(getSdkPath(sdk, version));
+  // normal check for SDK path
+  const sdkPath = getSdkPath(sdk, version);
+  const installed = await fs.exists(sdkPath);
+  if (!installed) {
+    return false;
+  }
+
+  // extra check for Go build tool, due to prior issue with it not being installed in all cases
+  if (sdk == globals.SDK.Go) {
+    const ext = os.platform() === "win32" ? ".exe" : "";
+    const buildTool = path.join(sdkPath, "modus-go-build" + ext);
+    if (await fs.exists(buildTool)) {
+      return true;
+    }
+
+    // SDK installed, but build tool not found, so delete and return false so it can be reinstalled
+    console.log(chalk.yellow(`ⓘ Detected incomplete installation of Modus Go SDK ${version}.  Reinstalling...`));
+    await fs.rm(sdkPath, { recursive: true, force: true });
+    return false;
+  }
+
+  return installed;
 }
 
 export async function runtimeVersionIsInstalled(version: string): Promise<boolean> {

--- a/cli/src/util/versioninfo.ts
+++ b/cli/src/util/versioninfo.ts
@@ -189,7 +189,7 @@ export async function sdkVersionIsInstalled(sdk: globals.SDK, version: string): 
   }
 
   // extra check for Go build tool, due to prior issue with it not being installed in all cases
-  if (sdk == globals.SDK.Go) {
+  if (sdk === globals.SDK.Go) {
     const ext = os.platform() === "win32" ? ".exe" : "";
     const buildTool = path.join(sdkPath, "modus-go-build" + ext);
     if (await fs.exists(buildTool)) {


### PR DESCRIPTION
## Description

There are three paths that a Modus SDK can be installed via the CLI:

- Explicitly via `modus sdk install`
- Automatically during `modus build`
- Automatically during the build phase of `modus dev`

The first two were correct, but the latter was not installing the `modus-go-build` tool.

Fixed by:
- reused the install command in `modus dev`, just like `modus build` was doing already
- added a check to repair via reinstall if the `modus-go-build` tool is missing

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
