### PR TITLE
chore: release runtime v0.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ NOTE: all releases may include dependency updates, not specifically mentioned
 ## UNRELEASED
 
 - feat: integrate try-as library [#912](https://github.com/hypermodeinc/modus/pull/912)
+
+## 2025-07-09 - Runtime v0.18.4
+
 - feat: improve sentry usage [#931](https://github.com/hypermodeinc/modus/pull/931) [#937](https://github.com/hypermodeinc/modus/pull/937)
 - fix: write inference history directly [#938](https://github.com/hypermodeinc/modus/pull/938)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=node-builder /src/dist ./explorer/content/dist
 
 # build the runtime binary
 ARG TARGETOS TARGETARCH RUNTIME_RELEASE_VERSION
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime -ldflags "-s -w -X github.com/hypermodeinc/modus/runtime/app.version=$RUNTIME_RELEASE_VERSION" .
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o modus_runtime -ldflags "-X github.com/hypermodeinc/modus/runtime/app.version=$RUNTIME_RELEASE_VERSION" .
 
 # build the container image
 FROM ubuntu:24.04


### PR DESCRIPTION
- Release Runtime v0.18.4
- Update the dockerfile to keep symbols (should have been done with #931)