### PR TITLE
feat: enforce WASI reactor mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
 - chore: rename agent lifecycle methods and APIs [#858](https://github.com/hypermodeinc/modus/pull/858)
+- feat: enforce WASI reactor mode [#859](https://github.com/hypermodeinc/modus/pull/859)
 
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 

--- a/cli/src/custom/globals.ts
+++ b/cli/src/custom/globals.ts
@@ -15,7 +15,7 @@ export const ModusHomeDir = process.env.MODUS_HOME || path.join(os.homedir(), ".
 
 export const MinNodeVersion = "22.0.0";
 export const MinGoVersion = "1.23.1";
-export const MinTinyGoVersion = "0.33.0";
+export const MinTinyGoVersion = "0.35.0";
 
 export const GitHubOwner = "hypermodeinc";
 export const GitHubRepo = "modus";

--- a/runtime/wasmhost/wasmhost.go
+++ b/runtime/wasmhost/wasmhost.go
@@ -106,7 +106,7 @@ func (host *wasmHost) GetModuleInstance(ctx context.Context, plugin *plugins.Plu
 	span, ctx := utils.NewSentrySpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	cfg := getModuleConfig(ctx, buffers)
+	cfg := getModuleConfig(ctx, buffers, plugin)
 	mod, err := host.runtime.InstantiateModule(ctx, plugin.Module, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate the plugin module: %w", err)
@@ -127,7 +127,7 @@ func (host *wasmHost) CompileModule(ctx context.Context, bytes []byte) (wazero.C
 	return cm, nil
 }
 
-func getModuleConfig(ctx context.Context, buffers utils.OutputBuffers) wazero.ModuleConfig {
+func getModuleConfig(ctx context.Context, buffers utils.OutputBuffers, plugin *plugins.Plugin) wazero.ModuleConfig {
 
 	// Get the logger and writers for the plugin's stdout and stderr.
 	log := logger.Get(ctx).With().Bool("user_visible", true).Logger()
@@ -155,7 +155,7 @@ func getModuleConfig(ctx context.Context, buffers utils.OutputBuffers) wazero.Mo
 	// And https://gophers.slack.com/archives/C040AKTNTE0/p1719587772724619?thread_ts=1719522663.531579&cid=C040AKTNTE0
 	cfg := wazero.NewModuleConfig().
 		WithName("").
-		WithStartFunctions("_initialize", "_start").
+		WithStartFunctions(plugin.StartFunction).
 		WithSysWalltime().WithSysNanotime().
 		WithRandSource(rand.Reader).
 		WithStdout(wOut).WithStderr(wErr).

--- a/sdk/assemblyscript/src/plugin.asconfig.json
+++ b/sdk/assemblyscript/src/plugin.asconfig.json
@@ -15,7 +15,7 @@
       "process=wasi_process",
       "Date=wasi_Date"
     ],
-    "exportStart": "_start",
+    "exportStart": "_initialize",
     "exportRuntime": true
   },
   "targets": {

--- a/sdk/go/tools/modus-go-build/compiler/compiler.go
+++ b/sdk/go/tools/modus-go-build/compiler/compiler.go
@@ -21,26 +21,16 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const minTinyGoVersion = "0.33.0"
+const minTinyGoVersion = "0.35.0"
 
 func Compile(config *config.Config) error {
-
-	tinygoVersion, err := getCompilerVersion(config)
-	if err != nil {
-		return err
-	}
 
 	args := []string{"build"}
 	args = append(args, "-target", "wasip1")
 	args = append(args, "-o", filepath.Join(config.OutputDir, config.WasmFileName))
 
-	// WASI "reactor mode" (-buildmode=c-shared) is required for TinyGo 0.35.0 and later.
-	// Otherwise, the _start function runs and immediately exits before any function can execute.
-	// This also switches the startup function to _initialize instead of _start, so the Modus runtime
-	// needs to match.
-	if tinygoVersion.GreaterThanOrEqual(version.Must(version.NewVersion("0.35.0"))) {
-		args = append(args, "-buildmode", "c-shared")
-	}
+	// build a WASI reactor module - not a command module
+	args = append(args, "-buildmode", "c-shared")
 
 	// disable the asyncify scheduler until we better understand how to use it
 	args = append(args, "-scheduler", "none")


### PR DESCRIPTION
All Modus apps are technically implemented as WASI "reactor" modules  - which should use `_initialize` as their internal wasm start function.  `_start` should be used only for WASI "command" modules.

This PR updates Modus to enforce this part of the WASI spec.  As a side effect, the minimum version of TinyGo for the Modus Go SDK is now increased to `v0.35.0`.