### PR TITLE
fix: use millisecond precision in timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feat: "start" and "stop" are now mutation prefixes [#889](https://github.com/hypermodeinc/modus/pull/889)
 - fix: start agents synchronously, and add examples setting data on start [#890](https://github.com/hypermodeinc/modus/pull/890)
 - fix: resolve deadlocks related to open inbound http connections [#891](https://github.com/hypermodeinc/modus/pull/891)
+- fix: use millisecond precision in timestamps [#892](https://github.com/hypermodeinc/modus/pull/892)
 
 ## 2025-06-10 - Runtime 0.18.0-alpha.6
 

--- a/runtime/actors/subscriber.go
+++ b/runtime/actors/subscriber.go
@@ -102,7 +102,7 @@ func (a *subscriptionActor) Receive(rc *goakt.ReceiveContext) {
 		event := &agentEvent{
 			Name:      msg.Name,
 			Data:      msg.Data,
-			Timestamp: msg.Timestamp.AsTime().Format(time.RFC3339),
+			Timestamp: msg.Timestamp.AsTime().Format(utils.TimeFormat),
 		}
 		if data, err := utils.JsonSerialize(event); err != nil {
 			rc.Err(fmt.Errorf("failed to serialize agent event message: %w", err))

--- a/runtime/actors/wasmagent.go
+++ b/runtime/actors/wasmagent.go
@@ -109,7 +109,7 @@ func (a *wasmAgentActor) saveState(ctx context.Context) error {
 		Name:      a.agentName,
 		Status:    a.status,
 		Data:      data,
-		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt: time.Now().UTC().Format(utils.TimeFormat),
 	}); err != nil {
 		return fmt.Errorf("error saving agent state to database: %w", err)
 	}

--- a/runtime/db/agentstate.go
+++ b/runtime/db/agentstate.go
@@ -83,7 +83,7 @@ func updateAgentStatusInModusDB(ctx context.Context, id string, status string) e
 	}
 
 	state.Status = status
-	state.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	state.UpdatedAt = time.Now().UTC().Format(utils.TimeFormat)
 
 	return writeAgentStateToModusDB(ctx, *state)
 }
@@ -179,7 +179,7 @@ func getAgentStateFromPostgresDB(ctx context.Context, id string) (*AgentState, e
 		if err := row.Scan(&a.Id, &a.Name, &a.Status, &a.Data, &ts); err != nil {
 			return fmt.Errorf("failed to get agent state: %w", err)
 		}
-		a.UpdatedAt = ts.UTC().Format(time.RFC3339)
+		a.UpdatedAt = ts.UTC().Format(utils.TimeFormat)
 		return nil
 	})
 
@@ -210,7 +210,7 @@ func queryActiveAgentsFromPostgresDB(ctx context.Context) ([]AgentState, error) 
 			if err := rows.Scan(&a.Id, &a.Name, &a.Status, &a.Data, &ts); err != nil {
 				return err
 			}
-			a.UpdatedAt = ts.UTC().Format(time.RFC3339)
+			a.UpdatedAt = ts.UTC().Format(utils.TimeFormat)
 			results = append(results, a)
 		}
 		if err := rows.Err(); err != nil {

--- a/runtime/db/inferencehistory.go
+++ b/runtime/db/inferencehistory.go
@@ -375,7 +375,7 @@ func writeInferenceHistoryToModusDb(ctx context.Context, batch []inferenceHistor
 			ModelHash:  data.model.Hash(),
 			Input:      string(input),
 			Output:     string(output),
-			StartedAt:  data.start.Format(time.RFC3339),
+			StartedAt:  data.start.Format(utils.TimeFormat),
 			DurationMs: data.end.Sub(data.start).Milliseconds(),
 			Function:   funcStr,
 			Plugin: Plugin{


### PR DESCRIPTION
A few places we had only seconds precision.  Increasing to milliseconds for consistency.