### PR TITLE
deps: update json-as

### DIFF
--- a/sdk/assemblyscript/examples/agents/package-lock.json
+++ b/sdk/assemblyscript/examples/agents/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/agents/package-lock.json
+++ b/sdk/assemblyscript/examples/agents/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/agents/package.json
+++ b/sdk/assemblyscript/examples/agents/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/agents/package.json
+++ b/sdk/assemblyscript/examples/agents/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/anthropic-functions/package.json
+++ b/sdk/assemblyscript/examples/anthropic-functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/auth/package-lock.json
+++ b/sdk/assemblyscript/examples/auth/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/auth/package-lock.json
+++ b/sdk/assemblyscript/examples/auth/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/auth/package.json
+++ b/sdk/assemblyscript/examples/auth/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/auth/package.json
+++ b/sdk/assemblyscript/examples/auth/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/classification/package-lock.json
+++ b/sdk/assemblyscript/examples/classification/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/classification/package-lock.json
+++ b/sdk/assemblyscript/examples/classification/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/classification/package.json
+++ b/sdk/assemblyscript/examples/classification/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/collections/package-lock.json
+++ b/sdk/assemblyscript/examples/collections/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/collections/package-lock.json
+++ b/sdk/assemblyscript/examples/collections/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/collections/package.json
+++ b/sdk/assemblyscript/examples/collections/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/collections/package.json
+++ b/sdk/assemblyscript/examples/collections/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/dgraph/package-lock.json
+++ b/sdk/assemblyscript/examples/dgraph/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/dgraph/package-lock.json
+++ b/sdk/assemblyscript/examples/dgraph/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/dgraph/package.json
+++ b/sdk/assemblyscript/examples/dgraph/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/embedding/package-lock.json
+++ b/sdk/assemblyscript/examples/embedding/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/embedding/package-lock.json
+++ b/sdk/assemblyscript/examples/embedding/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/embedding/package.json
+++ b/sdk/assemblyscript/examples/embedding/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/graphql/package-lock.json
+++ b/sdk/assemblyscript/examples/graphql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/graphql/package-lock.json
+++ b/sdk/assemblyscript/examples/graphql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/graphql/package.json
+++ b/sdk/assemblyscript/examples/graphql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/http/package-lock.json
+++ b/sdk/assemblyscript/examples/http/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/http/package-lock.json
+++ b/sdk/assemblyscript/examples/http/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/http/package.json
+++ b/sdk/assemblyscript/examples/http/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/mysql/package-lock.json
+++ b/sdk/assemblyscript/examples/mysql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/mysql/package-lock.json
+++ b/sdk/assemblyscript/examples/mysql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/mysql/package.json
+++ b/sdk/assemblyscript/examples/mysql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/mysql/package.json
+++ b/sdk/assemblyscript/examples/mysql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/neo4j/package-lock.json
+++ b/sdk/assemblyscript/examples/neo4j/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/neo4j/package-lock.json
+++ b/sdk/assemblyscript/examples/neo4j/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/neo4j/package.json
+++ b/sdk/assemblyscript/examples/neo4j/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/neo4j/package.json
+++ b/sdk/assemblyscript/examples/neo4j/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/postgresql/package-lock.json
+++ b/sdk/assemblyscript/examples/postgresql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/postgresql/package-lock.json
+++ b/sdk/assemblyscript/examples/postgresql/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/postgresql/package.json
+++ b/sdk/assemblyscript/examples/postgresql/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.1.11",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.11",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.11.tgz",
+      "integrity": "sha512-J96M8MYKOHg6G77p/y7EpjjkWl/b/L9s/uZkpq8LOFi3qsU2q7aGI2Th/hfg5UZu99xbKvR2WDyO7KmGQPkzkA==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/simple/package-lock.json
+++ b/sdk/assemblyscript/examples/simple/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/simple/package.json
+++ b/sdk/assemblyscript/examples/simple/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/textgeneration/package-lock.json
+++ b/sdk/assemblyscript/examples/textgeneration/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/textgeneration/package-lock.json
+++ b/sdk/assemblyscript/examples/textgeneration/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "@types/node": "^22.15.21",
-        "as-test": "^0.4.1",
+        "as-test": "^0.4.4",
         "assemblyscript": "^0.27.36",
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/textgeneration/package.json
+++ b/sdk/assemblyscript/examples/textgeneration/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/time/package-lock.json
+++ b/sdk/assemblyscript/examples/time/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/time/package-lock.json
+++ b/sdk/assemblyscript/examples/time/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/time/package.json
+++ b/sdk/assemblyscript/examples/time/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/time/package.json
+++ b/sdk/assemblyscript/examples/time/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/vectors/package-lock.json
+++ b/sdk/assemblyscript/examples/vectors/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -27,7 +27,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/vectors/package-lock.json
+++ b/sdk/assemblyscript/examples/vectors/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/examples/vectors/package.json
+++ b/sdk/assemblyscript/examples/vectors/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/examples/vectors/package.json
+++ b/sdk/assemblyscript/examples/vectors/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -339,6 +339,7 @@ export class ToolChoice {
 /**
  * An object for specifying a function to call.
  */
+@json
 class ToolChoiceFunction {
   /**
    * The name of the function to call.
@@ -1378,6 +1379,7 @@ export class AssistantMessage<T> extends RequestMessage {
 /**
  * Represents a reference to a previous audio response from the model.
  */
+@json
 export class AudioRef {
   /**
    * Creates a new audio reference object.

--- a/sdk/assemblyscript/src/package-lock.json
+++ b/sdk/assemblyscript/src/package-lock.json
@@ -10,7 +10,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.11",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1425,9 +1425,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.11.tgz",
+      "integrity": "sha512-J96M8MYKOHg6G77p/y7EpjjkWl/b/L9s/uZkpq8LOFi3qsU2q7aGI2Th/hfg5UZu99xbKvR2WDyO7KmGQPkzkA==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/src/package-lock.json
+++ b/sdk/assemblyscript/src/package-lock.json
@@ -10,7 +10,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "^1.1.11",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "@types/node": "^22.15.21",
-        "as-test": "^0.4.1",
+        "as-test": "^0.4.4",
         "assemblyscript": "^0.27.36",
         "assemblyscript-prettier": "^3.0.1",
         "eslint": "^9.27.0",
@@ -650,9 +650,9 @@
       "license": "MIT"
     },
     "node_modules/as-test": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/as-test/-/as-test-0.4.1.tgz",
-      "integrity": "sha512-8BjVCUUtNlZ5T8Ex6oh6dNaslddzClPtSloVsOx+FN7K70W6C/9IQB6J1i89g3r7uQr1+d1C9C3EzvsgsYohMQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/as-test/-/as-test-0.4.4.tgz",
+      "integrity": "sha512-VqE19MECRLlT4gUU1/BwX/WDWHotnwT5sMDHr1zRsQ6lECq6csSqQNuUafhFniCTIKO+VvzMCb/cZnN5ZzwOZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -662,12 +662,19 @@
         "chalk": "^5.4.1",
         "glob": "^11.0.1",
         "gradient-string": "^3.0.0",
-        "json-as": "^1.0.1",
         "typer-diff": "^1.1.1"
       },
       "bin": {
         "as-test": "bin/index.js",
         "ast": "bin/index.js"
+      },
+      "peerDependencies": {
+        "json-as": "*"
+      },
+      "peerDependenciesMeta": {
+        "json-as": {
+          "optional": true
+        }
       }
     },
     "node_modules/as-variant": {
@@ -1425,9 +1432,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.11.tgz",
-      "integrity": "sha512-J96M8MYKOHg6G77p/y7EpjjkWl/b/L9s/uZkpq8LOFi3qsU2q7aGI2Th/hfg5UZu99xbKvR2WDyO7KmGQPkzkA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -23,7 +23,7 @@
     "@assemblyscript/wasi-shim": "^0.1.0",
     "as-base64": "^0.2.0",
     "chalk": "^5.4.1",
-    "json-as": "1.1.5",
+    "json-as": "^1.1.11",
     "semver": "^7.7.2",
     "xid-ts": "^1.1.4"
   },

--- a/sdk/assemblyscript/src/package.json
+++ b/sdk/assemblyscript/src/package.json
@@ -23,14 +23,14 @@
     "@assemblyscript/wasi-shim": "^0.1.0",
     "as-base64": "^0.2.0",
     "chalk": "^5.4.1",
-    "json-as": "^1.1.11",
+    "json-as": "^1.1.14",
     "semver": "^7.7.2",
     "xid-ts": "^1.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
     "@types/node": "^22.15.21",
-    "as-test": "^0.4.1",
+    "as-test": "^0.4.4",
     "assemblyscript": "^0.27.36",
     "assemblyscript-prettier": "^3.0.1",
     "eslint": "^9.27.0",

--- a/sdk/assemblyscript/templates/default/package-lock.json
+++ b/sdk/assemblyscript/templates/default/package-lock.json
@@ -7,7 +7,7 @@
       "name": "my-modus-app",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.5"
+        "json-as": "^1.1.7"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.5.tgz",
-      "integrity": "sha512-rzVa0ERXCtUY64mPdUOp1Ko+H23xRcDn2a1K0+JxVhsnjW8q3aVH29jAw0nJB97Px9n6A44oyTqAXdpvR64k9w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
+      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/templates/default/package-lock.json
+++ b/sdk/assemblyscript/templates/default/package-lock.json
@@ -7,7 +7,7 @@
       "name": "my-modus-app",
       "dependencies": {
         "@hypermode/modus-sdk-as": "../../src",
-        "json-as": "^1.1.7"
+        "json-as": "^1.1.14"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -26,7 +26,7 @@
         "@assemblyscript/wasi-shim": "^0.1.0",
         "as-base64": "^0.2.0",
         "chalk": "^5.4.1",
-        "json-as": "1.1.5",
+        "json-as": "^1.1.14",
         "semver": "^7.7.2",
         "xid-ts": "^1.1.4"
       },
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/json-as": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.7.tgz",
-      "integrity": "sha512-N/Vw88DnWqyRzJllzAOeznO8ORswv66Sodsw877QEDDu5CukCd2quo/9kDh26VsghQ1gUSJy9yoMuz8MHYPgPw==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/json-as/-/json-as-1.1.14.tgz",
+      "integrity": "sha512-aVnYGPyO7v3AufF1ayyiGXXUQhfoCVabhhExhvEKadDHEuABN4MW9WCjZOmhwttD2rWxc9yj5lTaVIqNSwi+Ww==",
       "license": "MIT"
     },
     "node_modules/json-buffer": {

--- a/sdk/assemblyscript/templates/default/package.json
+++ b/sdk/assemblyscript/templates/default/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.7"
+    "json-as": "^1.1.14"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/sdk/assemblyscript/templates/default/package.json
+++ b/sdk/assemblyscript/templates/default/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@hypermode/modus-sdk-as": "../../src",
-    "json-as": "^1.1.5"
+    "json-as": "^1.1.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",


### PR DESCRIPTION
Update `json-as` to latest v1.1.14 to fix several issues, and added a couple of missing `@json` decorators.