### PR TITLE
fix: address agent lifecycle issues

### DIFF
--- a/.trunk/configs/cspell.json
+++ b/.trunk/configs/cspell.json
@@ -126,6 +126,7 @@
     "mydb",
     "mydgraph",
     "nanos",
+    "Nanosleep",
     "Nanotime",
     "neo4jclient",
     "nobuild",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: address agent lifecycle issues [#881](https://github.com/hypermodeinc/modus/pull/881)
+
 ## 2025-06-09 - Runtime 0.18.0-alpha.5
 
 - feat: remove embedded PostgresDB [#870](https://github.com/hypermodeinc/modus/pull/870)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 # Change Log
 
-## UNRELEASED
+## 2025-06-10 - Runtime 0.18.0-alpha.6
+
+- fix: address agent lifecycle issues [#881](https://github.com/hypermodeinc/modus/pull/881)
+
+## 2025-06-10 - Go SDK 0.18.0-alpha.6
+
+- fix: address agent lifecycle issues [#881](https://github.com/hypermodeinc/modus/pull/881)
+
+## 2025-06-10 - AssemblyScript SDK 0.18.0-alpha.5
 
 - fix: address agent lifecycle issues [#881](https://github.com/hypermodeinc/modus/pull/881)
 

--- a/runtime/wasmhost/wasmhost.go
+++ b/runtime/wasmhost/wasmhost.go
@@ -161,9 +161,12 @@ func getModuleConfig(ctx context.Context, buffers utils.OutputBuffers, plugin *p
 	cfg := wazero.NewModuleConfig().
 		WithName("").
 		WithStartFunctions(plugin.StartFunction).
-		WithSysWalltime().WithSysNanotime().
+		WithSysWalltime().
+		WithSysNanotime().
+		WithSysNanosleep().
 		WithRandSource(rand.Reader).
-		WithStdout(wOut).WithStderr(wErr).
+		WithStdout(wOut).
+		WithStderr(wErr).
 		WithEnv("TZ", timeZone).
 		WithEnv("CLAIMS", jwtClaims)
 

--- a/sdk/assemblyscript/src/assembly/exports.ts
+++ b/sdk/assemblyscript/src/assembly/exports.ts
@@ -13,7 +13,7 @@
 
 export {
   activateAgent as _modus_agent_activate,
-  shutdownAgent as _modus_agent_shutdown,
+  handleEvent as _modus_agent_handle_event,
   handleMessage as _modus_agent_handle_message,
   getAgentState as _modus_agent_get_state,
   setAgentState as _modus_agent_set_state,

--- a/sdk/go/examples/agents/main.go
+++ b/sdk/go/examples/agents/main.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"strconv"
-	"time"
 
 	"github.com/hypermodeinc/modus/sdk/go/pkg/agents"
 )
@@ -61,16 +60,8 @@ func GetCount(agentId string) (int, error) {
 }
 
 // Increments the count of the specified agent by 1 and returns the new count.
-func UpdateCount(agentId string, qty *int) (int, error) {
-	var count *string
-	var err error
-
-	if qty == nil {
-		count, err = agents.SendMessage(agentId, "increment", agents.WithTimeout(20*time.Second))
-	} else {
-		count, err = agents.SendMessage(agentId, "increment", agents.WithData(strconv.Itoa(*qty)), agents.WithTimeout(20*time.Second))
-	}
-
+func UpdateCount(agentId string) (int, error) {
+	count, err := agents.SendMessage(agentId, "increment")
 	if err != nil {
 		return 0, err
 	}
@@ -82,10 +73,6 @@ func UpdateCount(agentId string, qty *int) (int, error) {
 
 // Increments the count of the specified agent by the specified quantity.
 // This is an asynchronous operation and does not return a value.
-func UpdateCountAsync(agentId string, qty *int) error {
-	if qty == nil {
-		return agents.SendMessageAsync(agentId, "increment", agents.WithData(strconv.Itoa(*qty)))
-	} else {
-		return agents.SendMessageAsync(agentId, "increment")
-	}
+func UpdateCountAsync(agentId string, qty int) error {
+	return agents.SendMessageAsync(agentId, "increment", agents.WithData(strconv.Itoa(qty)))
 }

--- a/sdk/go/examples/agents/main.go
+++ b/sdk/go/examples/agents/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/hypermodeinc/modus/sdk/go/pkg/agents"
 )
@@ -60,8 +61,16 @@ func GetCount(agentId string) (int, error) {
 }
 
 // Increments the count of the specified agent by 1 and returns the new count.
-func UpdateCount(agentId string) (int, error) {
-	count, err := agents.SendMessage(agentId, "increment")
+func UpdateCount(agentId string, qty *int) (int, error) {
+	var count *string
+	var err error
+
+	if qty == nil {
+		count, err = agents.SendMessage(agentId, "increment", agents.WithTimeout(20*time.Second))
+	} else {
+		count, err = agents.SendMessage(agentId, "increment", agents.WithData(strconv.Itoa(*qty)), agents.WithTimeout(20*time.Second))
+	}
+
 	if err != nil {
 		return 0, err
 	}
@@ -73,6 +82,10 @@ func UpdateCount(agentId string) (int, error) {
 
 // Increments the count of the specified agent by the specified quantity.
 // This is an asynchronous operation and does not return a value.
-func UpdateCountAsync(agentId string, qty int) error {
-	return agents.SendMessageAsync(agentId, "increment", agents.WithData(strconv.Itoa(qty)))
+func UpdateCountAsync(agentId string, qty *int) error {
+	if qty == nil {
+		return agents.SendMessageAsync(agentId, "increment", agents.WithData(strconv.Itoa(*qty)))
+	} else {
+		return agents.SendMessageAsync(agentId, "increment")
+	}
 }

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -44,6 +44,15 @@ const (
 	AgentStatusTerminated AgentStatus = "terminated"
 )
 
+type agentEventAction = string
+
+const (
+	agentEventActionInitialize agentEventAction = "initialize"
+	agentEventActionSuspend    agentEventAction = "suspend"
+	agentEventActionResume     agentEventAction = "resume"
+	agentEventActionTerminate  agentEventAction = "terminate"
+)
+
 var agents = make(map[string]Agent)
 var activeAgent *Agent
 var activeAgentId *string
@@ -68,9 +77,18 @@ func Start(name string) (AgentInfo, error) {
 // Stops an agent with the given ID and returns its status info.
 // This will terminate the agent, and it cannot be resumed or restarted.
 func Stop(agentId string) (AgentInfo, error) {
+	if len(agentId) == 0 {
+		return AgentInfo{}, errors.New("invalid agent ID")
+	}
+
+	if info := hostGetAgentInfo(&agentId); info == nil {
+		return AgentInfo{}, fmt.Errorf("agent %s not found", agentId)
+	}
+
 	if info := hostStopAgent(&agentId); info != nil {
 		return *info, nil
 	}
+
 	return AgentInfo{}, fmt.Errorf("failed to stop agent %s", agentId)
 }
 
@@ -101,59 +119,28 @@ func ListAll() ([]AgentInfo, error) {
 // Assigning them to discard variables avoids "unused" linting errors.
 var (
 	_ = activateAgent
-	_ = shutdownAgent
+	_ = handleEvent
+	_ = handleMessage
 	_ = getAgentState
 	_ = setAgentState
-	_ = handleMessage
 )
 
-// The Modus Runtime will call this function to activate an agent.
+// The Modus Runtime will call this function to set the active agent.
+// This is called after the wasm module instance is loaded, regardless of whether
+// the agent is newly started or resumed from a suspended state.
 //
 //go:export _modus_agent_activate
-func activateAgent(name, id string, reloading bool) {
+func activateAgent(name, id string) {
 	if activeAgent != nil {
-		console.Error("Another agent is already active.")
+		console.Error("Another agent is already active in this module instance.")
 		return
 	}
 
 	if agent, ok := agents[name]; !ok {
 		console.Errorf("Agent %s not found.", name)
-		return
 	} else {
 		activeAgent = &agent
 		activeAgentId = &id
-
-		if reloading {
-			if err := agent.OnResume(); err != nil {
-				console.Errorf("Error reloading agent %s: %v", name, err)
-			}
-		} else {
-			if err := agent.OnInitialize(); err != nil {
-				console.Errorf("Error starting agent %s: %v", name, err)
-			}
-		}
-	}
-}
-
-// The Modus Runtime will call this function to shutdown an agent.
-//
-//go:export _modus_agent_shutdown
-func shutdownAgent(suspending bool) {
-	if activeAgent == nil {
-		console.Error("No active agent to shutdown.")
-		return
-	}
-
-	if suspending {
-		if err := (*activeAgent).OnSuspend(); err != nil {
-			console.Errorf("Error suspending agent %s: %v", (*activeAgent).Name(), err)
-			return
-		}
-	} else {
-		if err := (*activeAgent).OnTerminate(); err != nil {
-			console.Errorf("Error stopping agent %s: %v", (*activeAgent).Name(), err)
-			return
-		}
 	}
 }
 
@@ -179,7 +166,41 @@ func setAgentState(data *string) {
 	(*activeAgent).SetState(data)
 }
 
+// The Modus Runtime will call this function when an agent event occurs.
+// Events are part of the agent's lifecycle, managed by the Modus Runtime.
+//
+//go:export _modus_agent_handle_event
+func handleEvent(action string) {
+	if activeAgent == nil {
+		console.Errorf("No active agent to process %s even action.", action)
+		return
+	}
+	agent := *activeAgent
+
+	switch action {
+	case agentEventActionInitialize:
+		if err := (agent).OnInitialize(); err != nil {
+			console.Errorf("Error initializing agent %s: %v", agent.Name(), err)
+		}
+	case agentEventActionSuspend:
+		if err := agent.OnSuspend(); err != nil {
+			console.Errorf("Error suspending agent %s: %v", agent.Name(), err)
+		}
+	case agentEventActionResume:
+		if err := agent.OnResume(); err != nil {
+			console.Errorf("Error resuming agent %s: %v", agent.Name(), err)
+		}
+	case agentEventActionTerminate:
+		if err := agent.OnTerminate(); err != nil {
+			console.Errorf("Error terminating agent %s: %v", agent.Name(), err)
+		}
+	default:
+		console.Errorf("Unknown agent event action: %s", action)
+	}
+}
+
 // The Modus Runtime will call this function when an agent receives a message.
+// Messages are user-defined and can be sent from API functions or other agents.
 //
 //go:export _modus_agent_handle_message
 func handleMessage(msgName string, data *string) *string {

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -172,7 +172,7 @@ func setAgentState(data *string) {
 //go:export _modus_agent_handle_event
 func handleEvent(action string) {
 	if activeAgent == nil {
-		console.Errorf("No active agent to process %s even action.", action)
+		console.Errorf("No active agent to process %s event action.", action)
 		return
 	}
 	agent := *activeAgent


### PR DESCRIPTION
- Fixes several agent lifecycle issues, such as stopping an agent while its suspended.
- Agent activation within wasm module is now split from initialization.
- Updated agent functions for shutdown and event status.
- Added DB functions for updating status without resetting state data.
- Lots of refactoring and misc fixes.

Note, I tested with passivation enabled for suspend/restore state changes.  However, I disabled it at the end because there's still an open issue with long-running tasks.