### PR TITLE
chore: rename agent lifecycle methods and APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## UNRELEASED
 
 - chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
-- chore: rename agent lifecycle methods and apis [#858](https://github.com/hypermodeinc/modus/pull/858)
+- chore: rename agent lifecycle methods and APIs [#858](https://github.com/hypermodeinc/modus/pull/858)
 
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 - chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
+- chore: rename agent lifecycle methods and apis [#858](https://github.com/hypermodeinc/modus/pull/858)
 
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 

--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -500,7 +500,7 @@ func (a *wasmAgentActor) reloadModule(ctx context.Context, plugin *plugins.Plugi
 		return err
 	}
 
-	// resume the state in the new module instance
+	// restore the state in the new module instance
 	if err := a.setAgentState(ctx, state); err != nil {
 		logger.Err(ctx, err).Msg("Error setting agent state.")
 		return err

--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -45,7 +45,7 @@ const (
 	agentStatusTerminated agentStatus = "terminated"
 )
 
-func SpawnAgentActor(ctx context.Context, agentName string) (*agentInfo, error) {
+func StartAgent(ctx context.Context, agentName string) (*agentInfo, error) {
 	plugin, ok := plugins.GetPluginFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("no plugin found in context")
@@ -93,7 +93,7 @@ func spawnActorForAgent(host wasmhost.WasmHost, plugin *plugins.Plugin, agentId,
 	}()
 }
 
-func TerminateAgent(ctx context.Context, agentId string) bool {
+func StopAgent(ctx context.Context, agentId string) bool {
 	pid, err := getActorPid(ctx, agentId)
 	if err != nil {
 		logger.Err(ctx, err).Msg("Error stopping agent.")

--- a/runtime/hostfunctions/agents.go
+++ b/runtime/hostfunctions/agents.go
@@ -18,13 +18,13 @@ import (
 func init() {
 	const module_name = "modus_agents"
 
-	registerHostFunction(module_name, "spawnAgentActor", actors.SpawnAgentActor,
-		withErrorMessage("Error spawning actor for agent."),
+	registerHostFunction(module_name, "startAgent", actors.StartAgent,
+		withErrorMessage("Error starting agent."),
 		withMessageDetail(func(agentName string) string {
 			return fmt.Sprintf("Name: %s", agentName)
 		}))
 
-	registerHostFunction(module_name, "terminateAgent", actors.TerminateAgent,
+	registerHostFunction(module_name, "stopAgent", actors.StopAgent,
 		withErrorMessage("Error stopping agent."),
 		withMessageDetail(func(agentId string) string {
 			return fmt.Sprintf("AgentId: %s", agentId)

--- a/runtime/hostfunctions/agents.go
+++ b/runtime/hostfunctions/agents.go
@@ -25,7 +25,7 @@ func init() {
 		}))
 
 	registerHostFunction(module_name, "terminateAgent", actors.TerminateAgent,
-		withErrorMessage("Error terminating agent."),
+		withErrorMessage("Error stopping agent."),
 		withMessageDetail(func(agentId string) string {
 			return fmt.Sprintf("AgentId: %s", agentId)
 		}))

--- a/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
@@ -25,7 +25,7 @@ export class CounterAgent extends Agent {
   // In this case, we are just using a simple integer field to hold the count.
   private count: i32 = 0;
 
-  // The agent should be able to save its state and resume it later.
+  // The agent should be able to save its state and restore it later.
   // This is used for persisting data across soft restarts of the agent,
   // such as when updating the agent code, or when the agent is suspended and resumed.
   // The getState and setState methods below are used for this purpose.
@@ -62,7 +62,7 @@ export class CounterAgent extends Agent {
   // - The agent is being suspended to save resources.
   // - The agent is being relocated to a different host.
   // Note that the agent may be suspended and resumed multiple times during its lifetime,
-  // but the Modus Runtime will automatically save and resume the state of the agent,
+  // but the Modus Runtime will automatically save and restore the state of the agent,
   // so you don't need to worry about that here.
   onSuspend(): void {
     console.info("Counter agent suspended");

--- a/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
@@ -25,7 +25,7 @@ export class CounterAgent extends Agent {
   // In this case, we are just using a simple integer field to hold the count.
   private count: i32 = 0;
 
-  // The agent should be able to save its state and restore it later.
+  // The agent should be able to save its state and resume it later.
   // This is used for persisting data across soft restarts of the agent,
   // such as when updating the agent code, or when the agent is suspended and resumed.
   // The getState and setState methods below are used for this purpose.
@@ -62,16 +62,16 @@ export class CounterAgent extends Agent {
   // - The agent is being suspended to save resources.
   // - The agent is being relocated to a different host.
   // Note that the agent may be suspended and resumed multiple times during its lifetime,
-  // but the Modus Runtime will automatically save and restore the state of the agent,
+  // but the Modus Runtime will automatically save and resume the state of the agent,
   // so you don't need to worry about that here.
   onSuspend(): void {
     console.info("Counter agent suspended");
   }
 
-  // When the agent is restored, this method is automatically called.  Implementing it is optional.
-  // If you don't need to do anything special when the agent is restored, then you can omit it.
-  onRestore(): void {
-    console.info("Counter agent restored");
+  // When the agent is resumed, this method is automatically called.  Implementing it is optional.
+  // If you don't need to do anything special when the agent is resumed, then you can omit it.
+  onResume(): void {
+    console.info("Counter agent resumed");
   }
 
   // When the agent is terminated, this method is automatically called.  Implementing it is optional.
@@ -79,7 +79,7 @@ export class CounterAgent extends Agent {
   // This is a good place to unsubscribe from any listeners or subscriptions.
   // Note that resources are automatically cleaned up when the agent is terminated,
   // so you don't need to worry about that here.
-  // Once an agent is terminated, it cannot be restored.
+  // Once an agent is terminated, it cannot be resumed.
   onTerminate(): void {
     console.info("Counter agent terminated");
   }

--- a/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/counterAgent.ts
@@ -46,11 +46,11 @@ export class CounterAgent extends Agent {
     this.count = i32.parse(data);
   }
 
-  // When the agent is first started, this method is automatically called. Implementing it is optional.
+  // When the agent is started, this method is automatically called. Implementing it is optional.
   // If you don't need to do anything special when the agent starts, then you can omit it.
   // It can be used to initialize state, retrieve data, etc.
   // This is a good place to set up any listeners or subscriptions.
-  onStart(): void {
+  onInitialize(): void {
     console.info("Counter agent started");
   }
 

--- a/sdk/assemblyscript/examples/agents/assembly/index.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/index.ts
@@ -27,7 +27,7 @@ export function startCounterAgent(): AgentInfo {
 
 /**
  * Terminates the specified agent by ID.
- * Once terminated, the agent cannot be restored or restarted.
+ * Once terminated, the agent cannot be resumed or restarted.
  * However, a new agent with the same name can be started at any time.
  */
 export function terminateAgent(agentId: string): void {

--- a/sdk/assemblyscript/examples/agents/assembly/index.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/index.ts
@@ -26,12 +26,12 @@ export function startCounterAgent(): AgentInfo {
 }
 
 /**
- * Terminates the specified agent by ID.
- * Once terminated, the agent cannot be resumed or restarted.
+ * Stops the specified agent by ID.
+ * This will terminate the agent, and it cannot be resumed or restarted.
  * However, a new agent with the same name can be started at any time.
  */
-export function terminateAgent(agentId: string): void {
-  agents.terminate(agentId);
+export function stopAgent(agentId: string): void {
+  agents.stop(agentId);
 }
 
 /**

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -98,12 +98,12 @@ export function registerAgent<T extends Agent>(): void {
 }
 
 // @ts-expect-error: decorator
-@external("modus_agents", "spawnAgentActor")
-declare function hostSpawnAgentActor(agentName: string): AgentInfo;
+@external("modus_agents", "startAgent")
+declare function hostStartAgent(agentName: string): AgentInfo;
 
 // @ts-expect-error: decorator
-@external("modus_agents", "terminateAgent")
-declare function hostTerminateAgent(agentId: string): bool;
+@external("modus_agents", "stopAgent")
+declare function hostStopAgent(agentId: string): bool;
 
 /**
  * Starts an agent with the given name.
@@ -114,18 +114,19 @@ export function startAgent(name: string): AgentInfo {
     throw new Error(`Agent ${name} not found.`);
   }
 
-  return hostSpawnAgentActor(name);
+  return hostStartAgent(name);
 }
 
 /**
- * Terminates an agent with the given ID.
- * Once terminated, the agent cannot be resumed.
+ * Stops an agent with the given ID.
+ * This will terminate the agent, and it cannot be resumed or restarted.
+ * This can be called from any user code, such as function or another agent's methods.
  */
 export function stopAgent(agentId: string): void {
   if (agentId == "") {
     throw new Error("Agent ID cannot be empty.");
   }
-  const ok = hostTerminateAgent(agentId);
+  const ok = hostStopAgent(agentId);
   if (!ok) {
     throw new Error(`Failed to stop agent ${agentId}.`);
   }

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -48,10 +48,10 @@ export abstract class Agent {
   abstract setState(data: string | null): void;
 
   /**
-   * Called when the agent is first started.
+   * Called when the agent is started.
    * Override this method to perform any initialization.
    */
-  onStart(): void {}
+  onInitialize(): void {}
 
   /**
    * Called when the agent is suspended.
@@ -150,7 +150,7 @@ export function activateAgent(name: string, id: string, reloading: bool): void {
   if (reloading) {
     activeAgent!.onResume();
   } else {
-    activeAgent!.onStart();
+    activeAgent!.onInitialize();
   }
 }
 

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -63,18 +63,18 @@ export abstract class Agent {
   onSuspend(): void {}
 
   /**
-   * Called when the agent is restored.
-   * Override this method if you want to do anything special when the agent is restored,
+   * Called when the agent is resumed.
+   * Override this method if you want to do anything special when the agent is resumed,
    * such as sending a notification.
-   * Note that you do not need to restore the internal state of the agent here,
+   * Note that you do not need to resume the internal state of the agent here,
    * as that is handled automatically.
    */
-  onRestore(): void {}
+  onResume(): void {}
 
   /**
    * Called when the agent is terminated.
    * Override this method to send or save any final data.
-   * Note that once an agent is terminated, it cannot be restored.
+   * Note that once an agent is terminated, it cannot be resumed.
    */
   onTerminate(): void {}
 
@@ -119,7 +119,7 @@ export function startAgent(name: string): AgentInfo {
 
 /**
  * Terminates an agent with the given ID.
- * Once terminated, the agent cannot be restored.
+ * Once terminated, the agent cannot be resumed.
  */
 export function terminateAgent(agentId: string): void {
   if (agentId == "") {
@@ -148,7 +148,7 @@ export function activateAgent(name: string, id: string, reloading: bool): void {
   activeAgentId = id;
 
   if (reloading) {
-    activeAgent!.onRestore();
+    activeAgent!.onResume();
   } else {
     activeAgent!.onStart();
   }

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -121,13 +121,13 @@ export function startAgent(name: string): AgentInfo {
  * Terminates an agent with the given ID.
  * Once terminated, the agent cannot be resumed.
  */
-export function terminateAgent(agentId: string): void {
+export function stopAgent(agentId: string): void {
   if (agentId == "") {
     throw new Error("Agent ID cannot be empty.");
   }
   const ok = hostTerminateAgent(agentId);
   if (!ok) {
-    throw new Error(`Failed to terminate agent ${agentId}.`);
+    throw new Error(`Failed to stop agent ${agentId}.`);
   }
 }
 

--- a/sdk/assemblyscript/src/assembly/agents.ts
+++ b/sdk/assemblyscript/src/assembly/agents.ts
@@ -12,7 +12,7 @@ import { Duration } from "./enums";
 export {
   registerAgent as register,
   startAgent as start,
-  terminateAgent as terminate,
+  stopAgent as stop,
 } from "./agent";
 
 // @ts-expect-error: decorator

--- a/sdk/assemblyscript/src/assembly/enums.ts
+++ b/sdk/assemblyscript/src/assembly/enums.ts
@@ -24,7 +24,7 @@ export namespace AgentStatus {
   export const Suspending = "suspending";
   export const Suspended = "suspended";
   export const Resuming = "resuming";
-  export const Terminating = "terminating";
+  export const Stopping = "stopping";
   export const Terminated = "terminated";
 }
 export type AgentStatus = string;

--- a/sdk/assemblyscript/src/assembly/enums.ts
+++ b/sdk/assemblyscript/src/assembly/enums.ts
@@ -23,7 +23,7 @@ export namespace AgentStatus {
   export const Running = "running";
   export const Suspending = "suspending";
   export const Suspended = "suspended";
-  export const Restoring = "restoring";
+  export const Resuming = "resuming";
   export const Terminating = "terminating";
   export const Terminated = "terminated";
 }

--- a/sdk/go/examples/agents/counterAgent.go
+++ b/sdk/go/examples/agents/counterAgent.go
@@ -78,7 +78,7 @@ func (c *CounterAgent) OnInitialize() error {
 // - The agent is being suspended to save resources.
 // - The agent is being relocated to a different host.
 // Note that the agent may be suspended and resumed multiple times during its lifetime,
-// but the Modus Runtime will automatically save and resume the state of the agent,
+// but the Modus Runtime will automatically save and restore the state of the agent,
 // so you don't need to worry about that here.
 func (c *CounterAgent) OnSuspend() error {
 	fmt.Println("Counter agent suspended")

--- a/sdk/go/examples/agents/counterAgent.go
+++ b/sdk/go/examples/agents/counterAgent.go
@@ -37,7 +37,7 @@ func (c *CounterAgent) Name() string {
 	return "Counter"
 }
 
-// The agent should be able to save its state and resume it later.
+// The agent should be able to save its state and restore it later.
 // This is used for persisting data across soft restarts of the agent,
 // such as when updating the agent code, or when the agent is suspended and resumed.
 // The GetState and SetState methods below are used for this purpose.

--- a/sdk/go/examples/agents/counterAgent.go
+++ b/sdk/go/examples/agents/counterAgent.go
@@ -61,11 +61,11 @@ func (c *CounterAgent) SetState(data *string) {
 	}
 }
 
-// When the agent is first started, this method is automatically called. Implementing it is optional.
+// When the agent is started, this method is automatically called. Implementing it is optional.
 // If you don't need to do anything special when the agent starts, then you can omit it.
 // It can be used to initialize state, retrieve data, etc.
 // This is a good place to set up any listeners or subscriptions.
-func (c *CounterAgent) OnStart() error {
+func (c *CounterAgent) OnInitialize() error {
 	fmt.Println("Counter agent started")
 	return nil
 }

--- a/sdk/go/examples/agents/counterAgent.go
+++ b/sdk/go/examples/agents/counterAgent.go
@@ -37,7 +37,7 @@ func (c *CounterAgent) Name() string {
 	return "Counter"
 }
 
-// The agent should be able to save its state and restore it later.
+// The agent should be able to save its state and resume it later.
 // This is used for persisting data across soft restarts of the agent,
 // such as when updating the agent code, or when the agent is suspended and resumed.
 // The GetState and SetState methods below are used for this purpose.
@@ -78,17 +78,17 @@ func (c *CounterAgent) OnStart() error {
 // - The agent is being suspended to save resources.
 // - The agent is being relocated to a different host.
 // Note that the agent may be suspended and resumed multiple times during its lifetime,
-// but the Modus Runtime will automatically save and restore the state of the agent,
+// but the Modus Runtime will automatically save and resume the state of the agent,
 // so you don't need to worry about that here.
 func (c *CounterAgent) OnSuspend() error {
 	fmt.Println("Counter agent suspended")
 	return nil
 }
 
-// When the agent is restored, this method is automatically called.  Implementing it is optional.
-// If you don't need to do anything special when the agent is restored, then you can omit it.
-func (c *CounterAgent) OnRestore() error {
-	fmt.Println("Counter agent restored")
+// When the agent is resumed, this method is automatically called.  Implementing it is optional.
+// If you don't need to do anything special when the agent is resumed, then you can omit it.
+func (c *CounterAgent) OnResume() error {
+	fmt.Println("Counter agent resumed")
 	return nil
 }
 
@@ -97,7 +97,7 @@ func (c *CounterAgent) OnRestore() error {
 // This is a good place to unsubscribe from any listeners or subscriptions.
 // Note that resources are automatically cleaned up when the agent is terminated,
 // so you don't need to worry about that here.
-// Once an agent is terminated, it cannot be restored.
+// Once an agent is terminated, it cannot be resumed.
 func (c *CounterAgent) OnTerminate() error {
 	fmt.Println("Counter agent terminated")
 	return nil

--- a/sdk/go/examples/agents/main.go
+++ b/sdk/go/examples/agents/main.go
@@ -31,7 +31,7 @@ func StartCounterAgent() (agents.AgentInfo, error) {
 }
 
 // Terminates the specified agent by ID.
-// Once terminated, the agent cannot be restored or restarted.
+// Once terminated, the agent cannot be resumed or restarted.
 // However, a new agent with the same name can be started at any time.
 func TerminateAgent(agentId string) error {
 	return agents.Terminate(agentId)

--- a/sdk/go/examples/agents/main.go
+++ b/sdk/go/examples/agents/main.go
@@ -30,11 +30,11 @@ func StartCounterAgent() (agents.AgentInfo, error) {
 	return agents.Start("Counter")
 }
 
-// Terminates the specified agent by ID.
-// Once terminated, the agent cannot be resumed or restarted.
+// Stops the specified agent by ID.
+// This will terminate the agent, and it cannot be resumed or restarted.
 // However, a new agent with the same name can be started at any time.
-func TerminateAgent(agentId string) error {
-	return agents.Terminate(agentId)
+func StopAgent(agentId string) error {
+	return agents.Stop(agentId)
 }
 
 // Returns the current count of the specified agent.

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -96,7 +96,7 @@ func activateAgent(name, id string, reloading bool) {
 				console.Errorf("Error reloading agent %s: %v", name, err)
 			}
 		} else {
-			if err := agent.OnStart(); err != nil {
+			if err := agent.OnInitialize(); err != nil {
 				console.Errorf("Error starting agent %s: %v", name, err)
 			}
 		}
@@ -185,9 +185,9 @@ type Agent interface {
 	// Custom agents must implement this method.
 	SetState(data *string)
 
-	// OnStart is called when the agent is started.
+	// OnInitialize is called when the agent is started.
 	// Custom agents may implement this method to perform any initialization.
-	OnStart() error
+	OnInitialize() error
 
 	// OnSuspend is called when the agent is suspended.
 	// Custom agents may implement this method if for example, to send a notification.
@@ -217,7 +217,7 @@ func (a *AgentBase) Id() string {
 	return *activeAgentId
 }
 
-func (a *AgentBase) OnStart() error {
+func (a *AgentBase) OnInitialize() error {
 	return nil
 }
 

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -26,13 +26,13 @@ type AgentInfo struct {
 type AgentStatus = string
 
 const (
-	AgentStatusStarting    AgentStatus = "starting"
-	AgentStatusRunning     AgentStatus = "running"
-	AgentStatusSuspending  AgentStatus = "suspending"
-	AgentStatusSuspended   AgentStatus = "suspended"
-	AgentStatusResuming    AgentStatus = "resuming"
-	AgentStatusTerminating AgentStatus = "terminating"
-	AgentStatusTerminated  AgentStatus = "terminated"
+	AgentStatusStarting   AgentStatus = "starting"
+	AgentStatusRunning    AgentStatus = "running"
+	AgentStatusSuspending AgentStatus = "suspending"
+	AgentStatusSuspended  AgentStatus = "suspended"
+	AgentStatusResuming   AgentStatus = "resuming"
+	AgentStatusStopping   AgentStatus = "stopping"
+	AgentStatusTerminated AgentStatus = "terminated"
 )
 
 var agents = make(map[string]Agent)
@@ -119,7 +119,7 @@ func shutdownAgent(suspending bool) {
 		}
 	} else {
 		if err := (*activeAgent).OnTerminate(); err != nil {
-			console.Errorf("Error terminating agent %s: %v", (*activeAgent).Name(), err)
+			console.Errorf("Error stopping agent %s: %v", (*activeAgent).Name(), err)
 			return
 		}
 	}

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -56,11 +56,11 @@ func Start(name string) (AgentInfo, error) {
 	return *info, nil
 }
 
-// Terminates an agent with the given ID.
-// Once terminated, the agent cannot be resumed.
-func Terminate(agentId string) error {
+// Stops an agent with the given ID.
+// This will terminate the agent, and it cannot be resumed or restarted.
+func Stop(agentId string) error {
 	if ok := hostTerminateAgent(&agentId); !ok {
-		return fmt.Errorf("failed to terminate agent %s", agentId)
+		return fmt.Errorf("failed to stop agent %s", agentId)
 	}
 	return nil
 }

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -52,14 +52,14 @@ func Start(name string) (AgentInfo, error) {
 		return AgentInfo{}, fmt.Errorf("agent %s not found", name)
 	}
 
-	info := hostSpawnAgentActor(&name)
+	info := hostStartAgent(&name)
 	return *info, nil
 }
 
 // Stops an agent with the given ID.
 // This will terminate the agent, and it cannot be resumed or restarted.
 func Stop(agentId string) error {
-	if ok := hostTerminateAgent(&agentId); !ok {
+	if ok := hostStopAgent(&agentId); !ok {
 		return fmt.Errorf("failed to stop agent %s", agentId)
 	}
 	return nil

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -196,7 +196,7 @@ type Agent interface {
 
 	// OnResume is called when the agent is resumed from a suspended state.
 	// Custom agents may implement this method if for example, to send a notification.
-	// Note that you do not need to resume the internal state of the agent here, as that is handled automatically.
+	// Note that you do not need to restore the internal state of the agent here, as that is handled automatically.
 	OnResume() error
 
 	// OnTerminate is called when the agent is terminated.

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -30,7 +30,7 @@ const (
 	AgentStatusRunning     AgentStatus = "running"
 	AgentStatusSuspending  AgentStatus = "suspending"
 	AgentStatusSuspended   AgentStatus = "suspended"
-	AgentStatusRestoring   AgentStatus = "restoring"
+	AgentStatusResuming    AgentStatus = "resuming"
 	AgentStatusTerminating AgentStatus = "terminating"
 	AgentStatusTerminated  AgentStatus = "terminated"
 )
@@ -57,7 +57,7 @@ func Start(name string) (AgentInfo, error) {
 }
 
 // Terminates an agent with the given ID.
-// Once terminated, the agent cannot be restored.
+// Once terminated, the agent cannot be resumed.
 func Terminate(agentId string) error {
 	if ok := hostTerminateAgent(&agentId); !ok {
 		return fmt.Errorf("failed to terminate agent %s", agentId)
@@ -92,7 +92,7 @@ func activateAgent(name, id string, reloading bool) {
 		activeAgentId = &id
 
 		if reloading {
-			if err := agent.OnRestore(); err != nil {
+			if err := agent.OnResume(); err != nil {
 				console.Errorf("Error reloading agent %s: %v", name, err)
 			}
 		} else {
@@ -190,14 +190,14 @@ type Agent interface {
 	OnStart() error
 
 	// OnSuspend is called when the agent is suspended.
-	// Custom agents may implement this method if for example, to send a notification of the suspension.
+	// Custom agents may implement this method if for example, to send a notification.
 	// Note that you do not need to save the internal state of the agent here, as that is handled automatically.
 	OnSuspend() error
 
-	// OnRestore is called when the agent is restored from a suspended state.
-	// Custom agents may implement this method if for example, to send a notification of the restoration.
-	// Note that you do not need to restore the internal state of the agent here, as that is handled automatically.
-	OnRestore() error
+	// OnResume is called when the agent is resumed from a suspended state.
+	// Custom agents may implement this method if for example, to send a notification.
+	// Note that you do not need to resume the internal state of the agent here, as that is handled automatically.
+	OnResume() error
 
 	// OnTerminate is called when the agent is terminated.
 	// Custom agents may implement this method to send or save any final data.
@@ -225,7 +225,7 @@ func (a *AgentBase) OnSuspend() error {
 	return nil
 }
 
-func (a *AgentBase) OnRestore() error {
+func (a *AgentBase) OnResume() error {
 	return nil
 }
 

--- a/sdk/go/pkg/agents/imports_mock.go
+++ b/sdk/go/pkg/agents/imports_mock.go
@@ -15,12 +15,12 @@ import (
 	"github.com/hypermodeinc/modus/sdk/go/pkg/testutils"
 )
 
-var SpawnAgentActorCallStack = testutils.NewCallStack()
+var StartAgentCallStack = testutils.NewCallStack()
 var SendMessageCallStack = testutils.NewCallStack()
-var TerminateAgentCallStack = testutils.NewCallStack()
+var StopAgentCallStack = testutils.NewCallStack()
 
-func hostSpawnAgentActor(agentName *string) *AgentInfo {
-	SpawnAgentActorCallStack.Push(agentName)
+func hostStartAgent(agentName *string) *AgentInfo {
+	StartAgentCallStack.Push(agentName)
 
 	return &AgentInfo{
 		Id:     "abc123",
@@ -41,8 +41,8 @@ func hostSendMessage(agentId, msgName, data *string, timeout int64) *MessageResp
 	return nil
 }
 
-func hostTerminateAgent(agentId *string) bool {
-	TerminateAgentCallStack.Push(agentId)
+func hostStopAgent(agentId *string) bool {
+	StopAgentCallStack.Push(agentId)
 
 	return agentId != nil && *agentId == "abc123"
 }

--- a/sdk/go/pkg/agents/imports_wasi.go
+++ b/sdk/go/pkg/agents/imports_wasi.go
@@ -16,12 +16,12 @@ import (
 )
 
 //go:noescape
-//go:wasmimport modus_agents spawnAgentActor
-func _hostSpawnAgentActor(agentName *string) unsafe.Pointer
+//go:wasmimport modus_agents startAgent
+func _hostStartAgent(agentName *string) unsafe.Pointer
 
-//modus:import modus_agents spawnAgentActor
-func hostSpawnAgentActor(agentName *string) *AgentInfo {
-	info := _hostSpawnAgentActor(agentName)
+//modus:import modus_agents startAgent
+func hostStartAgent(agentName *string) *AgentInfo {
+	info := _hostStartAgent(agentName)
 	if info == nil {
 		return nil
 	}
@@ -42,5 +42,5 @@ func hostSendMessage(agentId, msgName, data *string, timeout int64) *MessageResp
 }
 
 //go:noescape
-//go:wasmimport modus_agents terminateAgent
-func hostTerminateAgent(agentId *string) bool
+//go:wasmimport modus_agents stopAgent
+func hostStopAgent(agentId *string) bool


### PR DESCRIPTION
Renaming a few things with Modus Agents.

Note, this breaks runtime compatibility with earlier alphas.  To use, you'll need to be fully updated, once released.