### PR TITLE
ci: move Trunk to action

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1,0 +1,15 @@
+name: Trunk Code Quality
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: main
+
+permissions:
+  contents: read
+  actions: write
+  checks: write
+
+jobs:
+  trunk-code-quality:
+    name: Trunk Code Quality
+    uses: hypermodeinc/.github/.github/workflows/trunk.yml@main


### PR DESCRIPTION
## Description

Move Trunk to GitHub Action given upcoming deprecation of Trunk's cloud-managed PR reviews.

## Checklist

All PRs should check the following boxes:

- [x] I have given this PR a title using the
      [Conventional Commits](https://www.conventionalcommits.org/) syntax, leading with `fix:`,
      `feat:`, `chore:`, `ci:`, etc.
  - The title should also be used for the commit message when the PR is squashed and merged.