### PR TITLE
feat: add agent management APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - feat: enforce WASI reactor mode [#859](https://github.com/hypermodeinc/modus/pull/859)
 - feat: return user and chat errors in API response [#863](https://github.com/hypermodeinc/modus/pull/863)
 - feat: list agents on health endpoint [#865](https://github.com/hypermodeinc/modus/pull/865)
+- feat: add agent management APIs [#866](https://github.com/hypermodeinc/modus/pull/866)
 
 ## 2025-05-22 - Go SDK 0.18.0-alpha.3
 

--- a/runtime/hostfunctions/agents.go
+++ b/runtime/hostfunctions/agents.go
@@ -30,6 +30,15 @@ func init() {
 			return fmt.Sprintf("AgentId: %s", agentId)
 		}))
 
+	registerHostFunction(module_name, "getAgentInfo", actors.GetAgentInfo,
+		withErrorMessage("Error getting agent info."),
+		withMessageDetail(func(agentId string) string {
+			return fmt.Sprintf("AgentId: %s", agentId)
+		}))
+
+	registerHostFunction(module_name, "listAgents", actors.ListActiveAgents,
+		withErrorMessage("Error listing agents."))
+
 	registerHostFunction(module_name, "sendMessage", actors.SendAgentMessage,
 		withErrorMessage("Error sending message to agent."),
 		withMessageDetail(func(agentId string, msgName string, data *string, timeout int64) string {

--- a/runtime/httpserver/health.go
+++ b/runtime/httpserver/health.go
@@ -22,7 +22,7 @@ import (
 var healthHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 	env := app.Config().Environment()
 	ver := app.VersionNumber()
-	agents := actors.ListAgents()
+	agents := actors.ListLocalAgents()
 
 	// custom format the JSON response for easy readability
 

--- a/sdk/assemblyscript/examples/agents/assembly/index.ts
+++ b/sdk/assemblyscript/examples/agents/assembly/index.ts
@@ -26,12 +26,26 @@ export function startCounterAgent(): AgentInfo {
 }
 
 /**
- * Stops the specified agent by ID.
+ * Stops the specified agent by ID, returning its status info.
  * This will terminate the agent, and it cannot be resumed or restarted.
  * However, a new agent with the same name can be started at any time.
  */
-export function stopAgent(agentId: string): void {
-  agents.stop(agentId);
+export function stopAgent(agentId: string): AgentInfo {
+  return agents.stop(agentId);
+}
+
+/**
+ * Gets information about the specified agent.
+ */
+export function getAgentInfo(agentId: string): AgentInfo {
+  return agents.getInfo(agentId);
+}
+
+/**
+ * List all agents, except those that have been fully terminated.
+ */
+export function ListAgents(): AgentInfo[] {
+  return agents.listAll();
 }
 
 /**

--- a/sdk/assemblyscript/src/assembly/agents.ts
+++ b/sdk/assemblyscript/src/assembly/agents.ts
@@ -13,6 +13,8 @@ export {
   registerAgent as register,
   startAgent as start,
   stopAgent as stop,
+  getAgentInfo as getInfo,
+  listAgents as listAll,
 } from "./agent";
 
 // @ts-expect-error: decorator

--- a/sdk/go/examples/agents/main.go
+++ b/sdk/go/examples/agents/main.go
@@ -30,11 +30,21 @@ func StartCounterAgent() (agents.AgentInfo, error) {
 	return agents.Start("Counter")
 }
 
-// Stops the specified agent by ID.
+// Stops the specified agent by ID, returning its status info.
 // This will terminate the agent, and it cannot be resumed or restarted.
 // However, a new agent with the same name can be started at any time.
-func StopAgent(agentId string) error {
+func StopAgent(agentId string) (agents.AgentInfo, error) {
 	return agents.Stop(agentId)
+}
+
+// Gets information about the specified agent.
+func GetAgentInfo(agentId string) (agents.AgentInfo, error) {
+	return agents.GetInfo(agentId)
+}
+
+// List all agents, except those that have been fully terminated.
+func ListAgents() ([]agents.AgentInfo, error) {
+	return agents.ListAll()
 }
 
 // Returns the current count of the specified agent.

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -56,13 +56,36 @@ func Start(name string) (AgentInfo, error) {
 	return *info, nil
 }
 
-// Stops an agent with the given ID.
+// Stops an agent with the given ID and returns its status info.
 // This will terminate the agent, and it cannot be resumed or restarted.
-func Stop(agentId string) error {
-	if ok := hostStopAgent(&agentId); !ok {
-		return fmt.Errorf("failed to stop agent %s", agentId)
+func Stop(agentId string) (AgentInfo, error) {
+	if info := hostStopAgent(&agentId); info != nil {
+		return *info, nil
 	}
-	return nil
+	return AgentInfo{}, fmt.Errorf("failed to stop agent %s", agentId)
+}
+
+// Gets information about an agent with the given ID.
+func GetInfo(agentId string) (AgentInfo, error) {
+	if len(agentId) == 0 {
+		return AgentInfo{}, errors.New("invalid agent ID")
+	}
+
+	info := hostGetAgentInfo(&agentId)
+	if info == nil {
+		return AgentInfo{}, fmt.Errorf("agent %s not found", agentId)
+	}
+
+	return *info, nil
+}
+
+// Returns a list of all agents, except those that have been fully terminated.
+func ListAll() ([]AgentInfo, error) {
+	agents := hostListAgents()
+	if agents == nil {
+		return nil, errors.New("failed to list agents")
+	}
+	return *agents, nil
 }
 
 // These functions are only invoked as wasm exports from the host.

--- a/sdk/go/pkg/agents/imports_mock.go
+++ b/sdk/go/pkg/agents/imports_mock.go
@@ -18,6 +18,8 @@ import (
 var StartAgentCallStack = testutils.NewCallStack()
 var SendMessageCallStack = testutils.NewCallStack()
 var StopAgentCallStack = testutils.NewCallStack()
+var GetAgentInfoCallStack = testutils.NewCallStack()
+var ListAgentsCallStack = testutils.NewCallStack()
 
 func hostStartAgent(agentName *string) *AgentInfo {
 	StartAgentCallStack.Push(agentName)
@@ -41,8 +43,38 @@ func hostSendMessage(agentId, msgName, data *string, timeout int64) *MessageResp
 	return nil
 }
 
-func hostStopAgent(agentId *string) bool {
+func hostStopAgent(agentId *string) *AgentInfo {
 	StopAgentCallStack.Push(agentId)
 
-	return agentId != nil && *agentId == "abc123"
+	if *agentId == "abc123" {
+		return &AgentInfo{
+			Id:     "abc123",
+			Name:   "Counter",
+			Status: AgentStatusStopping,
+		}
+	}
+	return nil
+}
+
+func hostGetAgentInfo(agentId *string) *AgentInfo {
+	GetAgentInfoCallStack.Push(agentId)
+
+	if *agentId == "abc123" {
+		return &AgentInfo{
+			Id:     "abc123",
+			Name:   "Counter",
+			Status: AgentStatusRunning,
+		}
+	}
+
+	return nil
+}
+
+func hostListAgents() *[]AgentInfo {
+	ListAgentsCallStack.Push()
+
+	return &[]AgentInfo{
+		{Id: "abc123", Name: "Counter", Status: AgentStatusRunning},
+		{Id: "def456", Name: "Logger", Status: AgentStatusRunning},
+	}
 }

--- a/sdk/go/pkg/agents/imports_wasi.go
+++ b/sdk/go/pkg/agents/imports_wasi.go
@@ -43,4 +43,40 @@ func hostSendMessage(agentId, msgName, data *string, timeout int64) *MessageResp
 
 //go:noescape
 //go:wasmimport modus_agents stopAgent
-func hostStopAgent(agentId *string) bool
+func _hostStopAgent(agentId *string) unsafe.Pointer
+
+//modus:import modus_agents stopAgent
+func hostStopAgent(agentId *string) *AgentInfo {
+	info := _hostStopAgent(agentId)
+	if info == nil {
+		return nil
+	}
+	return (*AgentInfo)(info)
+}
+
+//go:noescape
+//go:wasmimport modus_agents getAgentInfo
+func _hostGetAgentInfo(agentId *string) unsafe.Pointer
+
+//modus:import modus_agents getAgentInfo
+func hostGetAgentInfo(agentId *string) *AgentInfo {
+	info := _hostGetAgentInfo(agentId)
+	if info == nil {
+		return nil
+	}
+	return (*AgentInfo)(info)
+}
+
+//go:noescape
+//go:wasmimport modus_agents listAgents
+func _hostListAgents() unsafe.Pointer
+
+//modus:import modus_agents listAgents
+func hostListAgents() *[]AgentInfo {
+	ptr := _hostListAgents()
+	if ptr == nil {
+		return nil
+	}
+
+	return (*[]AgentInfo)(ptr)
+}


### PR DESCRIPTION
- Adds `agents.ListAll` and `agents.GetInfo` APIs to both SDKs
- Updates the `agents.Stop` API to return status info (aligning with the others)
- Update examples to show usage.