### PR TITLE
feat: distribute actors across cluster when restoring on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 2025-06-23 - Runtime 0.18.0-alpha.13
 
 - fix: time zone retrieval and logging [#906](https://github.com/hypermodeinc/modus/pull/906)
+- feat: distribute actors across cluster when restoring on startup [#976](https://github.com/hypermodeinc/modus/pull/907)
 
 ## 2025-06-23 - Runtime 0.18.0-alpha.12
 


### PR DESCRIPTION
When starting the actor system we restore agents that were suspended.  This shuffles the list retrieved from the database, which has the effect of distributing the actors across multiple nodes, if multiple nodes are being started simultaneously.