### PR TITLE
Agent event creation timestamps 

### DIFF
--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -229,7 +229,17 @@ func SendAgentMessage(ctx context.Context, agentId string, msgName string, data 
 	}
 }
 
-func PublishAgentEvent(ctx context.Context, agentId, eventName string, eventData *string) error {
+func PublishAgentEvent(ctx context.Context, agentId, eventName string, eventData *string, createdAt *string) error {
+	var createdTime time.Time
+	var err error
+	if createdAt != nil {
+		createdTime, err = time.Parse(time.RFC3339Nano, *createdAt)
+		if err != nil {
+			return fmt.Errorf("error parsing created timestamp: %w", err)
+		}
+	} else {
+		createdTime = time.Now()
+	}
 
 	var data any
 	if eventData != nil {
@@ -246,7 +256,7 @@ func PublishAgentEvent(ctx context.Context, agentId, eventName string, eventData
 	event := &messages.AgentEventMessage{
 		Name:      eventName,
 		Data:      dataValue,
-		Timestamp: timestamppb.Now(),
+		Timestamp: timestamppb.New(createdTime),
 	}
 
 	eventMsg, err := anypb.New(event)

--- a/runtime/actors/wasmagent.go
+++ b/runtime/actors/wasmagent.go
@@ -87,7 +87,8 @@ func (a *wasmAgentActor) updateStatus(ctx context.Context, status AgentStatus) e
 	}
 
 	data := fmt.Sprintf(`{"status":"%s"}`, a.status)
-	if err := PublishAgentEvent(ctx, a.agentId, agentStatusEventName, &data); err != nil {
+	createdAt := time.Now().Format(time.RFC3339Nano)
+	if err := PublishAgentEvent(ctx, a.agentId, agentStatusEventName, &data, &createdAt); err != nil {
 		return fmt.Errorf("error publishing agent status event: %w", err)
 	}
 

--- a/runtime/hostfunctions/agents.go
+++ b/runtime/hostfunctions/agents.go
@@ -47,7 +47,7 @@ func init() {
 
 	registerHostFunction(module_name, "publishEvent", actors.PublishAgentEvent,
 		withErrorMessage("Error publishing agent event."),
-		withMessageDetail(func(agentId, eventName string, eventData *string) string {
+		withMessageDetail(func(agentId, eventName string, eventData *string, createdAt *string) string {
 			return fmt.Sprintf("AgentId: %s, EventName: %s", agentId, eventName)
 		}))
 }

--- a/sdk/assemblyscript/src/assembly/__tests__/agent.spec.ts
+++ b/sdk/assemblyscript/src/assembly/__tests__/agent.spec.ts
@@ -54,8 +54,16 @@ mockImport(
 
 mockImport(
   "modus_agents.publishEvent",
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  (agentId: string, eventName: string, eventData: string | null): void => {},
+  (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    agentId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    eventName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    eventData: string | null,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    createdAt: string,
+  ): void => {},
 );
 
 it("should serialize an AgentStatus using type aliases", () => {

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -93,7 +93,7 @@ export abstract class Agent {
    * Publishes an event from this agent to any subscribers.
    */
   publishEvent(event: AgentEvent): void {
-    const createdAt = new Date().toISOString();
+    const createdAt = new Date(Date.now()).toISOString();
 
     const data = JSON.stringify(event);
     hostPublishEvent(this.id, event.eventName, data, createdAt);

--- a/sdk/assemblyscript/src/assembly/agent.ts
+++ b/sdk/assemblyscript/src/assembly/agent.ts
@@ -93,8 +93,10 @@ export abstract class Agent {
    * Publishes an event from this agent to any subscribers.
    */
   publishEvent(event: AgentEvent): void {
+    const createdAt = new Date().toISOString();
+
     const data = JSON.stringify(event);
-    hostPublishEvent(this.id, event.eventName, data);
+    hostPublishEvent(this.id, event.eventName, data, createdAt);
   }
 }
 
@@ -129,6 +131,7 @@ declare function hostPublishEvent(
   agentId: string,
   eventName: string,
   eventData: string | null,
+  createdAt: string,
 ): void;
 
 /**

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -290,15 +290,17 @@ func (a *AgentBase) OnReceiveMessage(msgName string, data *string) (*string, err
 	return nil, nil
 }
 
-// Publishes an event from this agent to any subscribers.
 func (a *AgentBase) PublishEvent(event AgentEvent) error {
+	createdAt := time.Now().Format(time.RFC3339Nano)
+
 	bytes, err := utils.JsonSerialize(event)
 	if err != nil {
 		return fmt.Errorf("failed to serialize event data: %w", err)
 	}
 	data := string(bytes)
 	name := event.EventName()
-	hostPublishEvent(activeAgentId, &name, &data)
+
+	hostPublishEvent(activeAgentId, &name, &data, &createdAt)
 	return nil
 }
 

--- a/sdk/go/pkg/agents/imports_mock.go
+++ b/sdk/go/pkg/agents/imports_mock.go
@@ -80,6 +80,6 @@ func hostListAgents() *[]AgentInfo {
 	}
 }
 
-func hostPublishEvent(agentId, eventName, eventData *string) {
-	PublishEventCallStack.Push(agentId, eventName, eventData)
+func hostPublishEvent(agentId, eventName, eventData, createdAt *string) {
+	PublishEventCallStack.Push(agentId, eventName, eventData, createdAt)
 }

--- a/sdk/go/pkg/agents/imports_wasi.go
+++ b/sdk/go/pkg/agents/imports_wasi.go
@@ -83,4 +83,4 @@ func hostListAgents() *[]AgentInfo {
 
 //go:noescape
 //go:wasmimport modus_agents publishEvent
-func hostPublishEvent(agentId, eventName, eventData *string)
+func hostPublishEvent(agentId, eventName, eventData, createdAt *string)


### PR DESCRIPTION
Events published by agents were showing identical timestamps even when there was significant time between them (e.g., a "generating" event followed by a "generated" event after an LLM call). This PR captures timestamps when agents actually create events rather than when the runtime processes them, ensuring unique and accurate timing information.