### PR TITLE
feat: "start" and "stop" are now mutation prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## UNRELEASED
 
 - feat: add kubernetes secrets provider and API to read secrets [#885](https://github.com/hypermodeinc/modus/pull/885)
+- feat: "start" and "stop" are now mutation prefixes [#889](https://github.com/hypermodeinc/modus/pull/889)
 
 ## 2025-06-10 - Runtime 0.18.0-alpha.6
 

--- a/runtime/graphql/schemagen/conventions.go
+++ b/runtime/graphql/schemagen/conventions.go
@@ -20,6 +20,7 @@ var mutationPrefixes = []string{
 	"post", "patch", "put", "delete",
 	"add", "update", "insert", "upsert",
 	"create", "edit", "save", "remove", "alter", "modify",
+	"start", "stop",
 }
 
 func isMutation(fnName string) bool {


### PR DESCRIPTION
Functions that start and stop agents should be exposed as mutations rather than queries on the GraphQL schema, because they modify the state of the system.

We'll use "start" and "stop" as prefixes to identify these.