### PR TITLE
feat: return user and chat errors in API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
 - chore: rename agent lifecycle methods and APIs [#858](https://github.com/hypermodeinc/modus/pull/858)
 - feat: enforce WASI reactor mode [#859](https://github.com/hypermodeinc/modus/pull/859)
+- feat: return user and chat errors in API response [#863](https://github.com/hypermodeinc/modus/pull/863)
 
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 

--- a/runtime/models/models.go
+++ b/runtime/models/models.go
@@ -107,12 +107,14 @@ func PostToModelEndpoint[TResult any](ctx context.Context, model *manifest.Model
 			}
 		}
 
-		return empty, err
+		if res == nil {
+			return empty, err
+		}
 	}
 
+	// NOTE: This path occurs whether or not there's an error, as long as there was some response body content.
 	db.WriteInferenceHistory(ctx, model, payload, res.Data, res.StartTime, res.EndTime)
-
-	return res.Data, nil
+	return res.Data, err
 }
 
 func getModelEndpointUrl(model *manifest.ModelInfo, connection *manifest.HTTPConnectionInfo) (string, error) {

--- a/runtime/utils/http.go
+++ b/runtime/utils/http.go
@@ -46,17 +46,22 @@ func sendHttp(req *http.Request) ([]byte, error) {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		if len(body) == 0 {
-			return nil, &HttpError{
-				StatusCode: response.StatusCode,
-				Message:    response.Status,
-			}
-		} else {
-			return nil, &HttpError{
-				StatusCode: response.StatusCode,
-				Message:    fmt.Sprintf("%s\n%s", response.Status, body),
-			}
+		return body, &HttpError{
+			StatusCode: response.StatusCode,
+			Message:    response.Status,
 		}
+
+		// if len(body) == 0 {
+		// 	return nil, &HttpError{
+		// 		StatusCode: response.StatusCode,
+		// 		Message:    response.Status,
+		// 	}
+		// } else {
+		// 	return nil, &HttpError{
+		// 		StatusCode: response.StatusCode,
+		// 		Message:    fmt.Sprintf("%s\n%s", response.Status, body),
+		// 	}
+		// }
 	}
 
 	return body, nil
@@ -111,20 +116,21 @@ func PostHttp[TResult any](ctx context.Context, url string, payload any, beforeS
 	startTime := GetTime()
 	content, err := sendHttp(req)
 	endTime := GetTime()
-	if err != nil {
-		return nil, err
-	}
+
+	// NOTE: Unlike most functions, the result and error are BOTH returned.
+	// This is because some error messages are returned in the body of the response.
 
 	var result TResult
-	switch any(result).(type) {
-	case []byte:
-		result = any(content).(TResult)
-	case string:
-		result = any(string(content)).(TResult)
-	default:
-		err = JsonDeserialize(content, &result)
-		if err != nil {
-			return nil, fmt.Errorf("error deserializing response: %w", err)
+	if content != nil {
+		switch any(result).(type) {
+		case []byte:
+			result = any(content).(TResult)
+		case string:
+			result = any(string(content)).(TResult)
+		default:
+			if err := JsonDeserialize(content, &result); err != nil {
+				return nil, fmt.Errorf("error deserializing response: %w", err)
+			}
 		}
 	}
 
@@ -132,7 +138,7 @@ func PostHttp[TResult any](ctx context.Context, url string, payload any, beforeS
 		Data:      result,
 		StartTime: startTime,
 		EndTime:   endTime,
-	}, nil
+	}, err
 }
 
 func WriteJsonContentHeader(w http.ResponseWriter) {

--- a/runtime/utils/http.go
+++ b/runtime/utils/http.go
@@ -50,18 +50,6 @@ func sendHttp(req *http.Request) ([]byte, error) {
 			StatusCode: response.StatusCode,
 			Message:    response.Status,
 		}
-
-		// if len(body) == 0 {
-		// 	return nil, &HttpError{
-		// 		StatusCode: response.StatusCode,
-		// 		Message:    response.Status,
-		// 	}
-		// } else {
-		// 	return nil, &HttpError{
-		// 		StatusCode: response.StatusCode,
-		// 		Message:    fmt.Sprintf("%s\n%s", response.Status, body),
-		// 	}
-		// }
 	}
 
 	return body, nil

--- a/runtime/utils/http_test.go
+++ b/runtime/utils/http_test.go
@@ -56,13 +56,16 @@ func Test_SendHttp_ErrorResponse(t *testing.T) {
 		t.Fatalf("Failed to create request: %v", err)
 	}
 
-	_, err = sendHttp(req)
+	res, err := sendHttp(req)
 	if err == nil {
 		t.Error("Expected an error, but got nil")
 	}
 
-	expected := "HTTP error: 500 Internal Server Error\nSomething went wrong!\n"
-	if err.Error() != expected {
+	if expected := "Something went wrong!\n"; string(res) != expected {
+		t.Errorf("Unexpected result. Got: %s, want: %s", string(res), expected)
+	}
+
+	if expected := "HTTP error: 500 Internal Server Error"; err.Error() != expected {
 		t.Errorf("Unexpected error message. Got: %s, want: %s", err.Error(), expected)
 	}
 }

--- a/runtime/wasmhost/fncall.go
+++ b/runtime/wasmhost/fncall.go
@@ -156,7 +156,7 @@ func (host *wasmHost) CallFunctionInModule(ctx context.Context, mod wasm.Module,
 				Dur("duration_ms", duration).
 				Bool("user_visible", true).
 				Int32("exit_code", exitCode).
-				Msgf("Function ended prematurely with exit code %d.  This may have been intentional, or caused by an exception or panic in your code.", exitCode)
+				Msgf("Function ended with exit code %d, indicating an error.", exitCode)
 		}
 	} else if errors.Is(err, context.Canceled) {
 		// Cancellation is not an error, but we still want to log it.

--- a/sdk/go/tools/modus-go-build/codegen/preprocess.go
+++ b/sdk/go/tools/modus-go-build/codegen/preprocess.go
@@ -251,6 +251,7 @@ func writeFuncWrappers(b *bytes.Buffer, pkg *packages.Package, imports map[strin
 		}
 
 		if hasErrorReturn {
+			imports["os"] = "os"
 			imports["github.com/hypermodeinc/modus/sdk/go/pkg/console"] = "console"
 
 			// remove the error return value from the function signature
@@ -320,6 +321,7 @@ func writeFuncWrappers(b *bytes.Buffer, pkg *packages.Package, imports map[strin
 
 			b.WriteString("\tif err != nil {\n")
 			b.WriteString("\t\tconsole.Error(err.Error())\n")
+			b.WriteString("\t\tos.Exit(1)\n")
 			b.WriteString("\t}\n")
 
 			if numResults > 0 {


### PR DESCRIPTION
This PR does the following:

- Changes how HTTP 4xx errors are handled by the Runtime when invoking models.  Previously, any body content on such an error was logged but not returned to user code, so it was not possible to take specific action or return the error response to the end-user.  Going forward, the body of error responses will not be in the logs, but will be returned to user code.
- Introduces an optional `Validator` function that can be set on any model in the models interface.  If provided, the validator can be used to determine if the response is the expected model output, or a well-known error response.
- Implements the validator for the OpenAI Chat Completions model interface.
- Ensures that top-level error messages returned from a user's function are returned in the GraphQL response.

The net result is that when a model returns a structured error object, we can now show the message from that error in the API output.

This affects the Runtime and the Go SDK.  A similar PR is forthcoming for AssemblyScript in #864, but is waiting on some json-as fixes before it's ready.