### PR TITLE
fix: write inference history directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ NOTE: all releases may include dependency updates, not specifically mentioned
 ## UNRELEASED
 
 - feat: integrate try-as library [#912](https://github.com/hypermodeinc/modus/pull/912)
-- feat: improve sentry usage [#931](https://github.com/hypermodeinc/modus/pull/931)
+- feat: improve sentry usage [#931](https://github.com/hypermodeinc/modus/pull/931) [#937](https://github.com/hypermodeinc/modus/pull/937)
+- fix: write inference history directly [#938](https://github.com/hypermodeinc/modus/pull/938)
 
 ## 2025-07-03 - Runtime v0.18.3
 

--- a/runtime/db/agentstate.go
+++ b/runtime/db/agentstate.go
@@ -66,7 +66,7 @@ func writeAgentStateToModusDB(ctx context.Context, state AgentState) error {
 	span, ctx := sentryutils.NewSpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	gid, _, _, err := modusgraph.Upsert(ctx, GlobalModusDbEngine, state)
+	gid, _, _, err := modusgraph.Upsert(ctx, globalModusDbEngine, state)
 	state.Gid = gid
 
 	return err
@@ -93,7 +93,7 @@ func getAgentStateFromModusDB(ctx context.Context, id string) (*AgentState, erro
 	span, ctx := sentryutils.NewSpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	_, result, err := modusgraph.Get[AgentState](ctx, GlobalModusDbEngine, modusgraph.ConstrainedField{
+	_, result, err := modusgraph.Get[AgentState](ctx, globalModusDbEngine, modusgraph.ConstrainedField{
 		Key:   "id",
 		Value: id,
 	})
@@ -108,7 +108,7 @@ func queryActiveAgentsFromModusDB(ctx context.Context) ([]AgentState, error) {
 	span, ctx := sentryutils.NewSpanForCurrentFunc(ctx)
 	defer span.Finish()
 
-	_, results, err := modusgraph.Query[AgentState](ctx, GlobalModusDbEngine, modusgraph.QueryParams{
+	_, results, err := modusgraph.Query[AgentState](ctx, globalModusDbEngine, modusgraph.QueryParams{
 		Filter: &modusgraph.Filter{
 			Not: &modusgraph.Filter{
 				Field: "status",

--- a/runtime/db/modusdb.go
+++ b/runtime/db/modusdb.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hypermodeinc/modusgraph"
 )
 
-var GlobalModusDbEngine *modusgraph.Engine
+var globalModusDbEngine *modusgraph.Engine
 
 func InitModusDb(ctx context.Context) {
 	if !useModusDB() {
@@ -50,13 +50,13 @@ func InitModusDb(ctx context.Context) {
 		sentryutils.CaptureError(ctx, err, msg)
 		logger.Fatal(ctx, err).Msg(msg)
 	} else {
-		GlobalModusDbEngine = eng
+		globalModusDbEngine = eng
 	}
 }
 
 func CloseModusDb(ctx context.Context) {
-	if GlobalModusDbEngine != nil {
-		GlobalModusDbEngine.Close()
+	if globalModusDbEngine != nil {
+		globalModusDbEngine.Close()
 	}
 }
 

--- a/runtime/metrics/metrics.go
+++ b/runtime/metrics/metrics.go
@@ -98,13 +98,6 @@ var (
 		},
 		[]string{"function_name"},
 	)
-
-	DroppedInferencesNum = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "runtime_dropped_inferences_num",
-			Help: "Number of dropped inference requests",
-		},
-	)
 )
 
 func init() {
@@ -116,7 +109,6 @@ func init() {
 		FunctionExecutionsNum,
 		FunctionExecutionDurationMilliseconds,
 		FunctionExecutionDurationMillisecondsSummary,
-		DroppedInferencesNum,
 	)
 }
 


### PR DESCRIPTION
- Remove the batching logic and background worker for writing inference history
- Misc refactoring

Fixes #927.  The issue was related to the batch not being thread safe, and having multiple triggers that could happen concurrently.