### PR TITLE
chore: unpin wrangler version

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -70,7 +70,6 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
-          wranglerVersion: 3.83.0
           workingDirectory: cli
           preCommands: |
             cat install.sh

--- a/.github/workflows/release-info.yaml
+++ b/.github/workflows/release-info.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
-          wranglerVersion: 3.83.0
           workingDirectory: tools/release-info
           preCommands: |
             cat modus-latest.json

--- a/.github/workflows/release-schema.yaml
+++ b/.github/workflows/release-schema.yaml
@@ -19,7 +19,6 @@ jobs:
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_TOKEN }}
-          wranglerVersion: 3.83.0
           workingDirectory: lib/manifest
           preCommands: |
             cat modus_schema.json


### PR DESCRIPTION
We shouldn't need to pin the Wrangler action to a specific version of Wrangler.

This should fix warnings such as this one
https://github.com/hypermodeinc/modus/actions/runs/15538336175/job/43742954687#step:8:304