### PR TITLE
Add retry logic with exponential backoff ensureAgentReady

### DIFF
--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -180,7 +180,8 @@ func ensureAgentReady(ctx context.Context, agentId string) (*AgentInfo, *goakt.P
 		info, pid, err := getAgentInfo(ctx, agentId)
 
 		if pid != nil {
-			if actor := pid.Actor().(*wasmAgentActor); actor.status == AgentStatusRunning {
+			actor := pid.Actor().(*wasmAgentActor)
+			if actor.status == AgentStatusRunning {
 				return info, pid, nil
 			}
 			lastErr = fmt.Errorf("agent %s not ready (status: %s)", agentId, actor.status)
@@ -215,6 +216,9 @@ func ensureAgentReady(ctx context.Context, agentId string) (*AgentInfo, *goakt.P
 				// Other statuses - don't retry
 				return info, nil, fmt.Errorf("agent %s is %s, but not found in local actor system", agentId, info.Status)
 			}
+		} else if err != nil {
+			// Handle the error from getAgentInfo
+			lastErr = err
 		} else {
 			// Agent doesn't exist at all - permanent failure
 			return nil, nil, fmt.Errorf("agent %s not found", agentId)


### PR DESCRIPTION
This PR adds retry logic with exponential backoff to ensureAgentReady to handle race conditions when agents are starting or resuming. 

This fixes issues where SendMessage calls immediately after StartAgent would fail with "agent not found" errors due to asynchronous agent initialization.