### PR TITLE
fix: don't wait indefinitely for k8s secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ NOTE: all releases may include dependency updates, not specifically mentioned
 - feat: integrate try-as library [#912](https://github.com/hypermodeinc/modus/pull/912)
 - fix: sentry source context [#940](https://github.com/hypermodeinc/modus/pull/940)
 - fix: connect kubernetes logger [#945](https://github.com/hypermodeinc/modus/pull/945)
+- fix: don't wait indefinitely for k8s secrets [#947](https://github.com/hypermodeinc/modus/pull/947)
 
 ## 2025-07-09 - Runtime v0.18.4
 


### PR DESCRIPTION
When initializing the kubernetes secretes provider, we should timeout if there are errors, rather than waiting indefinitely.

Some refactoring included.