### PR TITLE
chore: update json-as and remove hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
+
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 
 - fix: omit parallel_tool_calls in Go OpenAI SDK if it is set to true [#849](https://github.com/hypermodeinc/modus/pull/849)

--- a/sdk/assemblyscript/examples/agents/package-lock.json
+++ b/sdk/assemblyscript/examples/agents/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/agents/package-lock.json
+++ b/sdk/assemblyscript/examples/agents/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/agents/package.json
+++ b/sdk/assemblyscript/examples/agents/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/agents/package.json
+++ b/sdk/assemblyscript/examples/agents/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/auth/package-lock.json
+++ b/sdk/assemblyscript/examples/auth/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/auth/package-lock.json
+++ b/sdk/assemblyscript/examples/auth/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/auth/package.json
+++ b/sdk/assemblyscript/examples/auth/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/auth/package.json
+++ b/sdk/assemblyscript/examples/auth/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/classification/package-lock.json
+++ b/sdk/assemblyscript/examples/classification/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/classification/package-lock.json
+++ b/sdk/assemblyscript/examples/classification/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/collections/package-lock.json
+++ b/sdk/assemblyscript/examples/collections/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/collections/package-lock.json
+++ b/sdk/assemblyscript/examples/collections/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/collections/package.json
+++ b/sdk/assemblyscript/examples/collections/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/collections/package.json
+++ b/sdk/assemblyscript/examples/collections/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/dgraph/package-lock.json
+++ b/sdk/assemblyscript/examples/dgraph/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/dgraph/package-lock.json
+++ b/sdk/assemblyscript/examples/dgraph/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/embedding/package-lock.json
+++ b/sdk/assemblyscript/examples/embedding/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/embedding/package-lock.json
+++ b/sdk/assemblyscript/examples/embedding/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/graphql/package-lock.json
+++ b/sdk/assemblyscript/examples/graphql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/graphql/package-lock.json
+++ b/sdk/assemblyscript/examples/graphql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/http/package-lock.json
+++ b/sdk/assemblyscript/examples/http/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/http/package-lock.json
+++ b/sdk/assemblyscript/examples/http/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/mysql/package-lock.json
+++ b/sdk/assemblyscript/examples/mysql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/mysql/package-lock.json
+++ b/sdk/assemblyscript/examples/mysql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/mysql/package.json
+++ b/sdk/assemblyscript/examples/mysql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/mysql/package.json
+++ b/sdk/assemblyscript/examples/mysql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/neo4j/package-lock.json
+++ b/sdk/assemblyscript/examples/neo4j/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/neo4j/package-lock.json
+++ b/sdk/assemblyscript/examples/neo4j/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/neo4j/package.json
+++ b/sdk/assemblyscript/examples/neo4j/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/neo4j/package.json
+++ b/sdk/assemblyscript/examples/neo4j/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/postgresql/package-lock.json
+++ b/sdk/assemblyscript/examples/postgresql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/postgresql/package-lock.json
+++ b/sdk/assemblyscript/examples/postgresql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/textgeneration/package-lock.json
+++ b/sdk/assemblyscript/examples/textgeneration/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/textgeneration/package-lock.json
+++ b/sdk/assemblyscript/examples/textgeneration/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/time/package-lock.json
+++ b/sdk/assemblyscript/examples/time/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/time/package-lock.json
+++ b/sdk/assemblyscript/examples/time/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/time/package.json
+++ b/sdk/assemblyscript/examples/time/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/time/package.json
+++ b/sdk/assemblyscript/examples/time/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/vectors/package-lock.json
+++ b/sdk/assemblyscript/examples/vectors/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/vectors/package-lock.json
+++ b/sdk/assemblyscript/examples/vectors/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/vectors/package.json
+++ b/sdk/assemblyscript/examples/vectors/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/vectors/package.json
+++ b/sdk/assemblyscript/examples/vectors/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -1562,19 +1562,8 @@ class RawMessage extends RequestMessage {
 
   private _data: string;
 
-  // HACK: this is a workaround for https://github.com/JairusSW/json-as/issues/132
-  // TODO: unwind hack when issue is resolved
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  __SERIALIZE(ptr: usize): void {
-    const data = this.serialize(this);
-    const dataSize = data.length << 1;
-    // @ts-expect-error: bs is defined during the json-as-transform
-    memory.copy(bs.offset, changetype<usize>(data), dataSize);
-    // @ts-expect-error: bs is defined during the json-as-transform
-    bs.offset += dataSize;
-  }
 
-  // @serializer
+  @serializer
   serialize(self: RawMessage): string {
     return self._data;
   }

--- a/sdk/assemblyscript/src/package-lock.json
+++ b/sdk/assemblyscript/src/package-lock.json
@@ -10,7 +10,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/src/package-lock.json
+++ b/sdk/assemblyscript/src/package-lock.json
@@ -10,7 +10,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -23,7 +23,7 @@
     "@assemblyscript/wasi-shim": "^0.1.0",
     "as-base64": "^0.2.0",
     "chalk": "^5.4.1",
-    "json-as": "1.1.2",
+    "json-as": "1.1.5",
     "semver": "^7.7.2",
     "xid-ts": "^1.1.4"
   },

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -23,7 +23,7 @@
     "@assemblyscript/wasi-shim": "^0.1.0",
     "as-base64": "^0.2.0",
     "chalk": "^5.4.1",
-    "json-as": "^1.0.8",
+    "json-as": "1.1.2",
     "semver": "^7.7.2",
     "xid-ts": "^1.1.4"
   },

--- a/sdk/assemblyscript/templates/default/package-lock.json
+++ b/sdk/assemblyscript/templates/default/package-lock.json
@@ -7,7 +7,7 @@
       "name": "my-modus-app",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.2"
+        "json-as": "^1.1.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -26,7 +26,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.2",
+        "json-as": "1.1.5",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
-      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
+      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/templates/default/package-lock.json
+++ b/sdk/assemblyscript/templates/default/package-lock.json
@@ -7,7 +7,7 @@
       "name": "my-modus-app",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.0.8"
+        "json-as": "^1.1.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -26,7 +26,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.0.8",
+        "json-as": "1.1.2",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.0.8.tgz",
-      "integrity": "sha512-x4lTtNArVM9zP2csa+Rhjae33cnosr1HJpn4UTudtGTBzvvbxsXoi2Kwy50eC5kEQD+bCrgt/Bbl1BzLxUHO7A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.2.tgz",
+      "integrity": "sha512-2kfwPHm5TQVPO/2ox/fEwatHabB8bX01sSMg5vmy4LsisUjDDN6NcsaiVAAGu1F+U4qDiti8HvjFz/EDYpg8QQ==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/templates/default/package.json
+++ b/sdk/assemblyscript/templates/default/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.0.8"
+    "json-as": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/templates/default/package.json
+++ b/sdk/assemblyscript/templates/default/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.2"
+    "json-as": "^1.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",


### PR DESCRIPTION
Update all AssemblyScript projects to latest `json-as` v1.1.5, and remove previous hack that is no longer needed.