### PR TITLE
feat: return user and chat errors in API response (AssemblyScript)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - chore: update json-as and remove hack [#857](https://github.com/hypermodeinc/modus/pull/857)
 - chore: rename agent lifecycle methods and APIs [#858](https://github.com/hypermodeinc/modus/pull/858)
 - feat: enforce WASI reactor mode [#859](https://github.com/hypermodeinc/modus/pull/859)
-- feat: return user and chat errors in API response [#863](https://github.com/hypermodeinc/modus/pull/863)
+- feat: return user and chat errors in API response [#863](https://github.com/hypermodeinc/modus/pull/863) [#864](https://github.com/hypermodeinc/modus/pull/864)
 - feat: list agents on health endpoint [#865](https://github.com/hypermodeinc/modus/pull/865)
 - feat: add agent management APIs [#866](https://github.com/hypermodeinc/modus/pull/866)
 

--- a/sdk/assemblyscript/src/assembly/utils.ts
+++ b/sdk/assemblyscript/src/assembly/utils.ts
@@ -7,6 +7,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Checks if the result is invalid, by determining if it is a null pointer.
+ * This will work for any managed type, regardless of whether it is nullable or not.
+ */
 export function resultIsInvalid<T>(result: T): bool {
   return changetype<usize>(result) == 0;
+}
+
+/**
+ * Logs an error intended for the user, and exits.
+ * The message will be displayed in the API response, and in the console logs.
+ */
+export function throwUserError(message: string): void {
+  console.error(message);
+  process.exit(1);
 }

--- a/sdk/assemblyscript/src/models/openai/chat.ts
+++ b/sdk/assemblyscript/src/models/openai/chat.ts
@@ -1595,15 +1595,12 @@ function validateChatModelResponse(data: string): ModelError | null {
     throw new Error("No response received from model invocation");
   }
 
-  // hack until json-as issues are resolved
-  if (data.startsWith(`{\n  "error": {`)) {
-    return JSON.parse<ChatModelError>(data.substring(13, data.length - 2));
+  const obj = JSON.parse<JSON.Obj>(data);
+  const error = obj.get("error");
+  if (error) {
+    return JSON.parse<ChatModelError>(error.toString());
+    // return error.get<ChatModelError>(); // todo: this should work instead of the above line, but fails as of json-as v1.1.14
   }
-
-  // const obj = JSON.parse<JSON.Obj>(data);
-  // if (obj.has("error")) {
-  //   return obj.get("error")!.get<ChatModelError>();
-  // }
 
   return null;
 }


### PR DESCRIPTION
This continues on the work in #863, implementing for the AssemblyScript SDK.

There are a couple of minor differences:

- Errors that are thrown via `throw new Error(...)` will continue to be logged but not emitted via the GraphQL API, because they're likely not intended to be user facing.  (In the future we will be able to catch these via `try-as`.)
- User-facing error messages can be thrown via `utils.throwUserError(...)`, which logs the error and exits cleanly.  The runtime will trap this error message and return it via the GraphQL API errors section.
