### PR TITLE
fix: correct agent base event stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-05-19 - Go SDK 0.18.0-alpha.2
+
+- fix: correct agent base event stubs [#848](https://github.com/hypermodeinc/modus/pull/848)
+
 ## 2025-05-16 CLI 0.18.0
 
 - fix: pass pre-release flags properly to subcommands [#847](https://github.com/hypermodeinc/modus/pull/847)

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -221,11 +221,15 @@ func (a *AgentBase) OnStart() error {
 	return nil
 }
 
-func (a *AgentBase) OnStop() error {
+func (a *AgentBase) OnSuspend() error {
 	return nil
 }
 
-func (a *AgentBase) OnReload() error {
+func (a *AgentBase) OnRestore() error {
+	return nil
+}
+
+func (a *AgentBase) OnTerminate() error {
 	return nil
 }
 


### PR DESCRIPTION
This was missed in #843 