### PR TITLE
fix: update dockerfile to include legacy time zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 # Change Log
 
+## UNRELEASED
+
+- fix: update dockerfile to include legacy time zones [#909](https://github.com/hypermodeinc/modus/pull/909)
+
 ## 2025-06-23 - Runtime 0.18.0-alpha.13
 
 - fix: time zone retrieval and logging [#906](https://github.com/hypermodeinc/modus/pull/906)
-- feat: distribute actors across cluster when restoring on startup [#976](https://github.com/hypermodeinc/modus/pull/907)
+- feat: distribute actors across cluster when restoring on startup [#907](https://github.com/hypermodeinc/modus/pull/907)
 
 ## 2025-06-23 - Runtime 0.18.0-alpha.12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /src/runtime/modus_runtime /usr/bin/modus_runtime
 
 # update certificates and time zones every build
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
-    tzdata \
+    tzdata tzdata-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch to the custom user and set the working directory


### PR DESCRIPTION
The `tzdata` package in Ubuntu was split into `tzdata` and `tzdata-legacy`.  We need to install both to support all time zone identifiers.

Additionally, we can suppress some warnings by explicitly setting non-interactive mode when installing packages.