### PR TITLE
fix: sentry source context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NOTE: all releases may include dependency updates, not specifically mentioned
 ## UNRELEASED
 
 - feat: integrate try-as library [#912](https://github.com/hypermodeinc/modus/pull/912)
+- fix: sentry source context [#940](https://github.com/hypermodeinc/modus/pull/940)
 
 ## 2025-07-09 - Runtime v0.18.4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # copy runtime binary from the build phase
 COPY --from=builder /src/runtime/modus_runtime /usr/bin/modus_runtime
 
+# copy the runtime source code to the container (for Sentry source context)
+# keep only go source files and remove tests
+COPY ./runtime /src/runtime/
+COPY ./lib /src/lib/
+RUN find /src -type f ! -name '*.go' -delete && \
+    find /src -type f -name '*_test.go' -delete && \
+    find /src -type d -name '*test*' -exec rm -rf {} +
+
 # update certificates and time zones every build
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/runtime/sentryutils/sentry.go
+++ b/runtime/sentryutils/sentry.go
@@ -26,31 +26,20 @@ import (
 
 const max_breadcrumbs = 100
 
+// NOTE: If this code is moved, adjust these constants accordingly.
+const thisPackageDepth = 1 // root is 0
+const thisPackagePath = "github.com/hypermodeinc/modus/runtime/sentryutils"
+
 var rootSourcePath = func() string {
-	pc, filename, _, ok := runtime.Caller(0)
+	_, filename, _, ok := runtime.Caller(0)
 	if !ok {
 		return ""
 	}
-
-	callerName := runtime.FuncForPC(pc).Name()
-	depth := strings.Count(callerName, "/") + 1
-	s := filename
-	for range depth {
-		s = path.Dir(s)
+	dir := path.Dir(filename)
+	for range thisPackageDepth {
+		dir = path.Dir(dir)
 	}
-	return s + "/"
-}()
-
-var thisPackagePath = func() string {
-	pc, _, _, ok := runtime.Caller(0)
-	if !ok {
-		return ""
-	}
-
-	callerName := runtime.FuncForPC(pc).Name()
-	i := max(strings.LastIndexByte(callerName, '/'), 0)
-	j := strings.IndexByte(callerName[i:], '.')
-	return callerName[0 : i+j]
+	return dir + "/"
 }()
 
 func InitializeSentry() {


### PR DESCRIPTION
- Fix and simplify the path and package code needed to adjust sentry stack frames
- Include the Go source code in the docker image so Sentry can return source context