### PR TITLE
fix: default send message to have no timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: default send message to have no timeout [#896](https://github.com/hypermodeinc/modus/pull/896)
+
 ## 2025-06-12 CLI 0.18.1
 
 - fix: repair runtime prerelease matching bug and update dependencies [#894](https://github.com/hypermodeinc/modus/pull/894)

--- a/sdk/assemblyscript/src/assembly/agents.ts
+++ b/sdk/assemblyscript/src/assembly/agents.ts
@@ -27,15 +27,17 @@ declare function hostSendMessage(
 ): MessageResponse;
 
 /**
- * Sends a message to an agent, and waits for a response.
+ * Sends a message to the specified agent and waits for a response.
  * The data is optional and can be null.
- * The timeout is in seconds and defaults to 10 seconds.
+ * The message is sent synchronously and the function will block until a response is received or the timeout is reached.
+ * If there is no timeout set (or set to Duration.maxValue), it will wait indefinitely until a response is received,
+ * or until calling function is cancelled.
  */
 export function sendMessage(
   agentId: string,
   msgName: string,
   data: string | null = null,
-  timeout: Duration = 10 * Duration.second,
+  timeout: Duration = Duration.maxValue,
 ): string | null {
   if (timeout < 0) {
     throw new Error("Timeout must be a zero or positive value.");
@@ -59,8 +61,9 @@ export function sendMessage(
 }
 
 /**
- * Sends a message to an agent without waiting for a response.
+ * Sends a message to the specified agent without waiting for a response.
  * The data is optional and can be null.
+ * The message is sent asynchronously and the function will return immediately.
  */
 export function sendMessageAsync(
   agentId: string,

--- a/sdk/assemblyscript/src/assembly/enums.ts
+++ b/sdk/assemblyscript/src/assembly/enums.ts
@@ -7,15 +7,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export enum Duration {
-  zero = 0,
-  nanosecond = 1,
-  microsecond = 1000 * Duration.nanosecond,
-  millisecond = 1000 * Duration.microsecond,
-  second = 1000 * Duration.millisecond,
-  minute = 60 * Duration.second,
-  hour = 60 * Duration.minute,
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Duration {
+  export const zero = 0;
+  export const nanosecond = 1;
+  export const microsecond = 1000 * Duration.nanosecond;
+  export const millisecond = 1000 * Duration.microsecond;
+  export const second = 1000 * Duration.millisecond;
+  export const minute = 60 * Duration.second;
+  export const hour = 60 * Duration.minute;
+  export const maxValue = i64.MAX_VALUE;
 }
+export type Duration = i64;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AgentStatus {

--- a/sdk/go/pkg/agents/agents.go
+++ b/sdk/go/pkg/agents/agents.go
@@ -12,6 +12,7 @@ package agents
 import (
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/hypermodeinc/modus/sdk/go/pkg/console"
@@ -333,13 +334,14 @@ func WithTimeout(timeout time.Duration) messageOption {
 }
 
 // SendMessage sends a message to the specified agent and waits for a response.
-// The message is sent synchronously and the function will block until a response is received or the timeout is reached.
-// The timeout can be set using the WithTimeout option, and defaults to 10 seconds if not set.
 // Data can be sent with the message using the WithData option.
+// The message is sent synchronously and the function will block until a response is received or the timeout is reached.
+// The timeout can be set using the WithTimeout option. If there is no timeout set, it will wait indefinitely until a
+// response is received, or until calling function is cancelled.
 func SendMessage(agentId, msgName string, options ...messageOption) (*string, error) {
 	m := &message{
 		name:    msgName,
-		timeout: 10 * time.Second,
+		timeout: math.MaxInt64, // default to no timeout (wait indefinitely)
 	}
 
 	for _, opt := range options {
@@ -350,9 +352,9 @@ func SendMessage(agentId, msgName string, options ...messageOption) (*string, er
 }
 
 // SendMessageAsync sends a message to the specified agent without waiting for a response.
-// The message is sent asynchronously and the function will return immediately.
 // Data can be sent with the message using the WithData option.
-// The timeout is ignored for asynchronous messages and is always set to 0.
+// The message is sent asynchronously and the function will return immediately.
+// The WithTimeout option is ignored for asynchronous messages, as they do not wait for a response.
 func SendMessageAsync(agentId, msgName string, options ...messageOption) error {
 	m := &message{
 		name: msgName,


### PR DESCRIPTION
In testing, a common pitfall is that `SendMessage` was timing out at 10 seconds by default, where some operations naturally take longer than that.

This PR changes the default to wait indefinitely via max duration timeout (~292 years).  A shorter timeout can still be provided manually if desired.