### PR TITLE
fix: ensure valid UTF-8 byte sequence in HTTP response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-06-23 - Runtime 0.18.0-alpha.12
+
+- fix: ensure valid UTF8 byte sequence in HTTP response [#904](https://github.com/hypermodeinc/modus/pull/904)
+
 ## 2025-06-23 - Runtime 0.18.0-alpha.11
 
 - fix: adjust cluster sync settings and delays [#902](https://github.com/hypermodeinc/modus/pull/902)

--- a/runtime/utils/http.go
+++ b/runtime/utils/http.go
@@ -114,8 +114,10 @@ func PostHttp[TResult any](ctx context.Context, url string, payload any, beforeS
 		case []byte:
 			result = any(content).(TResult)
 		case string:
+			content = SanitizeUTF8(content)
 			result = any(string(content)).(TResult)
 		default:
+			content = SanitizeUTF8(content)
 			if err := JsonDeserialize(content, &result); err != nil {
 				return nil, fmt.Errorf("error deserializing response: %w", err)
 			}

--- a/runtime/utils/strings_test.go
+++ b/runtime/utils/strings_test.go
@@ -43,3 +43,35 @@ func Test_DecodeUTF16(t *testing.T) {
 		t.Errorf("expected %s, got %s", testString, str)
 	}
 }
+
+func Test_SanitizeUTF8(t *testing.T) {
+	// Test with a valid UTF-8 string
+	validUTF8 := []byte("Hello, 世界")
+	sanitized := utils.SanitizeUTF8(validUTF8)
+	if !bytes.Equal(sanitized, validUTF8) {
+		t.Errorf("expected %s, got %s", validUTF8, sanitized)
+	}
+
+	// Test with an invalid UTF-8 sequence
+	invalidUTF8 := []byte{0xff, 0xfe, 0xfd}
+	sanitized = utils.SanitizeUTF8(invalidUTF8)
+	if len(sanitized) != 0 {
+		t.Errorf("expected empty slice for invalid UTF-8, got %s", sanitized)
+	}
+
+	// Test with a mix of valid and invalid UTF-8
+	mixedUTF8 := []byte("Hello\xffWorld")
+	sanitized = utils.SanitizeUTF8(mixedUTF8)
+	expected := []byte("HelloWorld")
+	if !bytes.Equal(sanitized, expected) {
+		t.Errorf("expected %s, got %s", expected, sanitized)
+	}
+
+	// Test with some null bytes
+	nullBytes := []byte("Hello\x00World")
+	sanitized = utils.SanitizeUTF8(nullBytes)
+	expected = []byte("HelloWorld")
+	if !bytes.Equal(sanitized, expected) {
+		t.Errorf("expected %s, got %s", expected, sanitized)
+	}
+}


### PR DESCRIPTION
Sanitizes HTTP response from models or API calls to strip away any invalid UTF-8 sequences or null bytes, if the expected content is a string, or an object serialized as a JSON string.

Fixes #903
