### PR TITLE
fix: remove ack event from SSE stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2025-06-10 - Runtime 0.18.0-alpha.6
 
 - fix: address agent lifecycle issues [#881](https://github.com/hypermodeinc/modus/pull/881)
+- fix: remove ack event from SSE stream [#884](https://github.com/hypermodeinc/modus/pull/884)
 
 ## 2025-06-10 - Go SDK 0.18.0-alpha.6
 

--- a/runtime/graphql/graphql.go
+++ b/runtime/graphql/graphql.go
@@ -155,10 +155,6 @@ func handleGraphQLRequest(w http.ResponseWriter, r *http.Request) {
 		h.Set("Content-Type", "text/event-stream")
 		h.Set("Cache-Control", "no-cache")
 		h.Set("Connection", "keep-alive")
-
-		// note: this event isn't in the graphql-sse draft spec, but is helpful to indicate the connection is established,
-		// when testing, and doesn't interfere with the graphql events.
-		fmt.Fprint(w, "event: ack\ndata: \n\n")
 		flusher.Flush()
 
 		resultWriter.SetFlushCallback(func(data []byte) {


### PR DESCRIPTION
Removes the `ack` event from the SSE stream, so the stream conforms to the GraphQL-SSE spec.

This should prevent errors where the client doesn't know how to handle undefined events, such as seen here:
![image](https://github.com/user-attachments/assets/b563707c-1c12-487d-933d-586206a8659e)
