### PR TITLE
fix: time zone retrieval and logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Change Log
 
+## 2025-06-23 - Runtime 0.18.0-alpha.13
+
+- fix: time zone retrieval and logging [#906](https://github.com/hypermodeinc/modus/pull/906)
+
 ## 2025-06-23 - Runtime 0.18.0-alpha.12
 
 - fix: ensure valid UTF8 byte sequence in HTTP response [#904](https://github.com/hypermodeinc/modus/pull/904)

--- a/runtime/timezones/tzdata_other.go
+++ b/runtime/timezones/tzdata_other.go
@@ -17,27 +17,23 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 )
 
-func loadTimeZoneInfo(tz string) (*tzInfo, error) {
+func loadTimeZoneData(tz string) ([]byte, error) {
 	tzFile := "/usr/share/zoneinfo/" + tz
 	if _, err := os.Stat(tzFile); err != nil {
-		return nil, fmt.Errorf("could not find timezone file: %v", err)
+		return nil, fmt.Errorf("could not find time zone file: %v", err)
 	}
 
-	bytes, err := os.ReadFile(tzFile)
+	data, err := os.ReadFile(tzFile)
 	if err != nil {
-		return nil, fmt.Errorf("could not read timezone file: %v", err)
+		return nil, fmt.Errorf("could not read time zone file: %v", err)
 	}
 
-	loc, err := time.LoadLocationFromTZData(tz, bytes)
-	if err != nil {
-		return nil, fmt.Errorf("could not load timezone data: %v", err)
+	if len(data) == 0 {
+		return nil, errors.New("time zone data is empty")
 	}
-
-	info := &tzInfo{loc, bytes}
-	return info, nil
+	return data, nil
 }
 
 func getSystemLocalTimeZone() (string, error) {

--- a/runtime/timezones/tzdata_windows.go
+++ b/runtime/timezones/tzdata_windows.go
@@ -12,8 +12,8 @@
 package timezones
 
 import (
+	"errors"
 	"fmt"
-	"time"
 	"unsafe"
 
 	_ "time/tzdata"
@@ -27,22 +27,18 @@ import (
 //go:linkname loadFromEmbeddedTZData time/tzdata.loadFromEmbeddedTZData
 func loadFromEmbeddedTZData(string) (string, error)
 
-func loadTimeZoneInfo(tz string) (*tzInfo, error) {
-
+func loadTimeZoneData(tz string) ([]byte, error) {
 	var data []byte
 	if s, err := loadFromEmbeddedTZData(tz); err != nil {
-		return nil, fmt.Errorf("could not load timezone data: %v", err)
+		return nil, fmt.Errorf("could not load time zone data: %v", err)
 	} else {
 		data = []byte(s)
 	}
 
-	loc, err := time.LoadLocationFromTZData(tz, data)
-	if err != nil {
-		return nil, fmt.Errorf("could not load timezone data: %v", err)
+	if len(data) == 0 {
+		return nil, errors.New("time zone data is empty")
 	}
-
-	info := &tzInfo{loc, data}
-	return info, nil
+	return data, nil
 }
 
 func getSystemLocalTimeZone() (string, error) {


### PR DESCRIPTION
- Split the time zone cache into two parts, and used Go's built-in `time.LoadLocation` for the common path
- Added some logging in case we get any more errors in this area