### PR TITLE
fix: omit parallel_tool_calls in Go OpenAI SDK if it is set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: omit parallel_tool_calls in Go OpenAI SDK if it is set to true [#849](https://github.com/hypermodeinc/modus/pull/849)
+
 ## 2025-05-19 - Go SDK 0.18.0-alpha.2
 
 - fix: correct agent base event stubs [#848](https://github.com/hypermodeinc/modus/pull/848)

--- a/sdk/go/pkg/models/openai/chat.go
+++ b/sdk/go/pkg/models/openai/chat.go
@@ -1216,7 +1216,8 @@ func (mi *ChatModelInput) MarshalJSON() ([]byte, error) {
 	}
 
 	// don't send parallel_tool_calls if tools are not present
-	if len(mi.Tools) == 0 {
+	// or if parallel_tool_calls is true (default)
+	if len(mi.Tools) == 0 || mi.ParallelToolCalls {
 		b, err = sjson.DeleteBytes(b, "parallel_tool_calls")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description

We're already doing this for the Assemblyscript SDK: https://github.com/hypermodeinc/modus/blob/ef37f4b1922a4b41de15a173d394e35434a41886/sdk/assemblyscript/src/models/openai/chat.ts#L250

This is needed for working with OpenAI's o1 and o3 models, as they dont support `parallel_tool_calls`. even if we set it to false, we'll still get a 400 error.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.
- [x] I have formatted and linted my code with Trunk, per the instructions in
      [the contributing guide](https://github.com/hypermodeinc/modus/blob/main/CONTRIBUTING.md#trunk).

If the PR includes a _code change_, then also check the following boxes. _(If not, then delete the
next section.)_

- [x] I have added an entry to the `CHANGELOG.md` file.
  - Add to the "UNRELEASED" section at the top of the file, creating one if it doesn't yet exist.
  - Be sure to include the link to this PR, and please sort the section numerically by PR number.
- [x] I have manually tested the new or modified code, and it appears to behave correctly.
- [x] I have added or updated unit tests where appropriate, if applicable.
