### PR TITLE
feat: restore agents on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ NOTE: all releases may include dependency updates, not specifically mentioned
 
 - feat: integrate try-as library [#912](https://github.com/hypermodeinc/modus/pull/912)
 
+## 2025-07-14 - Runtime v0.18.6
+
+- feat: restore agents on demand [#949](https://github.com/hypermodeinc/modus/pull/949)
+
 ## 2025-07-12 - Runtime v0.18.5
 
 - fix: sentry source context [#940](https://github.com/hypermodeinc/modus/pull/940)

--- a/runtime/actors/subscriber.go
+++ b/runtime/actors/subscriber.go
@@ -68,6 +68,8 @@ func SubscribeForAgentEvents(ctx context.Context, agentId string, update func(da
 		return fmt.Errorf("failed to subscribe to topic: %w", err)
 	}
 
+	logger.Debug(ctx).Msgf("Subscribed to topic %s with subscription actor %s", topic, subActor.Name())
+
 	// When the context is done, we will unsubscribe and stop the subscription actor.
 	// For example, the GraphQL subscription is closed or the client disconnects.
 	go func() {


### PR DESCRIPTION
- Restore suspended agents on demand as needed rather than on startup
- Simplify agent suspension process during clean shutdown (and parallelize)
- Remove extra wait after spawning agent (not needed, since next message will be on same cluster node)

This should dramatically improve the thrashing and memory consumption we've been seeing whenever we roll out a new version to the cluster.