### PR TITLE
fix: trigger events correctly during agent reload 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 # Change Log
 
-## UNRELEASED
+## 2025-05-16 Runtime 0.18.0-alpha.2
 
 - fix: reflection error in runtime when starting agent [#845](https://github.com/hypermodeinc/modus/pull/845)
+- fix: trigger events correctly during agent reload [#846](https://github.com/hypermodeinc/modus/pull/846)
 
 ## 2025-05-16 - Runtime and all SDKs 0.18.0-alpha.1
 


### PR DESCRIPTION
During `modus dev`, the agent events were incorrect during a reload for a code change.

Before:
![image](https://github.com/user-attachments/assets/06f268ee-1acf-42fc-86c6-f96e852a0179)

After:

![image](https://github.com/user-attachments/assets/b35c8f0d-f1f0-4147-8574-0e30f480c3c7)

