### PR TITLE
fix: subscribing to events should not be blocked by agent actor state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 # Change Log
 
-## 2025-06-24 - Runtime v0.18.0
+## 2025-06-24 - Runtime v0.18.1
+
+- fix: subscribing to events should not be blocked by agent actor state [#910](https://github.com/hypermodeinc/modus/pull/910)
+
+## 2025-06-23 - Runtime v0.18.0
 
 NOTE: These notes are inclusive of all preview releases in the v0.18.0 series.
 
@@ -38,7 +42,7 @@ Other items:
 - fix: time zone retrieval and logging [#906](https://github.com/hypermodeinc/modus/pull/906)
 - fix: update dockerfile to include legacy time zones [#909](https://github.com/hypermodeinc/modus/pull/909)
 
-## 2025-06-24 - Go SDK v0.18.0
+## 2025-06-23 - Go SDK v0.18.0
 
 NOTE: These notes are inclusive of all preview releases in the v0.18.0 series.
 
@@ -62,7 +66,7 @@ Other items:
 - feat: return user and chat errors in API response [#863](https://github.com/hypermodeinc/modus/pull/863)
 - feat: delete collections features [#872](https://github.com/hypermodeinc/modus/pull/872)
 
-## 2025-06-24 - AssemblyScript SDK v0.18.0
+## 2025-06-23 - AssemblyScript SDK v0.18.0
 
 NOTE: These notes are inclusive of all preview releases in the v0.18.0 series.
 

--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -168,7 +168,7 @@ func GetAgentInfo(ctx context.Context, agentId string) (*AgentInfo, error) {
 		}, nil
 	}
 
-	// If the actor is not not responding, we can check the database for the agent state.
+	// If the actor is not responding, we can check the database for the agent state.
 	// This is useful for agents that are still starting, are terminated or suspended, or just busy processing another request.
 	if errors.Is(err, goakt.ErrActorNotFound) || errors.Is(err, goakt.ErrRequestTimeout) || errors.Is(err, goakt.ErrDead) || errors.Is(err, goakt.ErrRemoteSendFailure) {
 		return getAgentInfoFromDatabase(ctx, agentId)

--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -168,9 +168,9 @@ func GetAgentInfo(ctx context.Context, agentId string) (*AgentInfo, error) {
 		}, nil
 	}
 
-	// If the actor is not found, or if the request timed out, we can check the database for the agent state.
-	// This is useful for agents that are terminated or suspended, or just busy processing another request.
-	if errors.Is(err, goakt.ErrActorNotFound) || errors.Is(err, goakt.ErrRequestTimeout) {
+	// If the actor is not not responding, we can check the database for the agent state.
+	// This is useful for agents that are still starting, are terminated or suspended, or just busy processing another request.
+	if errors.Is(err, goakt.ErrActorNotFound) || errors.Is(err, goakt.ErrRequestTimeout) || errors.Is(err, goakt.ErrDead) || errors.Is(err, goakt.ErrRemoteSendFailure) {
 		return getAgentInfoFromDatabase(ctx, agentId)
 	}
 

--- a/runtime/actors/agents.go
+++ b/runtime/actors/agents.go
@@ -170,8 +170,16 @@ func GetAgentInfo(ctx context.Context, agentId string) (*AgentInfo, error) {
 
 	// If the actor is not responding, we can check the database for the agent state.
 	// This is useful for agents that are still starting, are terminated or suspended, or just busy processing another request.
-	if errors.Is(err, goakt.ErrActorNotFound) || errors.Is(err, goakt.ErrRequestTimeout) || errors.Is(err, goakt.ErrDead) || errors.Is(err, goakt.ErrRemoteSendFailure) {
-		return getAgentInfoFromDatabase(ctx, agentId)
+	allowedErrs := []error{
+		goakt.ErrActorNotFound,
+		goakt.ErrRequestTimeout,
+		goakt.ErrRemoteSendFailure,
+		goakt.ErrDead,
+	}
+	for _, r := range allowedErrs {
+		if errors.Is(err, r) {
+			return getAgentInfoFromDatabase(ctx, agentId)
+		}
 	}
 
 	return nil, fmt.Errorf("error getting agent info: %w", err)

--- a/runtime/actors/subscriber.go
+++ b/runtime/actors/subscriber.go
@@ -33,7 +33,9 @@ func SubscribeForAgentEvents(ctx context.Context, agentId string, update func(da
 	span, ctx := utils.NewSentrySpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	if a, err := GetAgentInfo(ctx, agentId); err != nil {
+	// Go directly to the database for the agent status, because we don't want subscribing to event to fail
+	// if there is any issue with the agent actor.
+	if a, err := getAgentInfoFromDatabase(ctx, agentId); err != nil {
 		return err
 	} else if a.Status == AgentStatusStopping || a.Status == AgentStatusTerminated {
 		return fmt.Errorf("agent %s is %s, cannot subscribe to events", agentId, a.Status)

--- a/runtime/actors/subscriber.go
+++ b/runtime/actors/subscriber.go
@@ -33,7 +33,7 @@ func SubscribeForAgentEvents(ctx context.Context, agentId string, update func(da
 	span, ctx := utils.NewSentrySpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	// Go directly to the database for the agent status, because we don't want subscribing to event to fail
+	// Go directly to the database for the agent status, because we don't want subscribing to events to fail
 	// if there is any issue with the agent actor.
 	if a, err := getAgentInfoFromDatabase(ctx, agentId); err != nil {
 		return err


### PR DESCRIPTION
Checking agent status when subscribing to an event stream should not be blocked by the agent actor's state.  We can just go directly to the database.

Additionally, in cases where we do want to talk to the actor, there are a couple more error states to consider.
