### PR TITLE
fix: reflection error in runtime when starting agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: reflection error in runtime when starting agent [#845](https://github.com/hypermodeinc/modus/pull/845)
+
 ## 2025-05-16 - Runtime and all SDKs 0.18.0-alpha.1
 
 NOTE: This is a pre-release that includes a new feature we are testing called Modus Agents. See the PRs below for more details.

--- a/runtime/utils/utils.go
+++ b/runtime/utils/utils.go
@@ -134,7 +134,7 @@ func GetStructFieldValue(rs reflect.Value, fieldName string, caseInsensitive boo
 	// see https://stackoverflow.com/a/43918797
 	if !rf.CanInterface() {
 		if !rf.CanAddr() {
-			rs2 := reflect.New(rsType.Elem())
+			rs2 := reflect.New(rsType).Elem()
 			rs2.Set(rs)
 			rf = rs2.FieldByIndex(field.Index)
 		}


### PR DESCRIPTION
Fixes a reflection issue found when starting a new agent.

Before:
![image](https://github.com/user-attachments/assets/855c64c2-d8e7-4f35-8e85-135ae33458e2)

After:

![image](https://github.com/user-attachments/assets/ee993163-9e05-4d6b-9db0-f727681c341f)
