### PR TITLE
chore: ignore modusgraph updates temporarily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "ignoreDeps": ["github.com/hypermodeinc/modusgraph"]
+}


### PR DESCRIPTION
Temporarily tell Renovate to not update the modusgraph dependency, since there are breaking changes.  We'll do that later manually.