### PR TITLE
fix: pass pre-release flags properly to subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-05-16 CLI 0.18.0
+
+- fix: pass pre-release flags properly to subcommands [#847](https://github.com/hypermodeinc/modus/pull/847)
+
 ## 2025-05-16 Runtime 0.18.0-alpha.2
 
 - fix: reflection error in runtime when starting agent [#845](https://github.com/hypermodeinc/modus/pull/845)

--- a/cli/src/commands/dev/index.ts
+++ b/cli/src/commands/dev/index.ts
@@ -80,6 +80,7 @@ export default class DevCommand extends BaseCommand {
 
     const app = await getAppInfo(appPath);
     const { sdk, sdkVersion } = app;
+    const prerelease = vi.isPrerelease(sdkVersion) || flags.prerelease;
 
     if (!flags["no-logo"]) {
       this.log(getHeader(this.config.version));
@@ -109,7 +110,7 @@ export default class DevCommand extends BaseCommand {
         }
       }
     } else if (await isOnline()) {
-      const version = await vi.findLatestCompatibleRuntimeVersion(sdk, sdkVersion, flags.prerelease);
+      const version = await vi.findLatestCompatibleRuntimeVersion(sdk, sdkVersion, prerelease);
       if (version && !(await vi.runtimeVersionIsInstalled(version))) {
         const runtimeText = `Modus Runtime ${version}`;
         await withSpinner(chalk.dim("Downloading and installing " + runtimeText), async (spinner) => {
@@ -128,7 +129,7 @@ export default class DevCommand extends BaseCommand {
       }
       runtimeVersion = version;
     } else {
-      const version = await vi.findCompatibleInstalledRuntimeVersion(sdk, sdkVersion, flags.prerelease);
+      const version = await vi.findCompatibleInstalledRuntimeVersion(sdk, sdkVersion, prerelease);
       if (!version) {
         this.logError("Could not find a compatible Modus runtime version. Please try again when you have an internet connection.");
         return;

--- a/cli/src/commands/new/index.ts
+++ b/cli/src/commands/new/index.ts
@@ -305,7 +305,11 @@ export default class NewCommand extends BaseCommand {
         }
       }
       if (updateSDK) {
-        await SDKInstallCommand.run([sdk, latestVersion!, "--no-logo"]);
+        const sdkInstallArgs = [sdk, latestVersion!, "--no-logo"];
+        if (prerelease) {
+          sdkInstallArgs.push("--prerelease");
+        }
+        await SDKInstallCommand.run(sdkInstallArgs);
         installedSdkVersion = latestVersion;
       }
     }

--- a/cli/src/util/versioninfo.ts
+++ b/cli/src/util/versioninfo.ts
@@ -311,7 +311,9 @@ export async function findLatestCompatibleRuntimeVersion(sdk: globals.SDK, sdkVe
       compatibleVersions = versions.filter((v) => semver.satisfies(v.slice(1), constraint, { includePrerelease: true }));
     }
     if (compatibleVersions.length > 0) {
-      return compatibleVersions[0];
+      // Sort in descending order and return the latest version
+      compatibleVersions = semver.rsort(compatibleVersions.map((v) => v.slice(1)));
+      return "v" + compatibleVersions[0];
     }
   }
 }


### PR DESCRIPTION
- `modus new --prerelease` should forward the pre-release flag to the sdk install subcommand when needed
- `modus dev` should not require `--prerelease` if the app is already using a pre-release SDK version

Versioning this as `0.18.0` to align with  current cycle