### PR TITLE
 chore: update go toolchain in examples

### DIFF
--- a/sdk/go/examples/agents/go.mod
+++ b/sdk/go/examples/agents/go.mod
@@ -2,7 +2,7 @@ module agents-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.18.0-alpha.1
 

--- a/sdk/go/examples/anthropic-functions/go.mod
+++ b/sdk/go/examples/anthropic-functions/go.mod
@@ -2,7 +2,7 @@ module anthropic-functions-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/auth/go.mod
+++ b/sdk/go/examples/auth/go.mod
@@ -2,7 +2,7 @@ module auth-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/classification/go.mod
+++ b/sdk/go/examples/classification/go.mod
@@ -2,7 +2,7 @@ module classification-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/dgraph/go.mod
+++ b/sdk/go/examples/dgraph/go.mod
@@ -2,7 +2,7 @@ module dgraph-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/embedding/go.mod
+++ b/sdk/go/examples/embedding/go.mod
@@ -2,7 +2,7 @@ module embedding-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/graphql/go.mod
+++ b/sdk/go/examples/graphql/go.mod
@@ -2,7 +2,7 @@ module graphql-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/http/go.mod
+++ b/sdk/go/examples/http/go.mod
@@ -2,7 +2,7 @@ module http-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/mysql/go.mod
+++ b/sdk/go/examples/mysql/go.mod
@@ -2,7 +2,7 @@ module mysql-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/neo4j/go.mod
+++ b/sdk/go/examples/neo4j/go.mod
@@ -2,7 +2,7 @@ module neo4j-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/postgresql/go.mod
+++ b/sdk/go/examples/postgresql/go.mod
@@ -2,7 +2,7 @@ module postgresql-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/simple/go.mod
+++ b/sdk/go/examples/simple/go.mod
@@ -2,7 +2,7 @@ module simple-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/textgeneration/go.mod
+++ b/sdk/go/examples/textgeneration/go.mod
@@ -2,7 +2,7 @@ module text-generation-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require (
 	github.com/hypermodeinc/modus/sdk/go v0.17.0

--- a/sdk/go/examples/time/go.mod
+++ b/sdk/go/examples/time/go.mod
@@ -2,7 +2,7 @@ module time-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 

--- a/sdk/go/examples/vectors/go.mod
+++ b/sdk/go/examples/vectors/go.mod
@@ -2,7 +2,7 @@ module vectors-example
 
 go 1.23.1
 
-toolchain go1.23.8
+toolchain go1.23.10
 
 require github.com/hypermodeinc/modus/sdk/go v0.17.0
 


### PR DESCRIPTION
Update the toolchain used in the example projects in the Go SDK to resolve trunk warnings.